### PR TITLE
Fix USE_DB_AUTHENTICATION checks for self-host

### DIFF
--- a/apps/api/src/controllers/crawl-status.ts
+++ b/apps/api/src/controllers/crawl-status.ts
@@ -23,7 +23,7 @@ export async function crawlStatusController(req: Request, res: Response) {
     const { current, current_url, total, current_step, partialDocs } = await job.progress();
 
     let data = job.returnvalue;
-    if (process.env.USE_DB_AUTHENTICATION) {
+    if (process.env.USE_DB_AUTHENTICATION === "true") {
       const supabaseData = await supabaseGetJobById(req.params.jobId);
 
       if (supabaseData) {

--- a/apps/api/src/controllers/status.ts
+++ b/apps/api/src/controllers/status.ts
@@ -11,7 +11,7 @@ export async function crawlJobStatusPreviewController(req: Request, res: Respons
 
     const { current, current_url, total, current_step, partialDocs } = await job.progress();
     let data = job.returnvalue;
-    if (process.env.USE_DB_AUTHENTICATION) {
+    if (process.env.USE_DB_AUTHENTICATION === "true") {
       const supabaseData = await supabaseGetJobById(req.params.jobId);
 
       if (supabaseData) {

--- a/apps/api/src/main/runWebScraper.ts
+++ b/apps/api/src/main/runWebScraper.ts
@@ -111,7 +111,7 @@ export async function runWebScraper({
 
 const saveJob = async (job: Job, result: any) => {
   try {
-    if (process.env.USE_DB_AUTHENTICATION) {
+    if (process.env.USE_DB_AUTHENTICATION === "true") {
       const { data, error } = await supabase_service
         .from("firecrawl_jobs")
         .update({ docs: result })

--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -6,7 +6,7 @@ import "dotenv/config";
 
 export async function logJob(job: FirecrawlJob) {
   try {
-    if (!process.env.USE_DB_AUTHENTICATION) {
+    if (process.env.USE_DB_AUTHENTICATION === "false") {
       return;
     }
 


### PR DESCRIPTION
Trying self hosting with `USE_DB_AUTHENTICATION=false`, some API endpints still tries to use Supabase and that seems blocking to get responses.


```
$ diff apps/api/.env.example .env
5c5
< REDIS_URL=redis://localhost:6379
---
> REDIS_URL=redis://redis:6379
9c9
< USE_DB_AUTHENTICATION=true
---
> USE_DB_AUTHENTICATION=false

$ docker compose up
```

```
$ curl -X POST http://localhost:3002/v0/crawl \
    -H 'Content-Type: application/json' \
    -d '{"url": "https://mendable.ai"}'

{"jobId":"55a746a8-2c99-4066-853a-b362b2f298ba"}
```

```
$ curl -X GET http://localhost:3002/v0/crawl/status/55a746a8-2c99-4066-853a-b362b2f298ba

{"error":"Supabase client is not configured."}
```

console shows:

```
api-1                 | Attempted to access Supabase client when it's not configured.
api-1                 | Error: Supabase client is not configured.
api-1                 |     at Proxy.<anonymous> (/app/dist/src/services/supabase.js:38:23)
api-1                 |     at supabaseGetJobById (/app/dist/src/lib/supabase-jobs.js:7:10)
api-1                 |     at crawlStatusController (/app/dist/src/controllers/crawl-status.js:21:79)
api-1                 |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

another one.

```
$ curl -X GET http://localhost:3002/v0/checkJobStatus/55a746a8-2c99-4066-853a-b362b2f298ba

{"error":"Supabase client is not configured."}
```

console shows:

```
api-1                 | Attempted to access Supabase client when it's not configured.
api-1                 | Error: Supabase client is not configured.
api-1                 |     at Proxy.<anonymous> (/app/dist/src/services/supabase.js:38:23)
api-1                 |     at supabaseGetJobById (/app/dist/src/lib/supabase-jobs.js:7:10)
api-1                 |     at crawlJobStatusPreviewController (/app/dist/src/controllers/status.js:15:79)
api-1                 |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

apply this PR and rebuild.

```
$ docker compose build --no-cache
$ docker compose up
```

```
$ curl -X GET http://localhost:3002/v0/checkJobStatus/55a746a8-2c99-4066-853a-b362b2f298ba

{"status":"waiting","data":null}
```

```
$ curl -X GET http://localhost:3002/v0/crawl/status/55a746a8-2c99-4066-853a-b362b2f298ba

{"status":"waiting","data":null}
```
