### PR TITLE
fix(api): use builtin async timeout

### DIFF
--- a/apps/api/src/__tests__/e2e_full_withAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_full_withAuth/index.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import dotenv from "dotenv";
 import { v4 as uuidv4 } from "uuid";
+import { setTimeout } from 'timers/promises'
 
 dotenv.config();
 
@@ -160,7 +161,7 @@ describe("E2E Tests for API Routes", () => {
         .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
         .set('Content-Type', 'application/json')
         .send({ url: 'https://arxiv.org/pdf/astro-ph/9301001.pdf' });
-      await new Promise((r) => setTimeout(r, 6000));
+      await setTimeout(6000);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty('data');
@@ -177,7 +178,7 @@ describe("E2E Tests for API Routes", () => {
         .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
         .set('Content-Type', 'application/json')
         .send({ url: 'https://arxiv.org/pdf/astro-ph/9301001' });
-      await new Promise((r) => setTimeout(r, 6000));
+      await setTimeout(6000);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty('data');
@@ -194,7 +195,7 @@ describe("E2E Tests for API Routes", () => {
         .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
         .set('Content-Type', 'application/json')
         .send({ url: 'https://arxiv.org/pdf/astro-ph/9301001.pdf', pageOptions: { parsePDF: false } });
-      await new Promise((r) => setTimeout(r, 6000));
+      await setTimeout(6000);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty('data');
@@ -264,7 +265,7 @@ describe("E2E Tests for API Routes", () => {
         .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
         .set('Content-Type', 'application/json')
         .send({ url: 'https://httpstat.us/400' });
-      await new Promise((r) => setTimeout(r, 5000));
+      await setTimeout(5000);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty('data');
@@ -280,7 +281,7 @@ describe("E2E Tests for API Routes", () => {
         .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
         .set('Content-Type', 'application/json')
         .send({ url: 'https://httpstat.us/401' });
-      await new Promise((r) => setTimeout(r, 5000));
+      await setTimeout(5000);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty('data');
@@ -297,7 +298,7 @@ describe("E2E Tests for API Routes", () => {
         .set('Content-Type', 'application/json')
         .send({ url: 'https://httpstat.us/403' });
 
-      await new Promise((r) => setTimeout(r, 5000));
+      await setTimeout(5000);
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty('data');
       expect(response.body.data).toHaveProperty('content');
@@ -312,7 +313,7 @@ describe("E2E Tests for API Routes", () => {
         .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
         .set('Content-Type', 'application/json')
         .send({ url: 'https://httpstat.us/404' });
-      await new Promise((r) => setTimeout(r, 5000));
+      await setTimeout(5000);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty('data');
@@ -328,7 +329,7 @@ describe("E2E Tests for API Routes", () => {
         .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
         .set('Content-Type', 'application/json')
         .send({ url: 'https://httpstat.us/405' });
-      await new Promise((r) => setTimeout(r, 5000));
+      await setTimeout(5000);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty('data');
@@ -344,7 +345,7 @@ describe("E2E Tests for API Routes", () => {
         .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
         .set('Content-Type', 'application/json')
         .send({ url: 'https://httpstat.us/500' });
-      await new Promise((r) => setTimeout(r, 5000));
+      await setTimeout(5000);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty('data');
@@ -446,7 +447,7 @@ describe("E2E Tests for API Routes", () => {
           isFinished = response.body.status === "completed";
 
           if (!isFinished) {
-            await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+            await setTimeout(1000); // Wait for 1 second before checking again
           }
         }
 
@@ -498,7 +499,7 @@ describe("E2E Tests for API Routes", () => {
         isFinished = response.body.status === "completed";
 
         if (!isFinished) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
 
@@ -536,7 +537,7 @@ describe("E2E Tests for API Routes", () => {
         isFinished = response.body.status === "completed";
 
         if (!isFinished) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
 
@@ -581,7 +582,7 @@ describe("E2E Tests for API Routes", () => {
         expect(statusCheckResponse.statusCode).toBe(200);
         isCompleted = statusCheckResponse.body.status === "completed";
         if (!isCompleted) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
       const completedResponse = await request(TEST_URL)
@@ -636,7 +637,7 @@ describe("E2E Tests for API Routes", () => {
         expect(statusCheckResponse.statusCode).toBe(200);
         isCompleted = statusCheckResponse.body.status === "completed";
         if (!isCompleted) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
       const completedResponse = await request(TEST_URL)
@@ -690,7 +691,7 @@ describe("E2E Tests for API Routes", () => {
         expect(statusCheckResponse.statusCode).toBe(200);
         isCompleted = statusCheckResponse.body.status === "completed";
         if (!isCompleted) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
       const completedResponse = await request(TEST_URL)
@@ -751,7 +752,7 @@ describe("E2E Tests for API Routes", () => {
     //     expect(statusCheckResponse.statusCode).toBe(200);
     //     isCompleted = statusCheckResponse.body.status === "completed";
     //     if (!isCompleted) {
-    //       await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+    //       await setTimeout(1000); // Wait for 1 second before checking again
     //     }
     //   }
 
@@ -797,7 +798,7 @@ describe("E2E Tests for API Routes", () => {
         expect(statusCheckResponse.statusCode).toBe(200);
         isCompleted = statusCheckResponse.body.status === "completed";
         if (!isCompleted) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
 
@@ -855,7 +856,7 @@ describe("E2E Tests for API Routes", () => {
           crawlData = statusResponse.body.data;
         }
         if (crawlStatus !== "completed") {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
       expect(crawlData.length).toBeGreaterThan(0);
@@ -988,7 +989,7 @@ describe("E2E Tests for API Routes", () => {
           isCompleted = true;
           completedResponse = response;
         } else {
-          await new Promise((r) => setTimeout(r, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
       expect(completedResponse.body).toHaveProperty("status");
@@ -1030,7 +1031,7 @@ describe("E2E Tests for API Routes", () => {
           isCompleted = true;
           completedResponse = response;
         } else {
-          await new Promise((r) => setTimeout(r, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
         expect(completedResponse.body.status).toBe('completed');
@@ -1083,7 +1084,7 @@ describe("E2E Tests for API Routes", () => {
           isFinished = true;
           completedResponse = response;
         } else {
-          await new Promise((r) => setTimeout(r, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
 
@@ -1129,7 +1130,7 @@ describe("E2E Tests for API Routes", () => {
         isFinished = true;
         completedResponse = response;
       } else {
-        await new Promise((r) => setTimeout(r, 1000)); // Wait for 1 second before checking again
+        await setTimeout(1000); // Wait for 1 second before checking again
       }
     }
 
@@ -1162,7 +1163,7 @@ describe("E2E Tests for API Routes", () => {
 
     expect(crawlResponse.statusCode).toBe(200);
 
-    await new Promise((r) => setTimeout(r, 20000));
+    await setTimeout(20000);
 
     const responseCancel = await request(TEST_URL)
       .delete(`/v0/crawl/cancel/${crawlResponse.body.jobId}`)
@@ -1171,7 +1172,7 @@ describe("E2E Tests for API Routes", () => {
     expect(responseCancel.body).toHaveProperty("status");
     expect(responseCancel.body.status).toBe("cancelled");
 
-    await new Promise((r) => setTimeout(r, 10000));
+    await setTimeout(10000);
     const completedResponse = await request(TEST_URL)
       .get(`/v0/crawl/status/${crawlResponse.body.jobId}`)
       .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`);
@@ -1369,7 +1370,7 @@ describe("E2E Tests for API Routes", () => {
         isFinished = statusResponse.body.status === "completed";
 
         if (!isFinished) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
 
@@ -1421,7 +1422,7 @@ describe("E2E Tests for API Routes", () => {
     //     isFinished = statusResponse.body.status === "completed";
 
     //     if (!isFinished) {
-    //       await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+    //       await setTimeout(1000); // Wait for 1 second before checking again
     //     }
     //   }
 

--- a/apps/api/src/__tests__/e2e_noAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_noAuth/index.test.ts
@@ -1,5 +1,7 @@
 import request from "supertest";
 import dotenv from "dotenv";
+import { setTimeout } from 'timers/promises'
+
 const fs = require("fs");
 const path = require("path");
 
@@ -188,7 +190,7 @@ describe("E2E Tests for API Routes with No Authentication", () => {
       expect(response.body.status).toBe("active");
 
       // wait for 30 seconds
-      await new Promise((r) => setTimeout(r, 30000));
+      await setTimeout(30000);
 
       const completedResponse = await request(TEST_URL).get(
         `/v0/crawl/status/${crawlResponse.body.jobId}`

--- a/apps/api/src/__tests__/e2e_v1_withAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_v1_withAuth/index.test.ts
@@ -1,5 +1,6 @@
 import request from "supertest";
 import { configDotenv } from "dotenv";
+import { setTimeout } from 'timers/promises';
 import {
   ScrapeRequest,
   ScrapeResponseRequestTest,
@@ -203,7 +204,7 @@ describe("E2E Tests for v1 API Routes", () => {
           .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
           .set('Content-Type', 'application/json')
           .send(scrapeRequest);
-        await new Promise((r) => setTimeout(r, 6000));
+        await setTimeout(6000);
   
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty('data');
@@ -225,7 +226,7 @@ describe("E2E Tests for v1 API Routes", () => {
           .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
           .set('Content-Type', 'application/json')
           .send(scrapeRequest);
-        await new Promise((r) => setTimeout(r, 6000));
+        await setTimeout(6000);
   
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty('data');
@@ -290,7 +291,7 @@ describe("E2E Tests for v1 API Routes", () => {
           .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
           .set('Content-Type', 'application/json')
           .send({ url: 'https://httpstat.us/400' });
-        await new Promise((r) => setTimeout(r, 5000));
+        await setTimeout(5000);
   
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty('data');
@@ -309,7 +310,7 @@ describe("E2E Tests for v1 API Routes", () => {
           .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
           .set('Content-Type', 'application/json')
           .send({ url: 'https://httpstat.us/401' });
-        await new Promise((r) => setTimeout(r, 5000));
+        await setTimeout(5000);
   
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty('data');
@@ -328,7 +329,7 @@ describe("E2E Tests for v1 API Routes", () => {
       //     .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
       //     .set('Content-Type', 'application/json')
       //     .send({ url: 'https://httpstat.us/403' });
-      //   await new Promise((r) => setTimeout(r, 5000));
+      //   await setTimeout(5000);
   
       //   expect(response.statusCode).toBe(200);
       //   expect(response.body).toHaveProperty('data');
@@ -346,7 +347,7 @@ describe("E2E Tests for v1 API Routes", () => {
           .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
           .set('Content-Type', 'application/json')
           .send({ url: 'https://httpstat.us/404' });
-        await new Promise((r) => setTimeout(r, 5000));
+        await setTimeout(5000);
   
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty('data');
@@ -364,7 +365,7 @@ describe("E2E Tests for v1 API Routes", () => {
       //     .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
       //     .set('Content-Type', 'application/json')
       //     .send({ url: 'https://httpstat.us/405' });
-      //   await new Promise((r) => setTimeout(r, 5000));
+      //   await setTimeout(5000);
   
       //   expect(response.statusCode).toBe(200);
       //   expect(response.body).toHaveProperty('data');
@@ -382,7 +383,7 @@ describe("E2E Tests for v1 API Routes", () => {
       //     .set('Authorization', `Bearer ${process.env.TEST_API_KEY}`)
       //     .set('Content-Type', 'application/json')
       //     .send({ url: 'https://httpstat.us/500' });
-      //   await new Promise((r) => setTimeout(r, 5000));
+      //   await setTimeout(5000);
   
       //   expect(response.statusCode).toBe(200);
       //   expect(response.body).toHaveProperty('data');
@@ -741,11 +742,11 @@ describe("POST /v1/crawl", () => {
         isFinished = response.body.status === "completed";
 
         if (!isFinished) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for data to be saved on the database
+      await setTimeout(1000); // wait for data to be saved on the database
       const completedResponse = await request(TEST_URL)
         .get(`/v1/crawl/${crawlResponse.body.id}`)
         .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`);
@@ -797,11 +798,11 @@ describe("POST /v1/crawl", () => {
         isFinished = response.body.status === "completed";
 
         if (!isFinished) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for data to be saved on the database
+      await setTimeout(1000); // wait for data to be saved on the database
       const completedResponse = await request(
         TEST_URL
       )
@@ -847,7 +848,7 @@ describe("POST /v1/crawl", () => {
         expect(statusCheckResponse.statusCode).toBe(200);
         isCompleted = statusCheckResponse.body.status === "completed";
         if (!isCompleted) {
-          await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000); // Wait for 1 second before checking again
         }
       }
       const completedResponse = await request(
@@ -934,11 +935,11 @@ describe("GET /v1/crawl/:jobId", () => {
         if (response.body.status === "completed") {
           isCompleted = true;
         } else {
-          await new Promise((r) => setTimeout(r, 1000)); // Wait for 1 second before checking again
+          await setTimeout(1000)); // Wait for 1 second before checking agan
         }
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for data to be saved on the database
+      await setTimeout(1000); // wait for data to be saved on the database
       const completedResponse = await request(TEST_URL)
         .get(`/v1/crawl/${crawlResponse.body.id}`)
         .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`);
@@ -976,7 +977,7 @@ describe("GET /v1/crawl/:jobId", () => {
 
       expect(crawlResponse.statusCode).toBe(200);
 
-      await new Promise((r) => setTimeout(r, 10000));
+      await setTimeout(10000);
 
       const responseCancel = await request(TEST_URL)
         .delete(`/v1/crawl/${crawlResponse.body.id}`)
@@ -985,7 +986,7 @@ describe("GET /v1/crawl/:jobId", () => {
       expect(responseCancel.body).toHaveProperty("status");
       expect(responseCancel.body.status).toBe("cancelled");
 
-      await new Promise((r) => setTimeout(r, 10000));
+      await setTimeout(10000);
       const completedResponse = await request(TEST_URL)
         .get(`/v1/crawl/${crawlResponse.body.id}`)
         .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`);

--- a/apps/api/src/__tests__/e2e_v1_withAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_v1_withAuth/index.test.ts
@@ -935,7 +935,8 @@ describe("GET /v1/crawl/:jobId", () => {
         if (response.body.status === "completed") {
           isCompleted = true;
         } else {
-          await setTimeout(1000)); // Wait for 1 second before checking agan
+          await setTimeout(1000)); // Wait for 1 second before checking again
+          
         }
       }
 

--- a/apps/api/src/__tests__/e2e_withAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_withAuth/index.test.ts
@@ -675,7 +675,7 @@ describe("E2E Tests for v0 API Routes", () => {
           if (response.body.status === "completed") {
             isCompleted = true;
           } else {
-            await setTimeout(1000)); // Wait for 1 second before checking agan
+            await setTimeout(1000)); // Wait for 1 second before checking again
           }
         }
 
@@ -735,7 +735,7 @@ describe("E2E Tests for v0 API Routes", () => {
     //       isCompleted = true;
     //       completedResponse = response;
     //     } else {
-    //       await setTimeout(1000)); // Wait for 1 second before checking agan
+    //       await setTimeout(1000)); // Wait for 1 second before checking again
     //     }
     //   }
     //     expect(completedResponse.body.status).toBe('completed');

--- a/apps/api/src/__tests__/e2e_withAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_withAuth/index.test.ts
@@ -1,5 +1,6 @@
 import request from "supertest";
 import dotenv from "dotenv";
+import { setTimeout } from 'timers/promises'
 import {
   FirecrawlCrawlResponse,
   FirecrawlCrawlStatusResponse,
@@ -124,7 +125,7 @@ describe("E2E Tests for v0 API Routes", () => {
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`)
           .set("Content-Type", "application/json")
           .send({ url: "https://arxiv.org/pdf/astro-ph/9301001.pdf" });
-        await new Promise((r) => setTimeout(r, 6000));
+        await setTimeout(6000);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty("data");
@@ -147,7 +148,7 @@ describe("E2E Tests for v0 API Routes", () => {
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`)
           .set("Content-Type", "application/json")
           .send({ url: "https://arxiv.org/pdf/astro-ph/9301001" });
-        await new Promise((r) => setTimeout(r, 6000));
+        await setTimeout(6000);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty("data");
@@ -220,7 +221,7 @@ describe("E2E Tests for v0 API Routes", () => {
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`)
           .set("Content-Type", "application/json")
           .send({ url: "https://httpstat.us/400" });
-        await new Promise((r) => setTimeout(r, 5000));
+        await setTimeout(5000);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty("data");
@@ -242,7 +243,7 @@ describe("E2E Tests for v0 API Routes", () => {
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`)
           .set("Content-Type", "application/json")
           .send({ url: "https://httpstat.us/401" });
-        await new Promise((r) => setTimeout(r, 5000));
+        await setTimeout(5000);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty("data");
@@ -265,7 +266,7 @@ describe("E2E Tests for v0 API Routes", () => {
           .set("Content-Type", "application/json")
           .send({ url: "https://httpstat.us/403" });
 
-        await new Promise((r) => setTimeout(r, 5000));
+        await setTimeout(5000);
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty("data");
         expect(response.body.data).toHaveProperty("content");
@@ -286,7 +287,7 @@ describe("E2E Tests for v0 API Routes", () => {
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`)
           .set("Content-Type", "application/json")
           .send({ url: "https://httpstat.us/404" });
-        await new Promise((r) => setTimeout(r, 5000));
+        await setTimeout(5000);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty("data");
@@ -305,7 +306,7 @@ describe("E2E Tests for v0 API Routes", () => {
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`)
           .set("Content-Type", "application/json")
           .send({ url: "https://httpstat.us/405" });
-        await new Promise((r) => setTimeout(r, 5000));
+        await setTimeout(5000);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty("data");
@@ -324,7 +325,7 @@ describe("E2E Tests for v0 API Routes", () => {
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`)
           .set("Content-Type", "application/json")
           .send({ url: "https://httpstat.us/500" });
-        await new Promise((r) => setTimeout(r, 5000));
+        await setTimeout(5000);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toHaveProperty("data");
@@ -400,11 +401,11 @@ describe("E2E Tests for v0 API Routes", () => {
           isFinished = response.body.status === "completed";
 
           if (!isFinished) {
-            await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+            await setTimeout(1000); // Wait for 1 second before checking again
           }
         }
 
-        await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for data to be saved on the database
+        await setTimeout(1000); // wait for data to be saved on the database
         const completedResponse = await request(TEST_URL)
           .get(`/v0/crawl/status/${crawlResponse.body.jobId}`)
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`);
@@ -463,11 +464,11 @@ describe("E2E Tests for v0 API Routes", () => {
           isFinished = response.body.status === "completed";
 
           if (!isFinished) {
-            await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+            await setTimeout(1000); // Wait for 1 second before checking again
           }
         }
 
-        await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for data to be saved on the database
+        await setTimeout(1000); // wait for data to be saved on the database
         const completedResponse: FirecrawlCrawlStatusResponse = await request(
           TEST_URL
         )
@@ -513,7 +514,7 @@ describe("E2E Tests for v0 API Routes", () => {
           expect(statusCheckResponse.statusCode).toBe(200);
           isCompleted = statusCheckResponse.body.status === "completed";
           if (!isCompleted) {
-            await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+            await setTimeout(1000); // Wait for 1 second before checking again
           }
         }
         const completedResponse: FirecrawlCrawlStatusResponse = await request(
@@ -674,11 +675,11 @@ describe("E2E Tests for v0 API Routes", () => {
           if (response.body.status === "completed") {
             isCompleted = true;
           } else {
-            await new Promise((r) => setTimeout(r, 1000)); // Wait for 1 second before checking again
+            await setTimeout(1000)); // Wait for 1 second before checking agan
           }
         }
 
-        await new Promise((resolve) => setTimeout(resolve, 1000)); // wait for data to be saved on the database
+        await setTimeout(1000); // wait for data to be saved on the database
         const completedResponse = await request(TEST_URL)
           .get(`/v0/crawl/status/${crawlResponse.body.jobId}`)
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`);
@@ -734,7 +735,7 @@ describe("E2E Tests for v0 API Routes", () => {
     //       isCompleted = true;
     //       completedResponse = response;
     //     } else {
-    //       await new Promise((r) => setTimeout(r, 1000)); // Wait for 1 second before checking again
+    //       await setTimeout(1000)); // Wait for 1 second before checking agan
     //     }
     //   }
     //     expect(completedResponse.body.status).toBe('completed');
@@ -764,7 +765,7 @@ describe("E2E Tests for v0 API Routes", () => {
 
         expect(crawlResponse.statusCode).toBe(200);
 
-        await new Promise((r) => setTimeout(r, 10000));
+        await setTimeout(10000);
 
         const responseCancel = await request(TEST_URL)
           .delete(`/v0/crawl/cancel/${crawlResponse.body.jobId}`)
@@ -773,7 +774,7 @@ describe("E2E Tests for v0 API Routes", () => {
         expect(responseCancel.body).toHaveProperty("status");
         expect(responseCancel.body.status).toBe("cancelled");
 
-        await new Promise((r) => setTimeout(r, 10000));
+        await setTimeout(10000);
         const completedResponse = await request(TEST_URL)
           .get(`/v0/crawl/status/${crawlResponse.body.jobId}`)
           .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`);

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -16,6 +16,7 @@ import { redlock } from "../services/redlock";
 import { deleteKey, getValue } from "../services/redis";
 import { setValue } from "../services/redis";
 import { validate } from "uuid";
+import { setTimeout } from "timers/promises";
 import * as Sentry from "@sentry/node";
 import { AuthCreditUsageChunk } from "./v1/types";
 // const { data, error } = await supabase_service
@@ -115,7 +116,7 @@ export async function getACUC(
       }
 
       // Wait for a short time before retrying
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      await setTimeout(200);
     }
 
     const chunk: AuthCreditUsageChunk | null =

--- a/apps/api/src/controllers/v0/admin/redis-health.ts
+++ b/apps/api/src/controllers/v0/admin/redis-health.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import Redis from "ioredis";
+import { setTimeout } from "timers/promises";
 import { Logger } from "../../../lib/logger";
 import { redisRateLimitClient } from "../../../services/rate-limiter";
 
@@ -11,7 +12,7 @@ export async function redisHealthController(req: Request, res: Response) {
       } catch (error) {
         if (attempt === retries) throw error;
         Logger.warn(`Attempt ${attempt} failed: ${error.message}. Retrying...`);
-        await new Promise((resolve) => setTimeout(resolve, 2000)); // Wait 2 seconds before retrying
+        await setTimeout(2000); // Wait 2 seconds before retrying
       }
     }
   };

--- a/apps/api/src/run-req.ts
+++ b/apps/api/src/run-req.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { promises as fs } from "fs";
 import { v4 as uuidV4 } from "uuid";
+import { setTimeout } from 'timers/promises'
 
 interface Result {
   start_url: string;
@@ -64,7 +65,7 @@ async function getContent(result: Result): Promise<boolean> {
       console.error("Error getting content:", error);
     }
     const randomSleep = Math.floor(Math.random() * 15000) + 5000;
-    await new Promise((resolve) => setTimeout(resolve, randomSleep)); // Reduce sleep time to 1.5 seconds
+    await setTimeout(randomSleep); // Reduce sleep time to 1.5 seconds
     attempts++;
   }
   // Set result as null if timed out
@@ -143,7 +144,7 @@ async function processResults(results: Result[]): Promise<void> {
       .catch((error) => {
         console.error(`Error processing batch starting at index ${i}:`, error);
       });
-    await new Promise((resolve) => setTimeout(resolve, 60 * 1000)); // Wait for 1 minute
+    await setTimeout(60 * 1000); // Wait for 1 minute
   }
 }
 

--- a/apps/api/src/scraper/WebScraper/scrapers/fireEngine.ts
+++ b/apps/api/src/scraper/WebScraper/scrapers/fireEngine.ts
@@ -7,6 +7,7 @@ import { universalTimeout } from "../global";
 import { Logger } from "../../../lib/logger";
 import * as Sentry from "@sentry/node";
 import axiosRetry from 'axios-retry';
+import { setTimeout } from "timers/promises";
 
 axiosRetry(axios, { retries: 3 , onRetry:()=>{
   console.log("Retrying (fire-engine)...");
@@ -140,7 +141,7 @@ export async function scrapWithFireEngine({
 
     // added 5 seconds to the timeout to account for 'smart wait'
     while (checkStatusResponse.data.processing && Date.now() - startTime < universalTimeout + waitTotal + 5000) {
-      await new Promise(resolve => setTimeout(resolve, 250)); // wait 0.25 seconds
+      await setTimeout(250); // wait 0.25 seconds
       checkStatusResponse = await axiosInstance.get(`${process.env.FIRE_ENGINE_BETA_URL}/scrape/${_response.data.jobId}`);
     }
 

--- a/apps/api/src/scraper/WebScraper/utils/pdfProcessor.ts
+++ b/apps/api/src/scraper/WebScraper/utils/pdfProcessor.ts
@@ -6,6 +6,7 @@ import dotenv from "dotenv";
 import pdf from "pdf-parse";
 import path from "path";
 import os from "os";
+import { setTimeout } from "timers/promises";
 import { axiosTimeout } from "../../../lib/timeout";
 import { Logger } from "../../../lib/logger";
 
@@ -84,7 +85,7 @@ export async function processPdfToText(filePath: string, parsePDF: boolean): Pro
           } else {
             // If the status code is not 200, increment the attempt counter and wait
             attempt++;
-            await new Promise((resolve) => setTimeout(resolve, 500)); // Wait for 0.5 seconds
+            await setTimeout(500); // Wait for 0.5 seconds
           }
         } catch (error) {
           Logger.debug("Error fetching result w/ LlamaIndex");
@@ -93,7 +94,7 @@ export async function processPdfToText(filePath: string, parsePDF: boolean): Pro
             Logger.error("Max attempts reached, unable to fetch result.");
             break; // Exit the loop if max attempts are reached
           }
-          await new Promise((resolve) => setTimeout(resolve, 500)); // Wait for 0.5 seconds before retrying
+          await setTimeout(500); // Wait for 0.5 seconds before retrying
           // You may want to handle specific errors differently
         }
       }

--- a/apps/api/src/search/googlesearch.ts
+++ b/apps/api/src/search/googlesearch.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 import * as querystring from 'querystring';
+import { setTimeout } from 'timers/promises';
 import { SearchResult } from '../../src/lib/entities';
 import { Logger } from '../../src/lib/logger';
 
@@ -94,7 +95,7 @@ export async function googleSearch(term: string, advanced = false, num_results =
                     }
                 }
             });
-            await new Promise(resolve => setTimeout(resolve, sleep_interval * 1000));
+            await setTimeout(sleep_interval * 1000);
         } catch (error) {
             if (error.message === 'Too many requests') {
                 Logger.warn('Too many requests, breaking the loop');

--- a/apps/api/src/services/rate-limiter.test.ts
+++ b/apps/api/src/services/rate-limiter.test.ts
@@ -4,6 +4,7 @@ import {
   testSuiteRateLimiter,
   redisRateLimitClient,
 } from "./rate-limiter";
+import { setTimeout } from "timers/promises";
 import { RateLimiterMode } from "../../src/types";
 import { RateLimiterRedis } from "rate-limiter-flexible";
 
@@ -362,7 +363,7 @@ describe("Rate Limiter Service", () => {
 
     const consumePoints = 5;
     await limiter.consume("test-prefix:someToken", consumePoints);
-    await new Promise((resolve) => setTimeout(resolve, duration * 1000 + 100)); // Wait for duration + 100ms
+    await setTimeout(duration * 1000 + 100); // Wait for duration + 100ms
 
     const res = await limiter.consume("test-prefix:someToken", consumePoints);
     expect(res.remainingPoints).toBe(points - consumePoints);

--- a/apps/js-sdk/example.js
+++ b/apps/js-sdk/example.js
@@ -1,4 +1,5 @@
 import FirecrawlApp from 'firecrawl';
+import { setTimeout } from 'timers/promises';
 
 const app = new FirecrawlApp({apiKey: "fc-YOUR_API_KEY"});
 
@@ -29,7 +30,7 @@ const main = async () => {
         if (checkStatus.success && checkStatus.status === 'completed') {
           break;
         }
-        await new Promise(resolve => setTimeout(resolve, 1000)); // wait 1 second
+        await setTimeout(1000); // wait 1 second
       }
 
       if (checkStatus.success && checkStatus.data) {

--- a/apps/js-sdk/example.ts
+++ b/apps/js-sdk/example.ts
@@ -1,4 +1,5 @@
 import FirecrawlApp, { CrawlStatusResponse, ErrorResponse } from 'firecrawl';
+import { setTimeout } from 'timers/promises';
 
 const app = new FirecrawlApp({apiKey: "fc-YOUR_API_KEY"});
 
@@ -29,7 +30,7 @@ const main = async () => {
         if (checkStatus.success && checkStatus.status === 'completed') {
           break;
         }
-        await new Promise(resolve => setTimeout(resolve, 1000)); // wait 1 second
+        await setTimeout(1000); // wait 1 second
       }
 
       if (checkStatus.success && checkStatus.data) {

--- a/apps/js-sdk/firecrawl/src/__tests__/e2e_withAuth/index.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/e2e_withAuth/index.test.ts
@@ -6,6 +6,7 @@ import FirecrawlApp, {
   ScrapeResponseV0,
   SearchResponseV0,
 } from "../../index";
+import { setTimeout } from "timers/promises";
 import { v4 as uuidv4 } from "uuid";
 import dotenv from "dotenv";
 import { describe, test, expect } from "@jest/globals";
@@ -243,7 +244,7 @@ describe('FirecrawlApp<"v0"> E2E Tests', () => {
       let checks = 0;
 
       while (statusResponse.status === "active" && checks < maxChecks) {
-        await new Promise((resolve) => setTimeout(resolve, 5000));
+        await setTimeout(5000);
         expect(statusResponse.partial_data).not.toBeNull();
         // expect(statusResponse.current).toBeGreaterThanOrEqual(1);
         statusResponse = (await app.checkCrawlStatus(

--- a/apps/js-sdk/firecrawl/src/__tests__/v1/e2e_withAuth/index.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/v1/e2e_withAuth/index.test.ts
@@ -1,5 +1,6 @@
 import FirecrawlApp, { type CrawlParams, type CrawlResponse, type CrawlStatusResponse, type MapResponse, type ScrapeResponse } from '../../../index';
 import { v4 as uuidv4 } from 'uuid';
+import { setTimeout } from 'timers/promises';
 import dotenv from 'dotenv';
 import { describe, test, expect } from '@jest/globals';
 
@@ -276,7 +277,7 @@ describe('FirecrawlApp E2E Tests', () => {
 
     expect(statusResponse.success).toBe(true);
     while ((statusResponse as any).status === 'scraping' && checks < maxChecks) {
-      await new Promise(resolve => setTimeout(resolve, 5000));
+      await setTimeout(5000);
       expect(statusResponse).not.toHaveProperty("partial_data"); // v0
       expect(statusResponse).not.toHaveProperty("current"); // v0
       expect(statusResponse).toHaveProperty("data");

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from "timers/promises";
 import axios, { type AxiosResponse, type AxiosRequestHeaders, AxiosError } from "axios";
 import type * as zt from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -768,9 +769,7 @@ export default class FirecrawlApp {
           ["active", "paused", "pending", "queued", "waiting", "scraping"].includes(statusData.status)
         ) {
           checkInterval = Math.max(checkInterval, 2);
-          await new Promise((resolve) =>
-            setTimeout(resolve, checkInterval * 1000)
-          );
+          await setTimeout(resolve, checkInterval * 1000);
         } else {
           throw new FirecrawlError(
             `Crawl job failed or was stopped. Status: ${statusData.status}`,

--- a/apps/test-suite/tests/crawl.test.ts
+++ b/apps/test-suite/tests/crawl.test.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from "timers/promises";
 import request from "supertest";
 import dotenv from "dotenv";
 import { WebsiteScrapeError } from "../utils/types";
@@ -54,7 +55,7 @@ describe("Crawling Checkup (E2E)", () => {
             isFinished = completedResponse.body.status === "completed";
 
             if (!isFinished) {
-              await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for 1 second before checking again
+              await setTimeout(1000); // Wait for 1 second before checking again
             }
           }
 

--- a/apps/test-suite/tests/scrape.test.ts
+++ b/apps/test-suite/tests/scrape.test.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from "timers/promises";
 import request from "supertest";
 import dotenv from "dotenv";
 import { numTokensFromString } from "../utils/tokens";
@@ -46,7 +47,7 @@ describe("Scraping Checkup (E2E)", () => {
       
       for (let i = 0; i < websitesData.length; i += batchSize) {
         // Introducing delay to respect the rate limit of 15 requests per minute
-        await new Promise(resolve => setTimeout(resolve, 10000)); 
+        await setTimeout(10000); 
 
         const batch = websitesData.slice(i, i + batchSize);
         const batchPromise = Promise.all(
@@ -102,7 +103,7 @@ describe("Scraping Checkup (E2E)", () => {
                   attempts++;
                   if (attempts < maxRetries) {
                     console.log(`Retrying... Attempt ${attempts + 1}`);
-                    await new Promise(resolve => setTimeout(resolve, 2000)); // Wait for 2 seconds before retrying
+                    await setTimeout(2000); // Wait for 2 seconds before retrying
                   }
                 }
               }


### PR DESCRIPTION
This PR replaces `await new Promise((..) => setTimeout(..))` with `await setTimeout(..)` from node's `timers/promises` module.