### PR TITLE
fix: FFI type mismatches between i8 and c_char

### DIFF
--- a/apps/api/sharedLibs/html-transformer/src/lib.rs
+++ b/apps/api/sharedLibs/html-transformer/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{collections::HashMap, ffi::{CStr, CString}};
+use libc::c_char;
 
 use kuchikiki::{parse_html, traits::TendrilSink};
 use serde::Deserialize;
@@ -10,7 +11,7 @@ use url::Url;
 /// # Safety
 /// Input options must be a C HTML string. Output will be a JSON string array. Output string must be freed with free_string.
 #[no_mangle]
-pub unsafe extern "C" fn extract_links(html: *const libc::c_char) -> *mut i8 {
+pub unsafe extern "C" fn extract_links(html: *const c_char) -> *mut c_char {
     let html = unsafe { CStr::from_ptr(html) }.to_str().unwrap();
 
     let document = parse_html().one(html);
@@ -54,7 +55,7 @@ macro_rules! insert_meta_property {
 /// # Safety
 /// Input options must be a C HTML string. Output will be a JSON object. Output string must be freed with free_string.
 #[no_mangle]
-pub unsafe extern "C" fn extract_metadata(html: *const libc::c_char) -> *mut i8 {
+pub unsafe extern "C" fn extract_metadata(html: *const c_char) -> *mut c_char {
     let html = unsafe { CStr::from_ptr(html) }.to_str().unwrap();
 
     let document = parse_html().one(html);
@@ -334,7 +335,7 @@ fn _transform_html_inner(opts: TranformHTMLOptions) -> Result<String, ()> {
 /// # Safety
 /// Input options must be a C JSON string. Output will be an HTML string. Output string must be freed with free_string.
 #[no_mangle]
-pub unsafe extern "C" fn transform_html(opts: *const libc::c_char) -> *mut i8 {
+pub unsafe extern "C" fn transform_html(opts: *const c_char) -> *mut c_char {
     let opts: TranformHTMLOptions = match unsafe { CStr::from_ptr(opts) }.to_str().map_err(|_| ()).and_then(|x| serde_json::de::from_str(x).map_err(|_| ())) {
         Ok(x) => x,
         Err(_) => {
@@ -355,6 +356,6 @@ pub unsafe extern "C" fn transform_html(opts: *const libc::c_char) -> *mut i8 {
 /// # Safety
 /// ptr must be a non-freed string pointer returned by Rust code.
 #[no_mangle]
-pub unsafe extern "C" fn free_string(ptr: *mut i8) {
+pub unsafe extern "C" fn free_string(ptr: *mut c_char) {
     drop(unsafe { CString::from_raw(ptr) })
 }


### PR DESCRIPTION
This PR fixes build errors related to type mismatches in the FFI interface. 
Specifically, it changes function signatures to consistently use libc::c_char 
instead of i8 for C string pointers.

Changes:
- Changed return types from *mut i8 to *mut c_char in extract_links, extract_metadata, and transform_html
- Changed parameter type in free_string from *mut i8 to *mut c_char
- Ensures type consistency across the FFI boundary

The changes fix build errors where the compiler expected *mut i8 but found *mut u8.