### PR TITLE
[Feat] Added proxy and media blocking support for Playwright

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -37,7 +37,7 @@ HDX_NODE_BETA_MODE=1
 
 FIRE_ENGINE_BETA_URL= # set if you'd like to use the fire engine closed beta
 
-# Proxy Settings (Alternative you can can use a proxy service like oxylabs, which rotates IPs for you on every request)
+# Proxy Settings for Playwright (Alternative you can can use a proxy service like oxylabs, which rotates IPs for you on every request)
 PROXY_SERVER=
 PROXY_USERNAME=
 PROXY_PASSWORD=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -36,3 +36,10 @@ HYPERDX_API_KEY=
 HDX_NODE_BETA_MODE=1
 
 FIRE_ENGINE_BETA_URL= # set if you'd like to use the fire engine closed beta
+
+# Proxy Settings (Alternative you can can use a proxy service like oxylabs, which rotates IPs for you on every request)
+PROXY_SERVER=
+PROXY_USERNAME=
+PROXY_PASSWORD=
+# set if you'd like to block media requests to save proxy bandwidth
+BLOCK_MEDIA=

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,10 @@ services:
     build: apps/playwright-service
     environment:
       - PORT=3000
+      - PROXY_SERVER=${PROXY_SERVER}
+      - PROXY_USERNAME=${PROXY_USERNAME}
+      - PROXY_PASSWORD=${PROXY_PASSWORD}
+      - BLOCK_MEDIA=${BLOCK_MEDIA}
     networks:
       - backend
   


### PR DESCRIPTION
Updated environment variables and application settings to include proxy configurations and media blocking option. The proxy settings allow users to use a proxy service, while the media blocking is an optional feature that can help save bandwidth. Changes have been made in the .env.example, docker-compose.yaml, and main.py files.