### PR TITLE
[Docs] upgraded the path of the self-hosted documentation URL to `/v1`.

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -106,7 +106,7 @@ You should be able to see the Bull Queue Manager UI on `http://localhost:3002/ad
 If you’d like to test the crawl endpoint, you can run this:
 
   ```bash
-  curl -X POST http://localhost:3002/v0/crawl \
+  curl -X POST http://localhost:3002/v1/crawl \
       -H 'Content-Type: application/json' \
       -d '{
         "url": "https://mendable.ai"


### PR DESCRIPTION
I was attempting self-hosting by referring to the following document, and I noticed that the URL path was outdated, so I fixed it.

- https://github.com/mendableai/firecrawl/blob/v1.0.0/SELF_HOST.md

I have compared it with the official documentation at https://docs.firecrawl.dev/api-reference/endpoint/crawl-post, and the issue has been corrected.
