### PR TITLE
fix: relative url 2 full url use error base url

### DIFF
--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -273,7 +273,7 @@ export class WebCrawler {
     let fullUrl = href;
     if (!href.startsWith("http")) {
       try {
-        fullUrl = new URL(href, this.baseUrl).toString();
+        fullUrl = new URL(href, url).toString();
       } catch (_) {
         return null;
       }


### PR DESCRIPTION
according to ： https://developer.mozilla.org/en-US/docs/Web/API/URL/URL 

> new URL(url, base)
[base](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#base) Optional
A string representing the base URL to use in cases where url is a relative reference. If not specified, it defaults to undefined.


eg: 
* pageUrl = `http://example.com/a/b/c/d.html `
* tag : `<a herf="../e.html"></a>`

correct: `new URL('../e.html','http://example.com/a/b/c/d.html')`
incorrect: `new URL('../e.html','http://example.com')` 