### PR TITLE
Caleb: Return a list of links on a page by default

### DIFF
--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -89,7 +89,8 @@ export class Document {
   warning?: string;
 
   index?: number;
-
+  linksOnPage?: string[]; // Add this new field as a separate property
+  
   constructor(data: Partial<Document>) {
     if (!data.content) {
       throw new Error("Missing required fields");
@@ -102,6 +103,7 @@ export class Document {
     this.markdown = data.markdown || "";
     this.childrenLinks = data.childrenLinks || undefined;
     this.provider = data.provider || undefined;
+    this.linksOnPage = data.linksOnPage; // Assign linksOnPage if provided
   }
 }
 

--- a/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
+++ b/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
@@ -33,5 +33,5 @@ it('should return a list of links on the mendable.ai page', async () => {
   expect(result.linksOnPage).toBeDefined();
   expect(Array.isArray(result.linksOnPage)).toBe(true);
   expect(result.linksOnPage.length).toBeGreaterThan(0);
-  expect(result.linksOnPage).toContain('https://www.mendable.ai/blog')
+  expect(result.linksOnPage).toContain('https://mendable.ai/blog')
 }, 10000);

--- a/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
+++ b/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
@@ -33,4 +33,5 @@ it('should return a list of links on the mendable.ai page', async () => {
   expect(result.linksOnPage).toBeDefined();
   expect(Array.isArray(result.linksOnPage)).toBe(true);
   expect(result.linksOnPage.length).toBeGreaterThan(0);
+  expect(result.linksOnPage).toContain('https://www.mendable.ai/blog')
 }, 10000);

--- a/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
+++ b/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
@@ -22,3 +22,17 @@ describe('scrapSingleUrl', () => {
   }, 10000);
 });
 
+
+it('should return a list of links on the mendable.ai page', async () => {
+  const url = 'https://mendable.ai';
+  const pageOptions: PageOptions = { includeHtml: true };
+
+  const result = await scrapSingleUrl(url, pageOptions);
+
+  // Check if the result contains a list of links
+  expect(result.linksOnPage).toBeDefined();
+  expect(Array.isArray(result.linksOnPage)).toBe(true);
+  expect(result.linksOnPage.length).toBeGreaterThan(0);
+}, 10000);
+
+

--- a/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
+++ b/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
@@ -22,6 +22,81 @@ describe('scrapSingleUrl', () => {
   }, 10000);
 });
 
