### PR TITLE
Allow users to pick Anthropic or OpenAI for LLM extraction

### DIFF
--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -177,7 +177,10 @@ export async function mapController(
     crawlerOptions: {},
     pageOptions: {},
     origin: req.body.origin,
-    extractor_options: { mode: "markdown" },
+    extractor_options: {
+      mode: "markdown",
+      llmOptions: { provider: "openai", model: "gpt-4o-mini" },
+    },
     num_tokens: 0,
   });
 

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -23,6 +23,7 @@ export async function scrapeController(
   res: Response<ScrapeResponse>
 ) {
   req.body = scrapeRequestSchema.parse(req.body);
+  Logger.info(`Scrape request: ${JSON.stringify(req.body)}`);
   let earlyReturn = false;
 
   const origin = req.body.origin;
@@ -111,7 +112,7 @@ export async function scrapeController(
 
   billTeam(req.auth.team_id, req.acuc?.sub_id, creditsToBeBilled).catch(error => {
     Logger.error(`Failed to bill team ${req.auth.team_id} for ${creditsToBeBilled} credits: ${error}`);
-    // Optionally, you could notify an admin or add to a retry queue here
+      // Optionally, you could notify an admin or add to a retry queue here
   });
 
   if (!pageOptions || !pageOptions.includeRawHtml) {

--- a/apps/api/src/lib/LLM-extraction/index.ts
+++ b/apps/api/src/lib/LLM-extraction/index.ts
@@ -2,7 +2,7 @@ import OpenAI from "openai";
 import Ajv from "ajv";
 const ajv = new Ajv(); // Initialize AJV for JSON schema validation
 
-import { generateOpenAICompletions } from "./models";
+import { generateLlmCompletions } from "./models";
 import { Document, ExtractorOptions } from "../entities";
 import { Logger } from "../logger";
 
@@ -12,50 +12,49 @@ export async function generateCompletions(
   extractionOptions: ExtractorOptions,
   mode: "markdown" | "raw-html"
 ): Promise<Document[]> {
+  Logger.info("attempting to generate LLM completion");
+  Logger.info(`extractionOptions: ${JSON.stringify(extractionOptions)}`);
   // const schema = zodToJsonSchema(options.schema)
 
   const schema = extractionOptions.extractionSchema;
   const systemPrompt = extractionOptions.extractionPrompt;
   const prompt = extractionOptions.userPrompt;
 
-  const switchVariable = "openAI"; // Placholder, want to think more about how we abstract the model provider
-
   const completions = await Promise.all(
     documents.map(async (document: Document) => {
-      switch (switchVariable) {
-        case "openAI":
-          const llm = new OpenAI();
-          try {
-            const completionResult = await generateOpenAICompletions({
-              client: llm,
-              document: document,
-              schema: schema,
-              prompt: prompt,
-              systemPrompt: systemPrompt,
-              mode: mode,
-            });
-            // Validate the JSON output against the schema using AJV
-            if (schema) {
-              const validate = ajv.compile(schema);
-              if (!validate(completionResult.llm_extraction)) {
-                //TODO: add Custom Error handling middleware that bubbles this up with proper Error code, etc.
-                throw new Error(
-                  `JSON parsing error(s): ${validate.errors
-                    ?.map((err) => err.message)
-                    .join(
-                      ", "
-                    )}\n\nLLM extraction did not match the extraction schema you provided. This could be because of a model hallucination, or an Error on our side. Try adjusting your prompt, and if it doesn't work reach out to support.`
-                );
-              }
-            }
-
-            return completionResult;
-          } catch (error) {
-            Logger.error(`Error generating completions: ${error}`);
-            throw error;
+      try {
+        const completionResult = await generateLlmCompletions({
+          clientType: extractionOptions.llmOptions
+            ? extractionOptions.llmOptions.provider
+            : "openai",
+          model: extractionOptions.llmOptions
+            ? extractionOptions.llmOptions.model
+            : "gpt-4o-mini",
+          document: document,
+          schema: schema,
+          prompt: prompt,
+          systemPrompt: systemPrompt,
+          mode: mode,
+        });
+        // Validate the JSON output against the schema using AJV
+        if (schema) {
+          const validate = ajv.compile(schema);
+          if (!validate(completionResult.llm_extraction)) {
+            //TODO: add Custom Error handling middleware that bubbles this up with proper Error code, etc.
+            throw new Error(
+              `JSON parsing error(s): ${validate.errors
+                ?.map((err) => err.message)
+                .join(
+                  ", "
+                )}\n\nLLM extraction did not match the extraction schema you provided. This could be because of a model hallucination, or an Error on our side. Try adjusting your prompt, and if it doesn't work reach out to support.`
+            );
           }
-        default:
-          throw new Error("Invalid client");
+        }
+
+        return completionResult;
+      } catch (error) {
+        Logger.error(`Error generating completions: ${error}`);
+        throw error;
       }
     })
   );

--- a/apps/api/src/lib/LLM-extraction/models.ts
+++ b/apps/api/src/lib/LLM-extraction/models.ts
@@ -1,11 +1,11 @@
 import OpenAI from "openai";
+import Anthropic from "@anthropic-ai/sdk";
 import { Document } from "../../lib/entities";
 import { numTokensFromString } from "./helpers";
+import { Logger } from "../../lib/logger";
 
-export type ScraperCompletionResult = {
-  data: any | null;
-  url: string;
-};
+// Add client type enum
+export type LLMClientType = "openai" | "anthropic";
 
 const maxTokens = 32000;
 const modifier = 4;
@@ -15,7 +15,7 @@ const defaultPrompt =
 function prepareOpenAIDoc(
   document: Document,
   mode: "markdown" | "raw-html"
-): [OpenAI.Chat.Completions.ChatCompletionContentPart[], number] | null {
+): [{ type: "text"; text: string }[], number] | null {
   let markdown = document.markdown;
 
   let extractionTarget = document.markdown;
@@ -42,8 +42,8 @@ function prepareOpenAIDoc(
   return [[{ type: "text", text: extractionTarget }], numTokens];
 }
 
-export async function generateOpenAICompletions({
-  client,
+export async function generateLlmCompletions({
+  clientType = "openai",
   model = process.env.MODEL_NAME || "gpt-4o-mini",
   document,
   schema, //TODO - add zod dynamic type checking
@@ -52,7 +52,7 @@ export async function generateOpenAICompletions({
   temperature,
   mode,
 }: {
-  client: OpenAI;
+  clientType?: LLMClientType;
   model?: string;
   document: Document;
   schema: any; // This should be replaced with a proper Zod schema type when available
@@ -61,7 +61,6 @@ export async function generateOpenAICompletions({
   temperature?: number;
   mode: "markdown" | "raw-html";
 }): Promise<Document> {
-  const openai = client as OpenAI;
   const preparedDoc = prepareOpenAIDoc(document, mode);
 
   if (preparedDoc === null) {
@@ -73,67 +72,140 @@ export async function generateOpenAICompletions({
   }
   const [content, numTokens] = preparedDoc;
 
-  let completion;
   let llmExtraction;
-  if (prompt && !schema) {
-    const jsonCompletion = await openai.chat.completions.create({
-      model,
-      messages: [
-        {
-          role: "system",
-          content: systemPrompt,
-        },
-        { role: "user", content },
-        {
-          role: "user",
-          content: `Transform the above content into structured json output based on the following user request: ${prompt}`,
-        },
-      ],
-      response_format: { type: "json_object" },
-      temperature,
-    });
+  Logger.info(
+    `Now extracting with LLM: ${clientType} ${model} ${schema} ${systemPrompt} ${prompt} ${temperature} ${mode}`
+  );
+
+  if (clientType === "anthropic") {
+    const anthropicClient = new Anthropic({});
+    const response =
+      prompt && !schema
+        ? await anthropicClient.messages.create({
+            model: model,
+            max_tokens: 8192, //maximum for Cluade 3.5 Sonnet
+            temperature: temperature ?? 0,
+            system: systemPrompt,
+            messages: [
+              {
+                role: "user" as const,
+                content: content[0].text,
+              },
+              {
+                role: "user" as const,
+                content: `Transform the above content into structured json output based on the following user request: ${prompt}`,
+              },
+            ],
+          })
+        : await anthropicClient.messages.create({
+            model: model,
+            max_tokens: 8192, //maximum for Cluade 3.5 Sonnet
+            temperature: temperature ?? 0,
+            system: systemPrompt,
+            messages: [
+              {
+                role: "user" as const,
+                content: content[0].text,
+              },
+              {
+                role: "user" as const,
+                content: `Transform the above content into structured json output based on the following user request: ${prompt}`,
+              },
+            ],
+            tool_choice: {
+              type: "tool" as const,
+              name: "extract_content",
+            },
+            tools: [
+              {
+                name: "extract_content",
+                description: "Extracts the content from the given webpage(s)",
+                input_schema: schema,
+              },
+            ],
+          });
+
+    Logger.info(`Anthropic response: ${JSON.stringify(response)}`);
 
     try {
-      llmExtraction = JSON.parse(
-        jsonCompletion.choices[0].message.content.trim()
-      );
+      switch (response.content[0].type) {
+        case "text":
+          llmExtraction = JSON.parse(response.content[0].text);
+          Logger.info(`LLM extraction: ${JSON.stringify(llmExtraction)}`);
+          break;
+        case "tool_use":
+          llmExtraction = response.content[0].input;
+          Logger.info(`LLM extraction: ${JSON.stringify(llmExtraction)}`);
+          break;
+      }
     } catch (e) {
-      throw new Error("Invalid JSON");
+      throw new Error("Invalid JSON response from Anthropic");
     }
   } else {
-    completion = await openai.chat.completions.create({
-      model,
-      messages: [
-        {
-          role: "system",
-          content: systemPrompt,
-        },
-        { role: "user", content },
-      ],
-      tools: [
-        {
-          type: "function",
-          function: {
-            name: "extract_content",
-            description: "Extracts the content from the given webpage(s)",
-            parameters: schema,
+    const openai = new OpenAI();
+    let completion;
+    if (prompt && !schema) {
+      const jsonCompletion = await openai.chat.completions.create({
+        model,
+        messages: [
+          {
+            role: "system",
+            content: systemPrompt,
           },
-        },
-      ],
-      tool_choice: { type: "function", function: { name: "extract_content" } },
-      temperature,
-    });
-    const c = completion.choices[0].message.tool_calls[0].function.arguments;
+          { role: "user", content },
+          {
+            role: "user",
+            content: `Transform the above content into structured json output based on the following user request: ${prompt}`,
+          },
+        ],
+        response_format: { type: "json_object" },
+        temperature,
+      });
 
-    // Extract the LLM extraction content from the completion response
-    try {
-      llmExtraction = JSON.parse(c);
-    } catch (e) {
-      throw new Error("Invalid JSON");
+      try {
+        llmExtraction = JSON.parse(
+          jsonCompletion.choices[0].message.content.trim()
+        );
+      } catch (e) {
+        throw new Error("Invalid JSON");
+      }
+    } else {
+      completion = await openai.chat.completions.create({
+        model,
+        messages: [
+          {
+            role: "system",
+            content: systemPrompt,
+          },
+          { role: "user", content },
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "extract_content",
+              description: "Extracts the content from the given webpage(s)",
+              parameters: schema,
+            },
+          },
+        ],
+        tool_choice: {
+          type: "function",
+          function: { name: "extract_content" },
+        },
+        temperature,
+      });
+      const c = completion.choices[0].message.tool_calls[0].function.arguments;
+
+      // Extract the LLM extraction content from the completion response
+      try {
+        llmExtraction = JSON.parse(c);
+      } catch (e) {
+        throw new Error("Invalid JSON");
+      }
     }
   }
 
-  // Return the document with the LLM extraction content added
   return {
     ...document,
     llm_extraction: llmExtraction,

--- a/apps/api/src/lib/default-values.ts
+++ b/apps/api/src/lib/default-values.ts
@@ -24,5 +24,9 @@ export const defaultCrawlPageOptions = {
 }
 
 export const defaultExtractorOptions = {
-  mode: "markdown"
-}
+  mode: "markdown",
+  llmOptions: {
+    provider: "openai",
+    model: "gpt-4o-mini",
+  },
+};

--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -28,7 +28,7 @@ export type Action = {
 } | {
   type: "scroll",
   direction: "up" | "down"
-};
+    };
 
 export type PageOptions = {
   includeMarkdown?: boolean;
@@ -59,6 +59,15 @@ export type PageOptions = {
 
 export type ExtractorOptions = {
   mode: "markdown" | "llm-extraction" | "llm-extraction-from-markdown" | "llm-extraction-from-raw-html";
+  llmOptions?:
+    | {
+        provider?: "openai";
+        model?: "gpt-4o" | "gpt-4o-mini";
+      }
+    | {
+        provider?: "anthropic";
+        model?: "claude-3-5-sonnet-20241022";
+      }; // "provider" and "model" were made optional due to a type error on line 506 in src/controllers/v1/types.ts, but should be required I think
   extractionPrompt?: string;
   extractionSchema?: Record<string, any>;
   userPrompt?: string;
@@ -129,7 +138,7 @@ export class Document {
 
   index?: number;
   linksOnPage?: string[]; // Add this new field as a separate property
-  
+
   constructor(data: Partial<Document>) {
     if (!data.content) {
       throw new Error("Missing required fields");
@@ -153,13 +162,13 @@ export class SearchResult {
   description: string;
 
   constructor(url: string, title: string, description: string) {
-      this.url = url;
-      this.title = title;
-      this.description = description;
+    this.url = url;
+    this.title = title;
+    this.description = description;
   }
 
   toString(): string {
-      return `SearchResult(url=${this.url}, title=${this.title}, description=${this.description})`;
+    return `SearchResult(url=${this.url}, title=${this.title}, description=${this.description})`;
   }
 }
 

--- a/apps/api/src/main/runWebScraper.ts
+++ b/apps/api/src/main/runWebScraper.ts
@@ -22,6 +22,9 @@ export async function startWebScraperPipeline({
   job: Job<WebScraperOptions>;
   token: string;
 }) {
+  Logger.info(
+    `starting startWebScraperPipeline for job: ${JSON.stringify(job)}`
+  );
   let partialDocs: Document[] = [];
   return (await runWebScraper({
     url: job.data.url,
@@ -31,7 +34,7 @@ export async function startWebScraperPipeline({
     pageOptions: {
       ...job.data.pageOptions,
       ...(job.data.crawl_id ? ({
-        includeRawHtml: true,
+            includeRawHtml: true,
       }): {}),
     },
     inProgress: (progress) => {
@@ -72,8 +75,17 @@ export async function runWebScraper({
   team_id,
   bull_job_id,
   priority,
-  is_scrape=false,
+  is_scrape = false,
 }: RunWebScraperParams): Promise<RunWebScraperResult> {
+  Logger.info(
+    `Running web scraper with params: ${JSON.stringify({
+      url,
+      mode,
+      crawlerOptions,
+      pageOptions,
+      extractorOptions,
+    })}`
+  );
   try {
     const provider = new WebScraperDataProvider();
     if (mode === "crawl") {
@@ -159,12 +171,12 @@ const saveJob = async (job: Job, result: any, token: string, mode: string) => {
       // } catch (error) {
       //   // I think the job won't exist here anymore
       // }
-    // } else {
-    //   try {
-    //     await job.moveToCompleted(result, token, false);
-    //   } catch (error) {
-    //     // I think the job won't exist here anymore
-    //   }
+      // } else {
+      //   try {
+      //     await job.moveToCompleted(result, token, false);
+      //   } catch (error) {
+      //     // I think the job won't exist here anymore
+      //   }
     }
     ScrapeEvents.logJobEvent(job, "completed");
   } catch (error) {

--- a/apps/api/src/scraper/WebScraper/index.ts
+++ b/apps/api/src/scraper/WebScraper/index.ts
@@ -59,6 +59,9 @@ export class WebScraperDataProvider {
     inProgress?: (progress: Progress) => void,
     allHtmls?: string[]
   ): Promise<Document[]> {
+    Logger.info(
+      `Converting ${urls.length}, url: ${JSON.stringify(urls)}URLs to documents`
+    );
     const totalUrls = urls.length;
     let processedUrls = 0;
 
@@ -75,8 +78,9 @@ export class WebScraperDataProvider {
             this.extractorOptions,
             existingHTML,
             this.priority,
-            this.teamId,
+            this.teamId
           );
+          Logger.info(`Scraped ${url} with result: ${JSON.stringify(result)}`);
           processedUrls++;
           if (inProgress) {
             inProgress({
@@ -303,7 +307,7 @@ export class WebScraperDataProvider {
         delete document.html;
       }
     }
-    
+
     // documents = await this.applyImgAltText(documents);
     if (this.mode === "single_urls" && this.pageOptions.includeExtract) {
       const extractionMode = this.extractorOptions?.mode ?? "markdown";
@@ -596,7 +600,10 @@ export class WebScraperDataProvider {
       geolocation: options.pageOptions?.geolocation ?? undefined,
       skipTlsVerification: options.pageOptions?.skipTlsVerification ?? false,
     };
-    this.extractorOptions = options.extractorOptions ?? { mode: "markdown" };
+    this.extractorOptions = options.extractorOptions ?? {
+      mode: "markdown",
+      llmOptions: { provider: "openai", model: "gpt-4o-mini" },
+    };
     this.replaceAllPathsWithAbsolutePaths =
       options.crawlerOptions?.replaceAllPathsWithAbsolutePaths ??
       options.pageOptions?.replaceAllPathsWithAbsolutePaths ??


### PR DESCRIPTION
I've added an `llmOptions` param in extract options for the `v1/scrape` endpoint.
This accepts an object with a 'model' and a 'provider' property.
For example,
```json
    "extract": {
          "llmOptions": {"provider": "anthropic", "model": "claude-3-5-sonnet-20241022"},
       }
```


Demo video: https://youtu.be/BqsS9UTMD3s

I've retained logs for now. Let me know if you'd like to make changes for merging.