### PR TITLE
[Bug] Fixed includeHTML to use cleanedHtml as response

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "build": "tsc",
     "test": "npx jest --detectOpenHandles --forceExit --openHandlesTimeout=120000 --watchAll=false --testPathIgnorePatterns='src/__tests__/e2e_noAuth/*'",
     "test:local-no-auth": "npx jest --detectOpenHandles --forceExit --openHandlesTimeout=120000 --watchAll=false --testPathIgnorePatterns='src/__tests__/e2e_withAuth/*'",
+    "test:full": "npx jest --detectOpenHandles --forceExit --openHandlesTimeout=120000 --watchAll=false --testPathIgnorePatterns='(src/__tests__/e2e_noAuth|src/__tests__/e2e_withAuth)'",
     "test:prod": "npx jest --detectOpenHandles --forceExit --openHandlesTimeout=120000 --watchAll=false --testPathIgnorePatterns='(src/__tests__/e2e_noAuth|src/__tests__/e2e_full_withAuth)'",
     "workers": "nodemon --exec ts-node src/services/queue-worker.ts",
     "worker:production": "node dist/src/services/queue-worker.js",

--- a/apps/api/src/scraper/WebScraper/single_url.ts
+++ b/apps/api/src/scraper/WebScraper/single_url.ts
@@ -401,7 +401,7 @@ export async function scrapSingleUrl(
 
     return {
       text: await parseMarkdown(cleanedHtml),
-      html: scraperResponse.text,
+      html: cleanedHtml,
       screenshot: scraperResponse.screenshot,
       pageStatusCode: scraperResponse.metadata.pageStatusCode,
       pageError: scraperResponse.metadata.pageError || undefined
@@ -428,7 +428,7 @@ export async function scrapSingleUrl(
       if (existingHtml && existingHtml.trim().length >= 100) {
         let cleanedHtml = removeUnwantedElements(existingHtml, pageOptions);
         text = await parseMarkdown(cleanedHtml);
-        html = existingHtml;
+        html = cleanedHtml;
         break;
       }
 


### PR DESCRIPTION
Closes #291 

Tested with `requests.http`:
```
POST http://localhost:3002/v0/scrape HTTP/1.1
Authorization: Bearer fc-<YOUR-KEY-HERE>
content-type: application/json

{
    "url":"mendable.ai",
    "pageOptions": {
      "includeHtml": true,
      "onlyMainContent": true
    }
}
```

the `html` should **not** contain "introducing" (from Firecrawl banner) 