### PR TITLE
fix: adjust Playwright service response to match API schema expectations

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -196,7 +196,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
     }
   }
 
-  const pageError = pageStatusCode !== 200 ? getError(pageStatusCode) : false;
+  const pageError = pageStatusCode !== 200 ? getError(pageStatusCode) : undefined;
 
   if (!pageError) {
     console.log(`✅ Scrape successful!`);
@@ -209,7 +209,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   res.json({
     content: pageContent,
     pageStatusCode,
-    pageError
+    ...(pageError && { pageError })
   });
 });
 


### PR DESCRIPTION
## Fix: Playwright Service Response Schema Mismatch

### Problem
The Playwright microservice was returning `pageError: false` for successful scrapes, but the main API expects `pageError` to be either a string or undefined (as defined by the Zod schema). This schema mismatch caused Playwright result parsing to fail silently, making the main API fall back to fetch even when Playwright successfully scraped the page.

### Solution
Modified the Playwright service response to:
1. Return `undefined` instead of `false` for successful scrapes (status code 200)
2. Only include `pageError` in the response when there is an actual error
3. Use spread operator to conditionally include pageError: `...(pageError && { pageError })`

### Testing
- Tested with local setup running both services
- Successfully scraped test URLs with Playwright without falling back to fetch
- Confirmed proper error handling for failed scrapes
- Verified logs showing successful Playwright scrapes being properly handled by the main API