### PR TITLE
[FIR-37] feat: extract and return favicon URL during scraping

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/extractMetadata.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractMetadata.ts
@@ -8,6 +8,7 @@ export function extractMetadata(
 ): Partial<Document["metadata"]> {
   let title: string | undefined = undefined;
   let description: string | undefined = undefined;
+  let favicon: string | undefined = undefined;
   let language: string | undefined = undefined;
   let keywords: string | undefined = undefined;
   let robots: string | undefined = undefined;
@@ -42,6 +43,12 @@ export function extractMetadata(
   try {
     title = soup("title").first().text().trim() || undefined;
     description = soup('meta[name="description"]').attr("content") || undefined;
+    
+    const faviconLink = soup('link[rel="icon"]').attr("href") || soup('link[rel*="icon"]').first().attr("href") || undefined;
+    if (faviconLink) {
+      const baseUrl = new URL(meta.url).origin;
+      favicon = faviconLink.startsWith('http') ? faviconLink : `${baseUrl}${faviconLink}`;
+    }
 
     // Assuming the language is part of the URL as per the regex pattern
     language = soup("html").attr("lang") || undefined;
@@ -121,6 +128,7 @@ export function extractMetadata(
   return {
     title,
     description,
+    favicon,
     language,
     keywords,
     robots,


### PR DESCRIPTION
Hello,

We cannot simply select the element using `'link[rel="icon"]'` because some websites (e.g., [_https://www.mendable.ai/_](https://www.mendable.ai/)) use tags like `<link href="/favicon.ico" rel="shortcut icon">` where the `rel` property includes additional details. To address this, we filter all `<link>` tags that contain `icon` in their `rel` attribute and select the first matching one.

----

**Preview without `favicon`**

<img width="1062" alt="image" src="https://github.com/user-attachments/assets/f205a4bd-f08b-4029-9bae-f0545263a77f" />

----

**Preview with `favicon` where `rel="icon"`**

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/bfe24a59-85a6-49b2-b89d-d21ea64e6a49" />

----

**Preview with `favicon` where `rel="whatever-value icon"`**

<img width="783" alt="image" src="https://github.com/user-attachments/assets/c5cde7e2-4b78-4815-956e-184a3d011e87" />
