### PR TITLE
fix: merge mock success data

### DIFF
--- a/apps/api/src/lib/withAuth.ts
+++ b/apps/api/src/lib/withAuth.ts
@@ -17,7 +17,7 @@ export function withAuth<T, U extends any[]>(
         logger.warn("You're bypassing authentication");
         warningCount++;
       }
-      return { success: true } as T;
+      return { success: true, ...(mockSuccess || {}) } as T;
     } else {
       return await originalFunction(...args);
     }


### PR DESCRIPTION
I am using API `/v0/crawl` with the limit=10 setting, but this setting does not take effect. 
After some investigation, I found that in code https://github.com/mendableai/firecrawl/blob/c911aad228ebb76384833e8e95e2a074f9d78030/apps/api/src/controllers/v0/crawl.ts#L82-L97
`remainingCredits` returns undefined, which causes `Math.min(remainingCredits, crawlerOptions.limit)` to return a `NaN`, resulting in the limit parameter not being effective.