### PR TITLE
update: wait until body attached in playwright-service

### DIFF
--- a/apps/playwright-service/main.py
+++ b/apps/playwright-service/main.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
+
 class UrlModel(BaseModel):
     url: str
     wait: int = None
@@ -29,9 +30,12 @@ async def shutdown_event():
 async def root(body: UrlModel):
     context = await browser.new_context()
     page = await context.new_page()
-    await page.goto(body.url, timeout=15000)  # Set max timeout to 15s
-    if body.wait:  # Check if wait parameter is provided in the request body
-        await page.wait_for_timeout(body.wait)  # Convert seconds to milliseconds for playwright
+    await page.goto(
+        body.url,
+        wait_until="load",
+        timeout=body.wait if body.wait else 15,
+    )
+    await page.wait_for_selector("body", state="attached")
     page_content = await page.content()
     await context.close()
     json_compatible_item_data = {"content": page_content}


### PR DESCRIPTION
Get the page content until the body is attached instead of hard coded timeout.