### PR TITLE
Add ENV environment variable to docker compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,7 @@ services:
       SELF_HOSTED_WEBHOOK_URL: ${SELF_HOSTED_WEBHOOK_URL}
       LOGGING_LEVEL: ${LOGGING_LEVEL}
       FLY_PROCESS_GROUP: app
+      ENV: ${ENV}
     depends_on:
       - redis
       - playwright-service


### PR DESCRIPTION
Add ENV environment variable to the docker compose file so setting ENV=local in the .env will work properly. fixes #930