### PR TITLE
URL Should be same protocol as request

### DIFF
--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -100,8 +100,7 @@ export async function crawlStatusController(req: RequestWithAuth<CrawlStatusPara
 
   const data = doneJobs.map(x => x.returnvalue);
 
-  const protocol = process.env.ENV === "local" ? req.protocol : "https";
-  const nextURL = new URL(`${protocol}://${req.get("host")}/v1/crawl/${req.params.jobId}`);
+  const nextURL = new URL(`${req.protocol}://${req.get("host")}/v1/crawl/${req.params.jobId}`);
 
   nextURL.searchParams.set("skip", (start + data.length).toString());
 

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -161,12 +161,10 @@ export async function crawlController(
     await callWebhook(req.auth.team_id, id, null, req.body.webhook, true, "crawl.started");
   }
 
-  const protocol = process.env.ENV === "local" ? req.protocol : "https";
-  
   return res.status(200).json({
     success: true,
     id,
-    url: `${protocol}://${req.get("host")}/v1/crawl/${id}`,
+    url: `${req.protocol}://${req.get("host")}/v1/crawl/${id}`,
   });
 }
 


### PR DESCRIPTION
- In self-host we are running without https, however the response Next is always https.

**Error Fixed:** 
HTTPSConnectionPool(host='172.18.0.8', port=3002): Max retries exceeded with url: /v1/crawl/6ebabc4e-6868-43da-a361-d1560dd55ce6?skip=125 (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1006)')))