### PR TITLE
Pin dependencies to avoid conflict

### DIFF
--- a/apps/python-sdk/requirements.txt
+++ b/apps/python-sdk/requirements.txt
@@ -1,5 +1,5 @@
-requests
-pytest
-python-dotenv
-websockets
-nest-asyncio
+requests==2.32.3
+pytest==8.3.3
+python-dotenv==1.0.1
+websockets==13.0
+nest-asyncio==1.6.0


### PR DESCRIPTION
Pinning the dependencies because Firecrawl was experiencing issues with WebSockets.
Reference: [WebSockets Documentation - Extra Headers](https://websockets.readthedocs.io/en/stable/howto/upgrade.html#extra-headers-additional-headers)