### PR TITLE
Fix: Conditionally enforce API key for self-hosted instances in js, python and rust SDKs

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -137,6 +137,14 @@ This error occurs because the Supabase client setup is not completed. You should
 **Explanation:**
 This error occurs because the Supabase client setup is not completed. You should be able to scrape and crawl with no problems. Right now it's not possible to configure Supabase in self-hosted instances.
 
+### SDK Authentication
+
+**Note:**
+When using the Firecrawl SDKs (JavaScript, Python, or Rust) with a self-hosted instance:
+- API key is optional for self-hosted instances
+- API key is required only when using the cloud service (firecrawl.dev)
+- Warning messages about missing API key can be safely ignored for self-hosted instances
+
 ### Docker containers fail to start
 
 **Symptom:**

--- a/apps/js-sdk/firecrawl/src/__tests__/e2e_withAuth/index.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/e2e_withAuth/index.test.ts
@@ -6,9 +6,10 @@ import FirecrawlApp, {
   ScrapeResponseV0,
   SearchResponseV0,
 } from "../../index";
-import { v4 as uuidv4 } from "uuid";
+import { describe, expect, test } from "@jest/globals";
+
 import dotenv from "dotenv";
-import { describe, test, expect } from "@jest/globals";
+import { v4 as uuidv4 } from "uuid";
 
 dotenv.config();
 
