### PR TITLE
chore(README.md): use `satisfies` instead of `as` for ts example

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ const crawlResponse = await app.crawlUrl('https://firecrawl.dev', {
   scrapeOptions: {
     formats: ['markdown', 'html'],
   }
-} as CrawlParams, true, 30) as CrawlStatusResponse;
+} satisfies CrawlParams, true, 30) satisfies CrawlStatusResponse;
 
 if (crawlResponse) {
   console.log(crawlResponse)


### PR DESCRIPTION
When we use `as`, typescript does not validate the types properly in scenarios like the typescript example. The `satisfies` operator is stricter and **does** validate the types, preventing misuse like such:

Using blank object
```ts
interface CrawlParams {
  required: boolean
}

// This is valid
const config = {} as CrawlParams

// this is invalid because 'required' field is missing
const config = {} satisfies CrawlParams
// ^ Type '{}' does not satisfy the expected type 'CrawlParams'. Property 'required' is missing in type '{}' but required in type 'CrawlParams'.
```