### PR TITLE
fix check url isInternalLink error (action urlObj.hostname --> urlObj.host)

### DIFF
--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -444,7 +444,7 @@ export class WebCrawler {
   private isInternalLink(link: string): boolean {
     const urlObj = new URL(link, this.baseUrl);
     const baseDomain = this.baseUrl.replace(/^https?:\/\//, "").replace(/^www\./, "").trim();
-    const linkDomain = urlObj.hostname.replace(/^www\./, "").trim();
+    const linkDomain = urlObj.host.replace(/^www\./, "").trim();
     
     return linkDomain === baseDomain;
   }


### PR DESCRIPTION

when crawl a ip based website , check a url isInternalLink looks incorrect
## case 1 : for domain based url ,it is ok 

`new URL("http://example.com/a.html").host ` === `new URL("http://example.com/a.html").hostname `

## case 2: for ip based url , it is not ok 
for a url : `http://127.0.0.1:8080/a/index.html`,
according to line 55 `this.baseUrl = new URL(initialUrl).origin;`  the baseUrl is  `http://127.0.0.1:8080`

```typescript
 private isInternalLink(link: string): boolean {
    const urlObj = new URL(link, this.baseUrl);
    const baseDomain = this.baseUrl.replace(/^https?:\/\//, "").replace(/^www\./, "").trim();
    const linkDomain = urlObj.hostname.replace(/^www\./, "").trim();
    
    return linkDomain === baseDomain;
  }
``` 

for method `isInternalLink`
urlObj: 
<img width="456" alt="image" src="https://github.com/user-attachments/assets/aa48662d-ca12-4e96-bdba-34f42398cd7b">

baseDomain: `127.0.0.1:8080`
linkDomain(incorrect): `127.0.0.1` (`urlObj.hostname`)
linkDomain(correct): `127.0.0.1:8080` (`urlObj.host`)

so above method `isInternalLink` should change to 
```typescript
 private isInternalLink(link: string): boolean {
    const urlObj = new URL(link, this.baseUrl);
    const baseDomain = this.baseUrl.replace(/^https?:\/\//, "").replace(/^www\./, "").trim();
    const linkDomain = urlObj.host.replace(/^www\./, "").trim();
    
    return linkDomain === baseDomain;
  }
``` 

main change: `urlObj.hostname` ==> `urlObj.host`