### PR TITLE
Adds a nolink attribute to scraper pageOptions

### DIFF
--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -13,6 +13,7 @@ export interface Progress {
 export type PageOptions = {
   onlyMainContent?: boolean;
   includeHtml?: boolean;
+  noLinks?: boolean;
   fallback?: boolean;
   fetchPageContent?: boolean;
   waitFor?: number;

--- a/apps/api/src/lib/html-to-markdown.ts
+++ b/apps/api/src/lib/html-to-markdown.ts
@@ -1,44 +1,72 @@
-
-export function parseMarkdown(html: string) {
-  var TurndownService = require("turndown");
-  var turndownPluginGfm = require('joplin-turndown-plugin-gfm')
-
+export function parseMarkdown(html: string, removeLinks: boolean = false) {
+  var TurndownService = require('turndown');
+  var turndownPluginGfm = require('joplin-turndown-plugin-gfm');
 
   const turndownService = new TurndownService();
-  turndownService.addRule("inlineLink", {
-    filter: function (node, options) {
-      return (
-        options.linkStyle === "inlined" &&
-        node.nodeName === "A" &&
-        node.getAttribute("href")
-      );
-    },
-    replacement: function (content, node) {
-      var href = node.getAttribute("href").trim();
-      var title = node.title ? ' "' + node.title + '"' : "";
-      return "[" + content.trim() + "](" + href + title + ")\n";
-    },
-  });
+
+  if (!removeLinks) {
+    turndownService.addRule('inlineLink', {
+      filter: function (node, options) {
+        return (
+          options.linkStyle === 'inlined' &&
+          node.nodeName === 'A' &&
+          node.getAttribute('href')
+        );
+      },
+      replacement: function (content, node) {
+        var href = node.getAttribute('href').trim();
+        var title = node.title ? ' "' + node.title + '"' : '';
+        return '[' + content.trim() + '](' + href + title + ')\n';
+      },
+    });
+  } else {
+    turndownService.addRule('inlineNoLink', {
+      filter: function (node, options) {
+        return (
+          options.linkStyle === 'inlined' &&
+          node.nodeName === 'A' &&
+          node.getAttribute('href')
+        );
+      },
+      replacement: function (content, node) {
+        var title = node.title ? ' "' + node.title + '"' : '';
+        return '[' + content.trim() + '](' + title + ')\n';
+      },
+    });
+
+    // Rule to handle image tags and remove the src attribute
+    turndownService.addRule('imageNoSrc', {
+      filter: function (node) {
+        return node.nodeName === 'IMG' && node.getAttribute('src');
+      },
+      replacement: function (content, node) {
+        var alt = node.alt ? node.alt : '';
+        var title = node.title ? ' "' + node.title + '"' : '';
+        return alt ? `![${alt}]${title}\n` : '';
+      },
+    });
+  }
+
   var gfm = turndownPluginGfm.gfm;
   turndownService.use(gfm);
   let markdownContent = turndownService.turndown(html);
 
   // multiple line links
   let insideLinkContent = false;
-  let newMarkdownContent = "";
+  let newMarkdownContent = '';
   let linkOpenCount = 0;
   for (let i = 0; i < markdownContent.length; i++) {
     const char = markdownContent[i];
 
-    if (char == "[") {
+    if (char == '[') {
       linkOpenCount++;
-    } else if (char == "]") {
+    } else if (char == ']') {
       linkOpenCount = Math.max(0, linkOpenCount - 1);
     }
     insideLinkContent = linkOpenCount > 0;
 
-    if (insideLinkContent && char == "\n") {
-      newMarkdownContent += "\\" + "\n";
+    if (insideLinkContent && char == '\n') {
+      newMarkdownContent += '\\' + '\n';
     } else {
       newMarkdownContent += char;
     }
@@ -48,7 +76,7 @@ export function parseMarkdown(html: string) {
   // Remove [Skip to Content](#page) and [Skip to content](#skip)
   markdownContent = markdownContent.replace(
     /\[Skip to Content\]\(#[^\)]*\)/gi,
-    ""
+    ''
   );
 
   return markdownContent;

--- a/apps/api/src/scraper/WebScraper/single_url.ts
+++ b/apps/api/src/scraper/WebScraper/single_url.ts
@@ -263,6 +263,7 @@ export async function scrapSingleUrl(
   urlToScrap: string,
   pageOptions: PageOptions = {
     onlyMainContent: true,
+    noLinks: false,
     includeHtml: false,
     waitFor: 0,
     screenshot: false,
@@ -355,7 +356,7 @@ export async function scrapSingleUrl(
     //* TODO: add an optional to return markdown or structured/extracted content
     let cleanedHtml = removeUnwantedElements(text, pageOptions);
 
-    return [await parseMarkdown(cleanedHtml), text, screenshot];
+    return [await parseMarkdown(cleanedHtml,pageOptions.noLinks), text, screenshot];
   };
   try {
     let [text, html, screenshot] = ["", "", ""];


### PR DESCRIPTION
Removes HREF and src, keep titles and alts if provided.

This is my first time coding TS, but works for me.
It just adds a couple of turndown rules to replace the elements.

Here's the test I used.
```
url = "https://www.humblebundle.com"

app = FirecrawlApp(api_url="http://localhost:3002")

params={"pageOptions": {
        "includeHtml": False,
        "noLinks": True,
        "waitFor": 123,        
        "onlyMainContent": True,}}
scraped_data = app.scrape_url(url,params=params)
```