### PR TITLE
fix(js-sdk): Add CJS-compatible WebSocket loading

### DIFF
--- a/apps/js-sdk/firecrawl/src/global.d.ts
+++ b/apps/js-sdk/firecrawl/src/global.d.ts
@@ -1,0 +1,5 @@
+export {};
+
+declare global {
+  const __WEBSOCKET_LOADER__: string;
+}

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -1069,8 +1069,9 @@ export class CrawlWatcher extends TypedEventTarget<CrawlWatcherEvents> {
     }).bind(this);
   }
 
-  async close() {
-    await this.initialized;
-    this.ws.close();
+  close() {
+    this.initialized.then(() => {
+      this.ws.close();
+    });
   }
 }

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -1,8 +1,8 @@
 import axios, { type AxiosResponse, type AxiosRequestHeaders, AxiosError } from "axios";
 import type * as zt from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
-import { WebSocket } from "isows";
 import { TypedEventTarget } from "typescript-event-target";
+
 
 /**
  * Configuration interface for FirecrawlApp.
@@ -947,10 +947,23 @@ export class CrawlWatcher extends TypedEventTarget<CrawlWatcherEvents> {
   public status: CrawlStatusResponse["status"];
   public id: string;
 
+  private static loadWebSocket() {
+    try {
+      return require('isows').WebSocket;
+    } catch {
+      try {
+        return import('isows').then(m => m.WebSocket);
+      } catch {
+        throw new FirecrawlError("WebSocket module failed to load", 500);
+      }
+    }
+  }
+
   constructor(id: string, app: FirecrawlApp) {
     super();
+    const WS = CrawlWatcher.loadWebSocket();
     this.id = id;
-    this.ws = new WebSocket(`${app.apiUrl}/v1/crawl/${id}`, app.apiKey);
+    this.ws = new WS(`${app.apiUrl}/v1/crawl/${id}`, app.apiKey);
     this.status = "scraping";
     this.data = [];
 

--- a/apps/js-sdk/firecrawl/tsup.config.ts
+++ b/apps/js-sdk/firecrawl/tsup.config.ts
@@ -6,4 +6,13 @@ export default defineConfig({
   dts: true,
   outDir: "dist",
   clean: true,
+  esbuildOptions(options, context) {
+    options.define = {
+      __WEBSOCKET_LOADER__: JSON.stringify(
+        context.format === 'cjs' 
+          ? `const { WebSocket } = require('isows'); WebSocket`
+          : `import('isows').then(m => m.WebSocket)`
+      )
+    };
+  },
 });


### PR DESCRIPTION
Fixes: #1011

The build passes for both ESM and CJS
```bash
npm run build

> @mendable/firecrawl-js@1.10.1 build
> tsup

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.2.4
CLI Using tsup config: /home/voldemort/Desktop/Code/open_source/firecrawl/apps/js-sdk/firecrawl/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
ESM dist/index.js 22.21 KB
ESM ⚡️ Build success in 17ms
CJS dist/index.cjs 24.08 KB
CJS ⚡️ Build success in 17ms
DTS Build start
DTS ⚡️ Build success in 1540ms
DTS dist/index.d.cts 15.45 KB
DTS dist/index.d.ts  15.45 KB
```