### PR TITLE
[BUG] fixed title extra info

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/extractMetadata.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractMetadata.ts
@@ -40,7 +40,7 @@ export function extractMetadata(
   const soup = load(html);
 
   try {
-    title = soup("title").text() || undefined;
+    title = soup("title").first().text().trim() || undefined;
     description = soup('meta[name="description"]').attr("content") || undefined;
 
     // Assuming the language is part of the URL as per the regex pattern


### PR DESCRIPTION
Removes extra text in title metadata. Example: "https://help.dropbox.com/storage-space/account-space-left" previously had the metadata.title = "How to check how much Dropbox storage space is left - Dropbox HelpClearSearchLoadingClearSearchLoadingperson iconhighlighter iconhighlighter icon", now it's "How to check how much Dropbox storage space is left - Dropbox Help"