### PR TITLE
fix: go-sdk module name

### DIFF
--- a/apps/go-sdk/README.md
+++ b/apps/go-sdk/README.md
@@ -7,7 +7,7 @@ The Firecrawl Go SDK is a library that allows you to easily scrape and crawl web
 To install the Firecrawl Go SDK, you can
 
 ```bash
-go get github.com/mendableai/firecrawl/go-sdk/firecrawl
+go get github.com/mendableai/firecrawl
 ```
 
 ## Usage
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mendableai/firecrawl/go-sdk/firecrawl"
+	"github.com/mendableai/firecrawl/firecrawl"
 )
 
 func main() {

--- a/apps/go-sdk/examples/example.go
+++ b/apps/go-sdk/examples/example.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/google/uuid"
-	"github.com/mendableai/firecrawl/go-sdk/firecrawl"
+	"github.com/mendableai/firecrawl/firecrawl"
 )
 
 func main() {

--- a/apps/go-sdk/examples/go.mod
+++ b/apps/go-sdk/examples/go.mod
@@ -1,10 +1,10 @@
-module github.com/mendableai/firecrawl/go-sdk/examples
+module github.com/mendableai/firecrawl/apps/go-sdk/examples
 
 go 1.22.5
 
-replace github.com/mendableai/firecrawl/go-sdk => ../
+replace github.com/mendableai/firecrawl => ../
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/mendableai/firecrawl/go-sdk v0.0.0-00010101000000-000000000000
+	github.com/mendableai/firecrawl v0.0.0-00010101000000-000000000000
 )

--- a/apps/go-sdk/go.mod
+++ b/apps/go-sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/mendableai/firecrawl/go-sdk
+module github.com/mendableai/firecrawl/apps/go-sdk
 
 go 1.22.5
 


### PR DESCRIPTION
# Description

This PR fixes go-sdk module name, so it matches with the project layout
README and example are also updated with new module name

## Issue reference

Please reference the issue this PR will close: #533  

## Prior work reference

Firecrawl go-sdk is added in this PR: #497 