+import { scrapSingleUrl } from '../single_url';
+import { PageOptions } from '../../../lib/entities';
+
+// Mock the fetchHtmlContent function
+jest.mock('../single_url', () => {
+  const originalModule = jest.requireActual('../single_url');
+  originalModule.fetchHtmlContent = jest.fn().mockResolvedValue(`
+    <html>
+      <head><title>Test Page</title></head>
+      <body>
+        <a href="https://example.com">Absolute Link</a>
+        <a href="/relative">Relative Link</a>
+        <a href="page">Page Link</a>
+        <a href="#fragment">Fragment Link</a>
+        <a href="mailto:test@example.com">Email Link</a>
+      </body>
+    </html>
+  `);
+  return originalModule;
+});
+
+describe('scrapSingleUrl with linksOnPage', () => {
+  const baseUrl = 'https://test.com';
+
+  it('should not include linksOnPage when option is false', async () => {
+    const pageOptions: PageOptions = {};
+    const result = await scrapSingleUrl(baseUrl, pageOptions);
+    expect(result.linksOnPage).toBeUndefined();
+  });
+
+  it('should include linksOnPage when option is true', async () => {
+    const pageOptions: PageOptions = {  };
+    const result = await scrapSingleUrl(baseUrl, pageOptions);
+    expect(result.linksOnPage).toBeDefined();
+    expect(Array.isArray(result.linksOnPage)).toBe(true);
+  });
+
+  it('should correctly handle absolute URLs', async () => {
+    const pageOptions: PageOptions = {  };
+    const result = await scrapSingleUrl(baseUrl, pageOptions);
+    expect(result.linksOnPage).toContain('https://example.com');
+  });
+
+  it('should correctly handle relative URLs', async () => {
+    const pageOptions: PageOptions = {  };
+    const result = await scrapSingleUrl(baseUrl, pageOptions);
+    expect(result.linksOnPage).toContain('https://test.com/relative');
+  });
+
+  it('should correctly handle page URLs', async () => {
+    const pageOptions: PageOptions = {  };
+    const result = await scrapSingleUrl(baseUrl, pageOptions);
+    expect(result.linksOnPage).toContain('https://test.com/page');
+  });
+
+  it('should not include fragment-only links', async () => {
+    const pageOptions: PageOptions = {  };
+    const result = await scrapSingleUrl(baseUrl, pageOptions);
+    expect(result.linksOnPage).not.toContain('#fragment');
+    expect(result.linksOnPage).not.toContain('https://test.com/#fragment');
+  });
+
+  it('should include mailto links', async () => {
+    const pageOptions: PageOptions = {  };
+    const result = await scrapSingleUrl(baseUrl, pageOptions);
+    expect(result.linksOnPage).toContain('mailto:test@example.com');
+  });
+
+  it('should return unique links', async () => {
+    const pageOptions: PageOptions = {  };
+    const result = await scrapSingleUrl(baseUrl, pageOptions);
+    const uniqueLinks = new Set(result.linksOnPage);
+    expect(result.linksOnPage?.length).toBe(uniqueLinks.size);
+  });
+});
 
 it('should return a list of links on the mendable.ai page', async () => {
   const url = 'https://mendable.ai';
@@ -34,5 +109,7 @@ it('should return a list of links on the mendable.ai page', async () => {
   expect(Array.isArray(result.linksOnPage)).toBe(true);
   expect(result.linksOnPage.length).toBeGreaterThan(0);
 }, 10000);
+
+
 
 

--- a/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
+++ b/apps/api/src/scraper/WebScraper/__tests__/single_url.test.ts
@@ -1,12 +1,13 @@
+import { scrapSingleUrl } from '../single_url';
+import { PageOptions } from '../../../lib/entities';
+
+
 jest.mock('../single_url', () => {
   const originalModule = jest.requireActual('../single_url');
   originalModule.fetchHtmlContent = jest.fn().mockResolvedValue('<html><head><title>Test</title></head><body><h1>Roast</h1></body></html>');
 
   return originalModule;
 });
-
-import { scrapSingleUrl } from '../single_url';
-import { PageOptions } from '../../../lib/entities';
 
 describe('scrapSingleUrl', () => {
   it('should handle includeHtml option correctly', async () => {
@@ -22,82 +23,6 @@ describe('scrapSingleUrl', () => {
   }, 10000);
 });
 
-import { scrapSingleUrl } from '../single_url';
-import { PageOptions } from '../../../lib/entities';
-
-// Mock the fetchHtmlContent function
-jest.mock('../single_url', () => {
-  const originalModule = jest.requireActual('../single_url');
-  originalModule.fetchHtmlContent = jest.fn().mockResolvedValue(`
-    <html>
-      <head><title>Test Page</title></head>
-      <body>
-        <a href="https://example.com">Absolute Link</a>
-        <a href="/relative">Relative Link</a>
-        <a href="page">Page Link</a>
-        <a href="#fragment">Fragment Link</a>
-        <a href="mailto:test@example.com">Email Link</a>
-      </body>
-    </html>
-  `);
-  return originalModule;
-});
-
-describe('scrapSingleUrl with linksOnPage', () => {
-  const baseUrl = 'https://test.com';
-
-  it('should not include linksOnPage when option is false', async () => {
-    const pageOptions: PageOptions = {};
-    const result = await scrapSingleUrl(baseUrl, pageOptions);
-    expect(result.linksOnPage).toBeUndefined();
-  });
-
-  it('should include linksOnPage when option is true', async () => {
-    const pageOptions: PageOptions = {  };
-    const result = await scrapSingleUrl(baseUrl, pageOptions);
-    expect(result.linksOnPage).toBeDefined();
-    expect(Array.isArray(result.linksOnPage)).toBe(true);
-  });
-
-  it('should correctly handle absolute URLs', async () => {
-    const pageOptions: PageOptions = {  };
-    const result = await scrapSingleUrl(baseUrl, pageOptions);
-    expect(result.linksOnPage).toContain('https://example.com');
-  });
-
-  it('should correctly handle relative URLs', async () => {
-    const pageOptions: PageOptions = {  };
-    const result = await scrapSingleUrl(baseUrl, pageOptions);
-    expect(result.linksOnPage).toContain('https://test.com/relative');
-  });
-
-  it('should correctly handle page URLs', async () => {
-    const pageOptions: PageOptions = {  };
-    const result = await scrapSingleUrl(baseUrl, pageOptions);
-    expect(result.linksOnPage).toContain('https://test.com/page');
-  });
-
-  it('should not include fragment-only links', async () => {
-    const pageOptions: PageOptions = {  };
-    const result = await scrapSingleUrl(baseUrl, pageOptions);
-    expect(result.linksOnPage).not.toContain('#fragment');
-    expect(result.linksOnPage).not.toContain('https://test.com/#fragment');
-  });
-
-  it('should include mailto links', async () => {
-    const pageOptions: PageOptions = {  };
-    const result = await scrapSingleUrl(baseUrl, pageOptions);
-    expect(result.linksOnPage).toContain('mailto:test@example.com');
-  });
-
-  it('should return unique links', async () => {
-    const pageOptions: PageOptions = {  };
-    const result = await scrapSingleUrl(baseUrl, pageOptions);
-    const uniqueLinks = new Set(result.linksOnPage);
-    expect(result.linksOnPage?.length).toBe(uniqueLinks.size);
-  });
-});
-
 it('should return a list of links on the mendable.ai page', async () => {
   const url = 'https://mendable.ai';
   const pageOptions: PageOptions = { includeHtml: true };
@@ -109,7 +34,3 @@ it('should return a list of links on the mendable.ai page', async () => {
   expect(Array.isArray(result.linksOnPage)).toBe(true);
   expect(result.linksOnPage.length).toBeGreaterThan(0);
 }, 10000);
-
-
-
-

--- a/apps/api/src/scraper/WebScraper/single_url.ts
+++ b/apps/api/src/scraper/WebScraper/single_url.ts
@@ -16,6 +16,7 @@ import { scrapWithFetch } from "./scrapers/fetch";
 import { scrapWithFireEngine } from "./scrapers/fireEngine";
 import { scrapWithPlaywright } from "./scrapers/playwright";
 import { scrapWithScrapingBee } from "./scrapers/scrapingBee";
+import { extractLinks } from "./utils/utils";
 
 dotenv.config();
 
@@ -109,37 +110,7 @@ function getScrapingFallbackOrder(
   return scrapersInOrder as (typeof baseScrapers)[number][];
 }
 
-function extractLinks(html: string, baseUrl: string): string[] {
-  const $ = cheerio.load(html);
-  const links: string[] = [];
 
-  // Parse the base URL to get the origin
-  const urlObject = new URL(baseUrl);
-  const origin = urlObject.origin;
-
-  $('a').each((_, element) => {
-    const href = $(element).attr('href');
-    if (href) {
-      if (href.startsWith('http://') || href.startsWith('https://')) {
-        // Absolute URL, add as is
-        links.push(href);
-      } else if (href.startsWith('/')) {
-        // Relative URL starting with '/', append to origin
-        links.push(`${origin}${href}`);
-      } else if (!href.startsWith('#') && !href.startsWith('mailto:')) {
-        // Relative URL not starting with '/', append to base URL
-        links.push(`${baseUrl}/${href}`);
-      } else if (href.startsWith('mailto:')) {
-        // mailto: links, add as is
-        links.push(href);
-      }
-      // Fragment-only links (#) are ignored
-    }
-  });
-
-  // Remove duplicates and return
-  return [...new Set(links)];
-}
 
 export async function scrapSingleUrl(
   urlToScrap: string,

--- a/apps/api/src/scraper/WebScraper/utils/utils.ts
+++ b/apps/api/src/scraper/WebScraper/utils/utils.ts
@@ -1,4 +1,6 @@
 import axios from "axios";
+import * as cheerio from "cheerio";
+
 
 export async function attemptScrapWithRequests(
   urlToScrap: string
@@ -20,4 +22,36 @@ export async function attemptScrapWithRequests(
 
 export function sanitizeText(text: string): string {
   return text.replace("\u0000", "");
+}
+
+export function extractLinks(html: string, baseUrl: string): string[] {
+  const $ = cheerio.load(html);
+  const links: string[] = [];
+
+  // Parse the base URL to get the origin
+  const urlObject = new URL(baseUrl);
+  const origin = urlObject.origin;
+
+  $('a').each((_, element) => {
+    const href = $(element).attr('href');
+    if (href) {
+      if (href.startsWith('http://') || href.startsWith('https://')) {
+        // Absolute URL, add as is
+        links.push(href);
+      } else if (href.startsWith('/')) {
+        // Relative URL starting with '/', append to origin
+        links.push(`${origin}${href}`);
+      } else if (!href.startsWith('#') && !href.startsWith('mailto:')) {
+        // Relative URL not starting with '/', append to base URL
+        links.push(`${baseUrl}/${href}`);
+      } else if (href.startsWith('mailto:')) {
+        // mailto: links, add as is
+        links.push(href);
+      }
+      // Fragment-only links (#) are ignored
+    }
+  });
+
+  // Remove duplicates and return
+  return [...new Set(links)];
 }


### PR DESCRIPTION
For issue #421. I just extract the links from the HTML then return them as the linksOnPageParameter.

I thought about making this optional, but I couldn't see any downside to just including them. Might adding an optional parameter just add complexity?

Would love your take @rafaelsideguide @nickscamara 

Either way, the customer needs this by EOW lets get it merged :)