### PR TITLE
Remove print statement in map

### DIFF
--- a/apps/python-sdk/firecrawl/firecrawl.py
+++ b/apps/python-sdk/firecrawl/firecrawl.py
@@ -229,7 +229,7 @@ class FirecrawlApp:
         json_data = {'url': url}
         if params:
             json_data.update(params)
-        
+
         # Make the POST request with the prepared headers and JSON data
         response = requests.post(
             f'{self.api_url}{endpoint}',
@@ -238,9 +238,8 @@ class FirecrawlApp:
         )
         if response.status_code == 200:
             response = response.json()
-            print(response)
             if response['success'] and 'links' in response:
-                return response['links']
+                return response
             else:
                 raise Exception(f'Failed to map URL. Error: {response["error"]}')
         else:

--- a/apps/python-sdk/firecrawl/firecrawl.py
+++ b/apps/python-sdk/firecrawl/firecrawl.py
@@ -239,7 +239,7 @@ class FirecrawlApp:
         if response.status_code == 200:
             response = response.json()
             if response['success'] and 'links' in response:
-                return response
+                return response['links']
             else:
                 raise Exception(f'Failed to map URL. Error: {response["error"]}')
         else:


### PR DESCRIPTION
Remove the print statement in map_url, which could be confusing when some client code has print statements for debugging. 
