### PR TITLE
fix multi-word search term issue: /search (w/o Serp)

### DIFF
--- a/apps/api/src/search/googlesearch.ts
+++ b/apps/api/src/search/googlesearch.ts
@@ -52,8 +52,6 @@ async function _req(term: string, results: number, lang: string, country: string
 
 
 export async function google_search(term: string, advanced = false, num_results = 7, tbs = null, filter = null, lang = "en", country = "us", proxy = null, sleep_interval = 0, timeout = 5000, ) :Promise<SearchResult[]> {
-    const escaped_term = querystring.escape(term);
-
     let proxies = null;
     if (proxy) {
         if (proxy.startsWith("https")) {
@@ -71,7 +69,7 @@ export async function google_search(term: string, advanced = false, num_results 
     const maxAttempts = 20; // Define a maximum number of attempts to prevent infinite loop
     while (start < num_results && attempts < maxAttempts) {
         try {
-            const resp = await _req(escaped_term, num_results - start, lang, country, start, proxies, timeout, tbs, filter);
+            const resp = await _req(term, num_results - start, lang, country, start, proxies, timeout, tbs, filter);
             const $ = cheerio.load(resp.data);
             const result_block = $("div.g");
             if (result_block.length === 0) {


### PR DESCRIPTION
I tried to use /search without Serp in my self-hosted app, and there was the result of the request:
`
curl -X POST http://localhost:3002/v0/search \
    -H 'Content-Type: application/json' \
    -d '{
      "query": "What is Mendable?"
    }'
`
![Screenshot 2024-06-24 at 1 46 45 PM](https://github.com/mendableai/firecrawl/assets/233766/4344ee8c-5dc6-4210-8ef0-7f884255800c)

This error only happens when the search term is a sentence.

In my fix, I pass the **term** without URLencode as this is apparently not as necessary when it is sent by params via axios.

so there are no problems with special characters after this change:
`
curl -X POST http://localhost:3002/v0/search \
    -H 'Content-Type: application/json' \
    -d '{
      "query": "Como funciona validação cruzada em LLMs?"
    }'
`
![image](https://github.com/mendableai/firecrawl/assets/233766/9223b939-b369-4947-9186-ac83368b424d)
