### PR TITLE
Allow users to manually set the waitFor param on /scrape

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -50,6 +50,11 @@
                         "type": "boolean",
                         "description": "Include the raw HTML content of the page. Will output a html key in the response.",
                         "default": false
+                      },
+                      "waitFor": {
+                        "type": "integer",
+                        "description": "Wait x amount of milliseconds for the page to load to fetch content",
+                        "default": 0
                       }
                     }
                   },

--- a/apps/api/src/__tests__/e2e_withAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_withAuth/index.test.ts
@@ -134,6 +134,26 @@ describe("E2E Tests for API Routes", () => {
       expect(response.body.data).toHaveProperty('metadata');
       expect(response.body.data.content).toContain('We present spectrophotometric observations of the Broad Line Radio Galaxy');
     }, 60000); // 60 seconds
+
+    it("should return a successful response with a valid API key and waitFor option", async () => {
+      const startTime = Date.now();
+      const response = await request(TEST_URL)
+        .post("/v0/scrape")
+        .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`)
+        .set("Content-Type", "application/json")
+        .send({ url: "https://firecrawl.dev", pageOptions: { waitFor: 7000 } });
+      const endTime = Date.now();
+      const duration = endTime - startTime;
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toHaveProperty("data");
+      expect(response.body.data).toHaveProperty("content");
+      expect(response.body.data).toHaveProperty("markdown");
+      expect(response.body.data).toHaveProperty("metadata");
+      expect(response.body.data).not.toHaveProperty("html");
+      expect(response.body.data.content).toContain("🔥 Firecrawl");
+      expect(duration).toBeGreaterThanOrEqual(7000);
+    }, 12000); // 12 seconds timeout
   });
 
   describe("POST /v0/crawl", () => {

--- a/apps/api/src/controllers/scrape.ts
+++ b/apps/api/src/controllers/scrape.ts
@@ -102,7 +102,7 @@ export async function scrapeController(req: Request, res: Response) {
       return res.status(status).json({ error });
     }
     const crawlerOptions = req.body.crawlerOptions ?? {};
-    const pageOptions = req.body.pageOptions ?? { onlyMainContent: false, includeHtml: false };
+    const pageOptions = req.body.pageOptions ?? { onlyMainContent: false, includeHtml: false, waitFor: 0 };
     const extractorOptions = req.body.extractorOptions ?? {
       mode: "markdown"
     }

--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -15,6 +15,7 @@ export type PageOptions = {
   includeHtml?: boolean;
   fallback?: boolean;
   fetchPageContent?: boolean;
+  waitFor?: number;
 };
 
 export type ExtractorOptions = {


### PR DESCRIPTION
closes #199 allowing users to set a wait param to wait x ms after the page load to grab its content in fire-engine and playwright.