@@ -16,6 +17,17 @@ const TEST_API_KEY = process.env.TEST_API_KEY;
 const API_URL = "http://127.0.0.1:3002";
 
 describe('FirecrawlApp<"v0"> E2E Tests', () => {
+  test.concurrent("should handle authentication based on deployment type", async () => {
+    // Should throw for cloud service
+    expect(() => {
+      new FirecrawlApp<"v0">({ apiKey: null });
+    }).toThrow("No API key provided");
+
+    // Should not throw for self-hosted
+    const app = new FirecrawlApp<"v0">({ apiKey: null, apiUrl: API_URL });
+    expect(app).toBeDefined();
+  });
+
   test.concurrent("should throw error for no API key", async () => {
     expect(() => {
       new FirecrawlApp<"v0">({ apiKey: null, apiUrl: API_URL, version: "v0" });

--- a/apps/js-sdk/firecrawl/src/__tests__/index.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/index.test.ts
@@ -16,11 +16,16 @@ async function loadFixture(name: string): Promise<string> {
 
 describe('the firecrawl JS SDK', () => {
 
-  test('Should require an API key to instantiate FirecrawlApp', async () => {
-    const fn = () => {
+  test('Should require an API key only for cloud service', async () => {
+    // Should throw for cloud service without API key
+    expect(() => {
       new FirecrawlApp({ apiKey: undefined });
-    };
-    expect(fn).toThrow('No API key provided');
+    }).toThrow('No API key provided');
+
+    // Should not throw for self-hosted without API key
+    expect(() => {
+      new FirecrawlApp({ apiKey: undefined, apiUrl: 'http://localhost:3000' });
+    }).not.toThrow();
   });
 
   test('Should return scraped data from a /scrape API call', async () => {

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -292,11 +292,12 @@ export default class FirecrawlApp {
    * @param config - Configuration options for the FirecrawlApp instance.
    */
   constructor({ apiKey = null, apiUrl = null }: FirecrawlAppConfig) {
-    if (typeof apiKey !== "string") {
+    const isCloudService = !apiUrl || apiUrl.includes('firecrawl.dev');
+    if (isCloudService && typeof apiKey !== "string") {
       throw new FirecrawlError("No API key provided", 401);
     }
 
-    this.apiKey = apiKey;
+    this.apiKey = apiKey || '';
     this.apiUrl = apiUrl || "https://api.firecrawl.dev";
   }
 

--- a/apps/python-sdk/firecrawl/__tests__/e2e_withAuth/test.py
+++ b/apps/python-sdk/firecrawl/__tests__/e2e_withAuth/test.py
@@ -19,9 +19,14 @@ spec.loader.exec_module(firecrawl)
 FirecrawlApp = firecrawl.FirecrawlApp
 
 def test_no_api_key():
+    # Should throw for cloud service
     with pytest.raises(Exception) as excinfo:
-      invalid_app = FirecrawlApp(api_url=API_URL, version='v0')
+        invalid_app = FirecrawlApp()
     assert "No API key provided" in str(excinfo.value)
+
+    # Should not throw for self-hosted
+    app = FirecrawlApp(api_url=API_URL)
+    assert app is not None
 
 def test_scrape_url_invalid_api_key():
     invalid_app = FirecrawlApp(api_url=API_URL, api_key="invalid_api_key", version='v0')

--- a/apps/python-sdk/firecrawl/__tests__/v1/e2e_withAuth/test.py
+++ b/apps/python-sdk/firecrawl/__tests__/v1/e2e_withAuth/test.py
@@ -20,9 +20,14 @@ spec.loader.exec_module(firecrawl)
 FirecrawlApp = firecrawl.FirecrawlApp
 
 def test_no_api_key():
+    # Should throw for cloud service
     with pytest.raises(Exception) as excinfo:
-      invalid_app = FirecrawlApp(api_url=API_URL)
+        invalid_app = FirecrawlApp()
     assert "No API key provided" in str(excinfo.value)
+
+    # Should not throw for self-hosted
+    app = FirecrawlApp(api_url=API_URL)
+    assert app is not None
 
 def test_scrape_url_invalid_api_key():
     invalid_app = FirecrawlApp(api_url=API_URL, api_key="invalid_api_key")
@@ -349,4 +354,3 @@ def test_search_e2e():
 #     assert isinstance(llm_extraction['is_open_source'], bool)
 
 
-    

--- a/apps/python-sdk/firecrawl/firecrawl.py
+++ b/apps/python-sdk/firecrawl/firecrawl.py
@@ -40,19 +40,25 @@ class FirecrawlApp:
         error: Optional[str] = None
 
     def __init__(self, api_key: Optional[str] = None, api_url: Optional[str] = None) -> None:
-      """
-      Initialize the FirecrawlApp instance with API key, API URL.
+        """
+        Initialize the FirecrawlApp instance with API key, API URL.
 
-      Args:
-          api_key (Optional[str]): API key for authenticating with the Firecrawl API.
-          api_url (Optional[str]): Base URL for the Firecrawl API.
-      """
-      self.api_key = api_key or os.getenv('FIRECRAWL_API_KEY')
-      self.api_url = api_url or os.getenv('FIRECRAWL_API_URL', 'https://api.firecrawl.dev')
-      if self.api_key is None:
-          logger.warning("No API key provided")
-          raise ValueError('No API key provided')
-      logger.debug(f"Initialized FirecrawlApp with API key: {self.api_key}")
+        Args:
+            api_key (Optional[str]): API key for authenticating with the Firecrawl API.
+            api_url (Optional[str]): Base URL for the Firecrawl API.
+        """
+        self.api_url = api_url or os.getenv('FIRECRAWL_API_URL', 'https://api.firecrawl.dev')
+        is_cloud_service = not api_url or 'firecrawl.dev' in self.api_url
+        self.api_key = api_key or os.getenv('FIRECRAWL_API_KEY')
+
+        if is_cloud_service and not self.api_key:
+            logger.warning("No API key provided for cloud service")
+            raise ValueError('No API key provided')
+        elif not self.api_key:
+            logger.warning("No API key provided for self-hosted instance")
+            self.api_key = ''
+
+        logger.debug(f"Initialized FirecrawlApp with API key: {self.api_key}")
 
     def scrape_url(self, url: str, params: Optional[Dict[str, Any]] = None) -> Any:
         """

--- a/apps/rust-sdk/src/lib.rs
+++ b/apps/rust-sdk/src/lib.rs
@@ -25,9 +25,16 @@ impl FirecrawlApp {
     }
 
     pub fn new_selfhosted(api_url: impl AsRef<str>, api_key: Option<impl AsRef<str>>) -> Result<Self, FirecrawlError> {
+        let api_url = api_url.as_ref().to_string();
+        let is_cloud_service = api_url.contains("firecrawl.dev");
+        
+        if is_cloud_service && api_key.is_none() {
+            return Err(FirecrawlError::InvalidConfiguration("Cloud service requires API key".to_string()));
+        }
+
         Ok(FirecrawlApp {
             api_key: api_key.map(|x| x.as_ref().to_string()),
-            api_url: api_url.as_ref().to_string(),
+            api_url,
             client: Client::new(),
         })
     }

--- a/apps/rust-sdk/tests/e2e_with_auth.rs
+++ b/apps/rust-sdk/tests/e2e_with_auth.rs
@@ -24,11 +24,7 @@ async fn test_blocklisted_url() {
 async fn test_successful_response_with_valid_preview_token() {
     dotenv().ok();
     let api_url = env::var("API_URL").unwrap();
-    let app = FirecrawlApp::new_selfhosted(
-        api_url,
-        Some("this_is_just_a_preview_token"),
-    )
-    .unwrap();
+    let app = FirecrawlApp::new_selfhosted(api_url, Some("this_is_just_a_preview_token")).unwrap();
     let result = app
         .scrape_url("https://roastmywebsite.ai", None)
         .await
@@ -58,7 +54,7 @@ async fn test_successful_response_with_valid_api_key_and_include_html() {
     let api_key = env::var("TEST_API_KEY").ok();
     let app = FirecrawlApp::new_selfhosted(api_url, api_key).unwrap();
     let params = ScrapeOptions {
-        formats: vec! [ ScrapeFormats::Markdown, ScrapeFormats::HTML ].into(),
+        formats: vec![ScrapeFormats::Markdown, ScrapeFormats::HTML].into(),
         ..Default::default()
     };
     let result = app
@@ -82,7 +78,8 @@ async fn test_successful_response_for_valid_scrape_with_pdf_file() {
         .await
         .unwrap();
     assert!(result.markdown.is_some());
-    assert!(result.markdown
+    assert!(result
+        .markdown
         .unwrap()
         .contains("We present spectrophotometric observations of the Broad Line Radio Galaxy"));
 }
@@ -98,7 +95,8 @@ async fn test_successful_response_for_valid_scrape_with_pdf_file_without_explici
         .await
         .unwrap();
     assert!(result.markdown.is_some());
-    assert!(result.markdown
+    assert!(result
+        .markdown
         .unwrap()
         .contains("We present spectrophotometric observations of the Broad Line Radio Galaxy"));
 }
@@ -153,4 +151,16 @@ async fn test_llm_extraction() {
         .contains_key("company_mission"));
     assert!(llm_extraction["supports_sso"].is_boolean());
     assert!(llm_extraction["is_open_source"].is_boolean());
+}
+
+#[tokio::test]
+async fn test_self_hosted_without_api_key() {
+    dotenv().ok();
+    let api_url = env::var("API_URL").unwrap();
+    let app = FirecrawlApp::new_selfhosted(api_url, None::<String>).unwrap();
+    let result = app
+        .scrape_url("https://roastmywebsite.ai", None)
+        .await
+        .unwrap();
+    assert!(result.markdown.is_some());
 }


### PR DESCRIPTION
Fixes: #961
by implementing conditional API key validation in the JavaScript, Python, and Rust SDKs.

**Problem:**

The SDKs were incorrectly enforcing API key requirements even when users were self-hosting Firecrawl and had disabled database authentication (`USE_DB_AUTHENTICATION=false` in `.env`). This made it harder to use the SDKs with a self-hosted instance without an API key.

**Solution:**

This PR modifies the SDKs to determine whether they are interacting with the official Firecrawl cloud service or a self-hosted instance based on the provided `api_url` (or `apiUrl` in JS SDK).

*   **Cloud Service:** If the `api_url` is not set (defaulting to the cloud service) or if it contains `firecrawl.dev`, the SDK assumes it's interacting with the cloud service and **requires** an API key.
*   **Self-Hosted Instance:** If the `api_url` is set to a different URL (not containing `firecrawl.dev`), the SDK assumes it's a self-hosted instance and will function **without** one, as long as database authentication is disabled on the self-hosted instance. If an API key is provided it will still be used.

**Changes Made:**

*   **JavaScript SDK:**
    *   Added `isCloudService` logic in `index.ts` to check the `apiUrl`.
    *   Conditionally threw an error in the constructor only if `isCloudService` is true and no API key is provided.
*   **Python SDK:**
    *   Added `is_cloud_service` logic in `firecrawl.py` to check the `api_url`.
    *   Modified the `__init__` method to conditionally raise a `ValueError` only if it's a cloud service and no API key is provided.
*   **Rust SDK:**
    *   Added `is_cloud_service` logic in `src/lib.rs` (within the `new_selfhosted` function) to check the `api_url`.
    *   Conditionally returned a `FirecrawlError` only if it's a cloud service and the API key is `None`.
