### PR TITLE
[BUG] filters failed and unknown jobs now

### DIFF
--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -64,7 +64,7 @@ export async function crawlStatusController(req: RequestWithAuth<CrawlStatusPara
   // filter out failed jobs
   jobIDs = jobIDs.filter(id => !jobStatuses.some(status => status[0] === id && status[1] === "failed"));
   // filter the job statues
-  jobStatuses = jobStatuses.filter(x => x[1] !== "failed");
+  jobStatuses = jobStatuses.filter(x => x[1] !== "failed" && x[1] !== "unknown");
   const status: Exclude<CrawlStatusResponse, ErrorResponse>["status"] = sc.cancelled ? "cancelled" : jobStatuses.every(x => x[1] === "completed") ? "completed" : "scraping";
   const doneJobsLength = await getDoneJobsOrderedLength(req.params.jobId);
   const doneJobsOrder = await getDoneJobsOrdered(req.params.jobId, start, end ?? -1);


### PR DESCRIPTION
I found a crawl that got stuck on "scraping" status for hours (`url: rospa.com`). This fixes it.
![Captura de Tela 2024-10-09 às 11 51 23](https://github.com/user-attachments/assets/fa1008fb-b55f-4332-83ac-65dc86380c53)