### PR TITLE
Self-host fix: Moving comments of .env.example values from end-of-line to above-line.

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -17,18 +17,29 @@ SUPABASE_URL=
 SUPABASE_SERVICE_TOKEN=
 
 # Other Optionals
-TEST_API_KEY= # use if you've set up authentication and want to test with a real API key
-RATE_LIMIT_TEST_API_KEY_SCRAPE= # set if you'd like to test the scraping rate limit
-RATE_LIMIT_TEST_API_KEY_CRAWL= # set if you'd like to test the crawling rate limit
-SCRAPING_BEE_API_KEY= #Set if you'd like to use scraping Be to handle JS blocking
-OPENAI_API_KEY= # add for LLM dependednt features (image alt generation, etc.)
-BULL_AUTH_KEY= @
-LOGTAIL_KEY= # Use if you're configuring basic logging with logtail
-LLAMAPARSE_API_KEY= #Set if you have a llamaparse key you'd like to use to parse pdfs
-SERPER_API_KEY= #Set if you have a serper key you'd like to use as a search api
-SLACK_WEBHOOK_URL= # set if you'd like to send slack server health status messages
-POSTHOG_API_KEY= # set if you'd like to send posthog events like job logs
-POSTHOG_HOST= # set if you'd like to send posthog events like job logs
+# use if you've set up authentication and want to test with a real API key
+TEST_API_KEY=
+# set if you'd like to test the scraping rate limit
+RATE_LIMIT_TEST_API_KEY_SCRAPE=
+# set if you'd like to test the crawling rate limit
+RATE_LIMIT_TEST_API_KEY_CRAWL=
+# set if you'd like to use scraping Be to handle JS blocking
+SCRAPING_BEE_API_KEY=
+# add for LLM dependednt features (image alt generation, etc.)
+OPENAI_API_KEY=
+BULL_AUTH_KEY=@
+# use if you're configuring basic logging with logtail
+LOGTAIL_KEY=
+# set if you have a llamaparse key you'd like to use to parse pdfs
+LLAMAPARSE_API_KEY=
+# set if you have a serper key you'd like to use as a search api
+SERPER_API_KEY=
+# set if you'd like to send slack server health status messages
+SLACK_WEBHOOK_URL=
+# set if you'd like to send posthog events like job logs
+POSTHOG_API_KEY=
+# set if you'd like to send posthog events like job logs
+POSTHOG_HOST=
 
 STRIPE_PRICE_ID_STANDARD=
 STRIPE_PRICE_ID_SCALE=
@@ -43,7 +54,8 @@ STRIPE_PRICE_ID_GROWTH_YEARLY=
 HYPERDX_API_KEY=
 HDX_NODE_BETA_MODE=1
 
-FIRE_ENGINE_BETA_URL= # set if you'd like to use the fire engine closed beta
+# set if you'd like to use the fire engine closed beta
+FIRE_ENGINE_BETA_URL=
 
 # Proxy Settings for Playwright (Alternative you can can use a proxy service like oxylabs, which rotates IPs for you on every request)
 PROXY_SERVER=


### PR DESCRIPTION
Self-host docs suggest using .env.example as a base. However, Docker doesn't respect end-of-line comments. It sets the comment as the actual value of the variable, leading to invalid behavior. This fix prevents that.