### PR TITLE
Docs: Remove wait_until_done from python-sdk example

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,8 +410,7 @@ crawl_status = app.crawl_url(
   params={
     'limit': 100, 
     'scrapeOptions': {'formats': ['markdown', 'html']}
-  }, 
-  wait_until_done=True, 
+  },
   poll_interval=30
 )
 print(crawl_status)


### PR DESCRIPTION
Adding `wait_until_done` parameter to the `crawl_url` function will throw a TypeError: FirecrawlApp.crawl_url() got an unexpected keyword argument 'wait_until_done'.