### PR TITLE
Added support for webhook authentication

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -64,6 +64,7 @@ BLOCK_MEDIA=
 
 # Set this to the URL of your webhook when using the self-hosted version of FireCrawl
 SELF_HOSTED_WEBHOOK_URL=
+SELF_HOSTED_WEBHOOK_SECRET=
 
 # Resend API Key for transactional emails
 RESEND_API_KEY=

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -117,6 +117,7 @@ export async function crawlController(
           crawl_id: id,
           sitemapped: true,
           webhook: req.body.webhook,
+          secretKey: req.body.secretKey,
           v1: true,
         },
         opts: {
@@ -148,6 +149,7 @@ export async function crawlController(
         origin: "api",
         crawl_id: id,
         webhook: req.body.webhook,
+        secretKey: req.body.secretKey,
         v1: true,
       },
       {
@@ -158,7 +160,7 @@ export async function crawlController(
   }
 
   if(req.body.webhook) {
-    await callWebhook(req.auth.team_id, id, null, req.body.webhook, true, "crawl.started");
+    await callWebhook(req.auth.team_id, id, null, req.body.webhook, req.body.secretKey, true, "crawl.started");
   }
 
   const protocol = process.env.ENV === "local" ? req.protocol : "https";

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -195,7 +195,8 @@ export const crawlRequestSchema = crawlerOptions.extend({
   secretKey: z
     .string()
     .min(32, "The secret key must be at least 32 characters long.")
-    .max(64, "The secret key must not exceed 64 characters."),
+    .max(64, "The secret key must not exceed 64 characters.")
+    .optional(),
   limit: z.number().default(10000),
 }).strict(strictMessage);
 

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -192,6 +192,10 @@ export const crawlRequestSchema = crawlerOptions.extend({
   origin: z.string().optional().default("api"),
   scrapeOptions: scrapeOptions.omit({ timeout: true }).default({}),
   webhook: z.string().url().optional(),
+  secretKey: z
+    .string()
+    .min(32, "The secret key must be at least 32 characters long.")
+    .max(64, "The secret key must not exceed 64 characters."),
   limit: z.number().default(10000),
 }).strict(strictMessage);
 

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -328,6 +328,7 @@ async function processJob(job: Job, token: string) {
         job.data.team_id,
         job.id as string,
         data,
+        job.data.secretKey,
         job.data.webhook,
         job.data.v1,
         job.data.crawlerOptions !== null ? "crawl.page" : "batch_scrape.page",
@@ -339,6 +340,7 @@ async function processJob(job: Job, token: string) {
         job.data.crawl_id,
         data,
         job.data.webhook,
+        job.data.secretKey,
         job.data.v1,
         job.data.crawlerOptions !== null ? "crawl.page" : "batch_scrape.page",
         true
@@ -466,6 +468,7 @@ async function processJob(job: Job, token: string) {
               job.data.team_id,
               job.data.crawl_id,
               data,
+              job.data.secretKey,
               job.data.webhook,
               job.data.v1,
               job.data.crawlerOptions !== null ? "crawl.completed" : "batch_scrape.completed"
@@ -484,6 +487,7 @@ async function processJob(job: Job, token: string) {
               job.data.team_id,
               job.data.crawl_id,
               [],
+              job.data.secretKey,
               job.data.webhook,
               job.data.v1,
               job.data.crawlerOptions !== null ? "crawl.completed" : "batch_scrape.completed"
@@ -554,6 +558,7 @@ async function processJob(job: Job, token: string) {
         job.data.team_id,
         job.data.crawl_id ?? (job.id as string),
         data,
+        job.data.secretKey,
         job.data.webhook,
         job.data.v1,
         job.data.crawlerOptions !== null ? "crawl.page" : "batch_scrape.page",

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -33,6 +33,7 @@ export interface WebScraperOptions {
   crawl_id?: string;
   sitemapped?: boolean;
   webhook?: string;
+  secretKey?: string,
   v1?: boolean;
   is_scrape?: boolean;
 }


### PR DESCRIPTION
Adds HMAC-SHA256 verification on webhooks
If provided with a "secretKey" in the request body, the webhook response will now contain a header,
 `"Webhook-Signature": "sha256=<hash>"`
The \<hash\> being a SHA256 hash with the secretKey on the raw request body string.

Example of verifying the request body with express.js

```
app.post("/webhook", function (req, res) {
    console.log(req.headers["webhook-signature"]);
    let rawBody = "";
    req.on("data", (chunk) => {
        rawBody += chunk;
    });

    req.on("end", () => {
        console.log(rawBody);
        console.log(checkSignature(req.headers["webhook-signature"], rawBody));
        res.status(200).send("Raw body received and logged.");
    });
});

const secret = "1f29rv8owfa0w9wr4tswpg0f9897162dbfkjvdlz";
function checkSignature(signatureFromHeader, rawPayload) {
    const hmac = crypto.createHmac("sha256", secret);
    hmac.update(rawPayload);
    const digest = hmac.digest("hex");
    return "sha256=" + digest === signatureFromHeader;
}
```

Make sure to use the body string before it is parsed to JSON (JSON.parse() or equivalent).

