### PR TITLE
[BUG] Fixed missing error handling in JS-SDK

### DIFF
--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -287,7 +287,7 @@ export default class FirecrawlApp {
         this.handleError(response, "scrape URL");
       }
     } catch (error: any) {
-      throw new FirecrawlError(error.message, 500);
+      this.handleError(error.response, "scrape URL");
     }
     return { success: false, error: "Internal server error." };
   }


### PR DESCRIPTION
Closes #758 

Previously the error would look like:

```
.../firecrawl/apps/js-sdk/node_modules/firecrawl/build/esm/index.js:67
            throw new Error(error.message);
                  ^

Error: Request failed with status code 402
    at FirecrawlApp.scrapeUrl (.../firecrawl/apps/js-sdk/node_modules/firecrawl/build/esm/index.js:67:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at main (.../firecrawl/apps/js-sdk/example.ts:8:24)

Node.js v20.9.0
```

Now it looks like:

```bash
.../firecrawl/apps/js-sdk/firecrawl/src/index.ts:571
      throw new FirecrawlError(
            ^
FirecrawlError: Failed to scrape URL. Status code: 402. Error: Insufficient credits. For more credits, you can upgrade your plan at https://firecrawl.dev/pricing.
    at FirecrawlApp.handleError (.../firecrawl/apps/js-sdk/firecrawl/src/index.ts:571:13)
    at FirecrawlApp.scrapeUrl (.../firecrawl/apps/js-sdk/firecrawl/src/index.ts:290:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at main (.../firecrawl/apps/js-sdk/example.ts:8:24) {
  statusCode: 402
}

Node.js v20.9.0
```

@huangbaitu123, what do you think?