### PR TITLE
Cjp/email to posthog logging

### DIFF
--- a/apps/api/src/services/idempotency/validate.ts
+++ b/apps/api/src/services/idempotency/validate.ts
@@ -10,10 +10,12 @@ export async function validateIdempotencyKey(
     // // not returning for missing idempotency key for now
     return true;
   }
-  if (!isUuid(idempotencyKey)) {
-    console.error("Invalid idempotency key provided in the request headers.");
-    return false;
-  }
+   // Ensure idempotencyKey is treated as a string
+   const key = Array.isArray(idempotencyKey) ? idempotencyKey[0] : idempotencyKey;
+   if (!isUuid(key)) {
+     console.error("Invalid idempotency key provided in the request headers.");
+     return false;
+   }
 
   const { data, error } = await supabase_service
     .from("idempotency_keys")


### PR DESCRIPTION
Changed how Posthog tracking works. Now, we associate each job to a group with the team_id instead of just creating users under that name.

See associated [pull in firecrawl-web ](https://github.com/mendableai/firecrawl-web/pull/29)