### PR TITLE
feat: use new random user agent instead of the old one

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from 'express';
 import bodyParser from 'body-parser';
 import { chromium, Browser, BrowserContext, Route, Request as PlaywrightRequest } from 'playwright';
 import dotenv from 'dotenv';
-import randomUseragent from 'random-useragent';
+import UserAgent from 'user-agents';
 import { getError } from './helpers/get_error';
 
 dotenv.config();
@@ -60,7 +60,7 @@ const initializeBrowser = async () => {
     ]
   });
 
-  const userAgent = randomUseragent.getRandom();
+  const userAgent = new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {

--- a/apps/playwright-service-ts/package.json
+++ b/apps/playwright-service-ts/package.json
@@ -16,12 +16,12 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "playwright": "^1.45.0",
-    "random-useragent": "^0.5.0"
+    "user-agents": "^1.1.410"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.9",
-    "@types/random-useragent": "^0.3.3",
+    "@types/user-agents": "^1.0.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.2"
   }


### PR DESCRIPTION
The `random-useragent` package (https://github.com/skratchdot/random-useragent) hasn't been updated for three years and in it repo user agents set manually via json file, therefore they all are easily detected (because old).

so it would be better to add a new modern package that generates different actual user agents daily (https://github.com/intoli/user-agents)