### PR TITLE
[BUG] Added trycatch and removed redundancy

### DIFF
--- a/apps/api/src/scraper/WebScraper/utils/utils.ts
+++ b/apps/api/src/scraper/WebScraper/utils/utils.ts
@@ -29,27 +29,28 @@ export function extractLinks(html: string, baseUrl: string): string[] {
   const $ = cheerio.load(html);
   const links: string[] = [];
 
-  // Parse the base URL to get the origin
-  const urlObject = new URL(baseUrl);
-  const origin = urlObject.origin;
-
   $('a').each((_, element) => {
     const href = $(element).attr('href');
     if (href) {
-      if (href.startsWith('http://') || href.startsWith('https://')) {
-        // Absolute URL, add as is
-        links.push(href);
-      } else if (href.startsWith('/')) {
-        // Relative URL starting with '/', append to origin
-        links.push(new URL(href, baseUrl).href);
-      } else if (!href.startsWith('#') && !href.startsWith('mailto:')) {
-        // Relative URL not starting with '/', append to base URL
-        links.push(new URL(href, baseUrl).href);
-      } else if (href.startsWith('mailto:')) {
-        // mailto: links, add as is
-        links.push(href);
+      try {
+        if (href.startsWith('http://') || href.startsWith('https://')) {
+          // Absolute URL, add as is
+          links.push(href);
+        } else if (href.startsWith('/')) {
+          // Relative URL starting with '/', append to base URL
+          links.push(new URL(href, baseUrl).href);
+        } else if (!href.startsWith('#') && !href.startsWith('mailto:')) {
+          // Relative URL not starting with '/', append to base URL
+          links.push(new URL(href, baseUrl).href);
+        } else if (href.startsWith('mailto:')) {
+          // mailto: links, add as is
+          links.push(href);
+        }
+        // Fragment-only links (#) are ignored
+      } catch (error) {
+        // Log the error and continue
+        console.error(`Failed to construct URL for href: ${href} with base: ${baseUrl}`, error);
       }
-      // Fragment-only links (#) are ignored
     }
   });
 


### PR DESCRIPTION
Customer found a bug while scraping [sentientsight.com](http://sentientsight.com/):
```
{
  "type": "error",
  "stack": "TypeError: Invalid URL\n at new URL (node:internal/url:806:29)\n at Element.<anonymous> (/app/dist/src/scraper/WebScraper/utils/utils.js:67:28)\n at LoadedCheerio.each (/app/node_modules/.pnpm/cheerio@1.0.0-rc.12/node_modules/cheerio/lib/api/traversing.js:519:26)\n at extractLinks (/app/dist/src/scraper/WebScraper/utils/utils.js:58:12)\n at scrapSingleUrl
...
}
```

This fixes it.