### PR TITLE
Prevent Python Firecrawl logger from interfering with loggers in client 

### DIFF
--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -11,32 +11,54 @@ For more information visit https://github.com/firecrawl/
 import logging
 import os
 
-from .firecrawl import FirecrawlApp
+from .firecrawl import FirecrawlApp # noqa
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")
 
 
-def _basic_config() -> None:
-    """Set up basic configuration for logging with a specific format and date format."""
+def _configure_logger() -> None:
+    """
+    Configure the firecrawl logger for console output.
+
+    The function attaches a handler for console output with a specific format and date
+    format to the firecrawl logger.
+    """
     try:
-        logging.basicConfig(
-            format="[%(asctime)s - %(name)s:%(lineno)d - %(levelname)s] %(message)s",
+        # Check if the firecrawl logger already has a handler
+        if logger.hasHandlers():
+            return
+
+        # Create the formatter
+        formatter = logging.Formatter(
+            "[%(asctime)s - %(name)s:%(lineno)d - %(levelname)s] %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
+
+        # Create the console handler and set the formatter
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(formatter)
+
+        # Add the console handler to the firecrawl logger
+        logger.addHandler(console_handler)
     except Exception as e:
         logger.error("Failed to configure logging: %s", e)
 
 
 def setup_logging() -> None:
     """Set up logging based on the FIRECRAWL_LOGGING_LEVEL environment variable."""
-    env = os.environ.get(
-        "FIRECRAWL_LOGGING_LEVEL", "INFO"
-    ).upper()  # Default to 'INFO' level
-    _basic_config()
+    # Check if the FIRECRAWL_LOGGING_LEVEL environment variable is set
+    if not (env := os.getenv("FIRECRAWL_LOGGING_LEVEL", "").upper()):
+        # Attach a no-op handler to prevent warnings about no handlers
+        logger.addHandler(logging.NullHandler()) 
+        return
 
+    # Attach the console handler to the firecrawl logger
+    _configure_logger()
+
+    # Set the logging level based on the FIRECRAWL_LOGGING_LEVEL environment variable
     if env == "DEBUG":
         logger.setLevel(logging.DEBUG)
     elif env == "INFO":

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -27,10 +27,6 @@ def _configure_logger() -> None:
     format to the firecrawl logger.
     """
     try:
-        # Check if the firecrawl logger already has a handler
-        if logger.hasHandlers():
-            return
-
         # Create the formatter
         formatter = logging.Formatter(
             "[%(asctime)s - %(name)s:%(lineno)d - %(levelname)s] %(message)s",
@@ -49,6 +45,10 @@ def _configure_logger() -> None:
 
 def setup_logging() -> None:
     """Set up logging based on the FIRECRAWL_LOGGING_LEVEL environment variable."""
+    # Check if the firecrawl logger already has a handler
+    if logger.hasHandlers():
+        return # To prevent duplicate logging
+
     # Check if the FIRECRAWL_LOGGING_LEVEL environment variable is set
     if not (env := os.getenv("FIRECRAWL_LOGGING_LEVEL", "").upper()):
         # Attach a no-op handler to prevent warnings about no handlers


### PR DESCRIPTION
This PR updates the logging setup in the Firecrawl Python SDK to replace the use of `basicConfig`. 

**Why this change is important:**
Using `basicConfig` in a library can unintentionally change the logging settings of any application that imports the library. `basicConfig` modifies the global logging configuration, which can cause conflicts, such as:
- Overriding the logging format or level set by the application.
- Adding duplicate log entries if the application has already configured its logging.

To avoid these problems, this PR introduces a more controlled logging setup that:
- Configures logging specifically for the Firecrawl package without affecting the rest of the application.
- Ensures that Firecrawl’s logs are handled properly without interfering with the global logging configuration.