### PR TITLE
fix(WebScraper): infinite regex leading to fly.io instance hangs

### DIFF
--- a/apps/api/src/scraper/WebScraper/utils/replacePaths.ts
+++ b/apps/api/src/scraper/WebScraper/utils/replacePaths.ts
@@ -6,13 +6,13 @@ export const replacePathsWithAbsolutePaths = (documents: Document[]): Document[]
       const baseUrl = new URL(document.metadata.sourceURL).origin;
       const paths =
         document.content.match(
-          /(!?\[.*?\])\(((?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)|href="([^"]+)"/g
+          /!?\[.*?\]\(.*?\)|href=".+?"/g
         ) || [];
 
       paths.forEach((path: string) => {
         try {
           const isImage = path.startsWith("!");
-        let matchedUrl = path.match(/\(([^)]+)\)/) || path.match(/href="([^"]+)"/);
+        let matchedUrl = path.match(/\((.*?)\)/) || path.match(/href="([^"]+)"/);
         let url = matchedUrl[1];
 
         if (!url.startsWith("data:") && !url.startsWith("http")) {
@@ -50,11 +50,11 @@ export const replaceImgPathsWithAbsolutePaths = (documents: Document[]): Documen
       const baseUrl = new URL(document.metadata.sourceURL).origin;
       const images =
         document.content.match(
-          /!\[.*?\]\(((?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)/g
+          /!\[.*?\]\(.*?\)/g
         ) || [];
 
       images.forEach((image: string) => {
-        let imageUrl = image.match(/\(([^)]+)\)/)[1];
+        let imageUrl = image.match(/\((.*?)\)/)[1];
         let altText = image.match(/\[(.*?)\]/)[1];
 
         if (!imageUrl.startsWith("data:image")) {


### PR DESCRIPTION
After SSH-ing into a frozen Fly machine with CPU utilization on 100%, I noticed that the process using the most CPU was Node itself.

<img width="696" alt="Screenshot 2024-07-18 at 19 19 28" src="https://github.com/user-attachments/assets/bc7e8477-b1b0-4e74-ac26-ebd175d179ed">

After putting Node into debugging mode, attaching the monitor, and pausing the process, it was stuck on a regex in `replacePaths`.

<img width="766" alt="Screenshot 2024-07-18 at 19 21 34" src="https://github.com/user-attachments/assets/05dce2d1-f88f-41d2-9d3d-1a2cbaf61ca6">

I dumped the document's content and I was able to reproduce the issue locally. I consulted with @rafaelsideguide to replace the problematic regex with something that still worked the same, and I tested the new regex locally.