### PR TITLE
[bug/JS-SDK]Added check for object and trycatch as workaround for 502s

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "1.9.4",
+  "version": "1.10.1",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Customer found the following error when 502

```bash
Error: TypeError: Cannot use 'in' operator to search for 'next' in
2024-12-11T08:38:12.249Z
<html><head>
2024-12-11T08:38:12.249Z
<meta http-equiv="content-type" content="text/html;charset=utf-8">
2024-12-11T08:38:12.249Z
<title>502 Server Error</title>
2024-12-11T08:38:12.249Z
</head>
2024-12-11T08:38:12.249Z
<body text=#000000 bgcolor=#ffffff>
2024-12-11T08:38:12.249Z
<h1>Error: Server Error</h1>
2024-12-11T08:38:12.249Z
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
2024-12-11T08:38:12.249Z
<h2></h2>
2024-12-11T08:38:12.249Z
</body></html>
2024-12-11T08:38:12.249Z
at FirecrawlApp.monitorJobStatus (/usr/src/app/node_modules/@mendable/firecrawl-js/dist/index.cjs:542:27)
2024-12-11T08:38:12.249Z
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2024-12-11T08:38:12.249Z
at async handler (/usr/src/app/index.js:183:27)
2024-12-11T08:38:12.249Z
at async main (/usr/src/app/index.js:257:20)
```