### PR TITLE
Self-hosting quality of life fixes

### DIFF
--- a/apps/api/src/services/webhook.ts
+++ b/apps/api/src/services/webhook.ts
@@ -2,7 +2,7 @@ import { supabase_service } from "./supabase";
 
 export const callWebhook = async (teamId: string, jobId: string,data: any) => {
   try {
-    const selfHostedUrl = process.env.SELF_HOSTED_WEBHOOK_URL;
+    const selfHostedUrl = process.env.SELF_HOSTED_WEBHOOK_URL?.replace("{{JOB_ID}}", jobId);
     const useDbAuthentication = process.env.USE_DB_AUTHENTICATION === 'true';
     let webhookUrl = selfHostedUrl;
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,9 @@ x-common-service: &common-service
     - SUPABASE_SERVICE_TOKEN=${SUPABASE_SERVICE_TOKEN}
     - SCRAPING_BEE_API_KEY=${SCRAPING_BEE_API_KEY}
     - HOST=${HOST:-0.0.0.0}
+    - SELF_HOSTED_WEBHOOK_URL=${SELF_HOSTED_WEBHOOK_URL}
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
 
 services:
   playwright-service:


### PR DESCRIPTION
1. Fixes missing env var mapping in docker-compose.yml
2. Allows for connection to local machine from docker-compose network
3. Rudimentary jobId templating for webhook URL (self-hosted only of course)