### PR TITLE
perf(js-sdk): move `dotenv` and `uuid` to `devDependencies`, fix `zod` import

### DIFF
--- a/apps/js-sdk/firecrawl/package-lock.json
+++ b/apps/js-sdk/firecrawl/package-lock.json
@@ -1,19 +1,17 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendable/firecrawl-js",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",
-        "dotenv": "^16.4.5",
         "isows": "^1.0.4",
         "typescript-event-target": "^1.1.1",
-        "uuid": "^9.0.1",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.0"
       },
@@ -25,9 +23,11 @@
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.12.12",
         "@types/uuid": "^9.0.8",
+        "dotenv": "^16.4.5",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.2",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1657,6 +1657,7 @@
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
       "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -3794,6 +3795,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -29,10 +29,8 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^1.6.8",
-    "dotenv": "^16.4.5",
     "isows": "^1.0.4",
     "typescript-event-target": "^1.1.1",
-    "uuid": "^9.0.1",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.0"
   },
@@ -41,6 +39,8 @@
   },
   "homepage": "https://github.com/mendableai/firecrawl#readme",
   "devDependencies": {
+    "uuid": "^9.0.1",
+    "dotenv": "^16.4.5",
     "@jest/globals": "^29.7.0",
     "@types/axios": "^0.14.0",
     "@types/dotenv": "^8.2.0",

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse, AxiosRequestHeaders } from "axios";
-import { z } from "zod";
+import type { ZodSchema } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { WebSocket } from "isows";
 import { TypedEventTarget } from "typescript-event-target";
@@ -81,7 +81,7 @@ export interface ScrapeParams {
   onlyMainContent?: boolean;
   extract?: {
     prompt?: string;
-    schema?: z.ZodSchema | any;
+    schema?: ZodSchema | any;
     systemPrompt?: string;
   };
   waitFor?: number;


### PR DESCRIPTION
## Changes made
- Moved `dotenv` and `uuid` from `dependencies` to `devDependencies` since they're only used in tests
- Fixed `zod` import since before sometimes `import { z } from "zod"` would remain in the build js files, causing the whole zod to be imported even if it's not used