### PR TITLE
Add support for Self-Hosted Webhook URL Usage and added project_id into the webhook payload

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -52,4 +52,4 @@ PROXY_PASSWORD=
 BLOCK_MEDIA=
 
 # Set this to the URL of your webhook when using the self-hosted version of FireCrawl
-SELF_HOSTED_WEBHOOK_URL=https://webhook.site/9d867d67-f77a-409b-aad6-73ebb2a264c2
+SELF_HOSTED_WEBHOOK_URL=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -50,3 +50,6 @@ PROXY_USERNAME=
 PROXY_PASSWORD=
 # set if you'd like to block media requests to save proxy bandwidth
 BLOCK_MEDIA=
+
+# Set this to the URL of your webhook when using the self-hosted version of FireCrawl
+SELF_HOSTED_WEBHOOK_URL=https://webhook.site/9d867d67-f77a-409b-aad6-73ebb2a264c2


### PR DESCRIPTION
This commit introduces the capability of using a Self-Hosted Webhook URL. The application now checks for a self-hosted URL before querying the database for the webhook settings. If a Self-Hosted Webhook URL is set in the environment variables, it will be used directly, diminishing unnecessary database queries.