### PR TITLE
fix(api): use availableParallelism method

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,7 +26,7 @@ const { createBullBoard } = require("@bull-board/api");
 const { BullAdapter } = require("@bull-board/api/bullAdapter");
 const { ExpressAdapter } = require("@bull-board/express");
 
-const numCPUs = process.env.ENV === "local" ? 2 : os.cpus().length;
+const numCPUs = process.env.ENV === "local" ? 2 : os.availableParallelism();
 Logger.info(`Number of CPUs: ${numCPUs} available`);
 
 const cacheable = new CacheableLookup()


### PR DESCRIPTION
This method returns an estimate of the default amount of parallelism a program should use, compared to `cpus().length` which returns the cpu core count.