### PR TITLE
feat(crawl): add parameter to treat differing query parameters as different URLs

### DIFF
--- a/apps/api/src/controllers/v0/crawl.ts
+++ b/apps/api/src/controllers/v0/crawl.ts
@@ -195,6 +195,7 @@ export async function crawlController(req: Request, res: Response) {
 
       await lockURLs(
         id,
+        sc,
         jobs.map((x) => x.data.url)
       );
       await addCrawlJobs(

--- a/apps/api/src/controllers/v1/batch-scrape.ts
+++ b/apps/api/src/controllers/v1/batch-scrape.ts
@@ -76,6 +76,7 @@ export async function batchScrapeController(
 
   await lockURLs(
     id,
+    sc,
     jobs.map((x) => x.data.url)
   );
   await addCrawlJobs(

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -133,6 +133,7 @@ export async function crawlController(
 
     await lockURLs(
       id,
+      sc,
       jobs.map((x) => x.data.url)
     );
     await addCrawlJobs(

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -200,6 +200,7 @@ const crawlerOptions = z.object({
   allowExternalLinks: z.boolean().default(false),
   ignoreSitemap: z.boolean().default(true),
   deduplicateSimilarURLs: z.boolean().default(true),
+  ignoreQueryParameters: z.boolean().default(false),
 }).strict(strictMessage);
 
 // export type CrawlerOptions = {

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -456,6 +456,7 @@ export function toLegacyCrawlerOptions(x: CrawlerOptions) {
     allowExternalContentLinks: x.allowExternalLinks,
     ignoreSitemap: x.ignoreSitemap,
     deduplicateSimilarURLs: x.deduplicateSimilarURLs,
+    ignoreQueryParameters: x.ignoreQueryParameters,
   };
 }
 
@@ -470,6 +471,7 @@ export function fromLegacyCrawlerOptions(x: any): { crawlOptions: CrawlerOptions
       allowExternalLinks: x.allowExternalContentLinks,
       ignoreSitemap: x.ignoreSitemap,
       deduplicateSimilarURLs: x.deduplicateSimilarURLs,
+      ignoreQueryParameters: x.ignoreQueryParameters,
     }),
     internalOptions: {
       v0CrawlOnlyUrls: x.returnOnlyUrls,

--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -90,21 +90,26 @@ export async function getThrottledJobs(teamId: string): Promise<string[]> {
     return await redisConnection.zrangebyscore("concurrency-limiter:" + teamId + ":throttled", Date.now(), Infinity);
 }
 
-export function normalizeURL(url: string): string {
+export function normalizeURL(url: string, sc: StoredCrawl): string {
     const urlO = new URL(url);
-    urlO.search = "";
+    if (!sc.crawlerOptions || sc.crawlerOptions.ignoreQueryParameters) {
+        urlO.search = "";
+    }
     urlO.hash = "";
     return urlO.href;
 }
 
 export async function lockURL(id: string, sc: StoredCrawl, url: string): Promise<boolean> {
     if (typeof sc.crawlerOptions?.limit === "number") {
-        if (await redisConnection.scard("crawl:" + id + ":visited") >= sc.crawlerOptions.limit) {
+        if (await redisConnection.scard("crawl:" + id + ":visited_unique") >= sc.crawlerOptions.limit) {
             return false;
         }
     }
 
-    url = normalizeURL(url);
+    url = normalizeURL(url, sc);
+
+    await redisConnection.sadd("crawl:" + id + ":visited_unique", url);
+    await redisConnection.expire("crawl:" + id + ":visited_unique", 24 * 60 * 60, "NX");
 
     let res: boolean;
     if (!sc.crawlerOptions.deduplicateSimilarURLs) {
@@ -145,18 +150,9 @@ export async function lockURL(id: string, sc: StoredCrawl, url: string): Promise
 }
 
 /// NOTE: does not check limit. only use if limit is checked beforehand e.g. with sitemap
-export async function lockURLs(id: string, urls: string[]): Promise<boolean> {
+export async function lockURLs(id: string, sc: StoredCrawl, urls: string[]): Promise<boolean> {
     urls = urls.map(url => {
-        try {
-            const urlO = new URL(url);
-            urlO.search = "";
-            urlO.hash = "";
-            return urlO.href;
-        } catch (error) {
-            logger.warn("Failed to normalize URL " + JSON.stringify(url) + ": " + error);
-        }
-
-        return url;
+        return normalizeURL(url, sc);
     });
     
     const res = (await redisConnection.sadd("crawl:" + id + ":visited", ...urls)) !== 0

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -307,7 +307,7 @@ async function processJob(job: Job & { id: string }, token: string) {
     if (job.data.crawl_id) {
       const sc = (await getCrawl(job.data.crawl_id)) as StoredCrawl;
     
-      if (doc.metadata.url !== undefined && doc.metadata.sourceURL !== undefined && normalizeURL(doc.metadata.url) !== normalizeURL(doc.metadata.sourceURL)) {
+      if (doc.metadata.url !== undefined && doc.metadata.sourceURL !== undefined && normalizeURL(doc.metadata.url, sc) !== normalizeURL(doc.metadata.sourceURL, sc)) {
         logger.debug("Was redirected, locking new URL...");
         await lockURL(job.data.crawl_id, sc, doc.metadata.url);
       }

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -151,6 +151,7 @@ export interface CrawlParams {
   scrapeOptions?: CrawlScrapeOptions;
   webhook?: string;
   deduplicateSimilarURLs?: boolean;
+  ignoreQueryParameters?: boolean;
 }
 
 /**


### PR DESCRIPTION
Setting `ignoreQueryParameters` to false (true by default which retains old logic) will treat changes to the query parameters of the URL as expected to return different content.