### PR TITLE
Fix corepack and self hosting setup

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,9 +3,8 @@ FROM node:20-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 LABEL fly_launch_runtime="Node.js"
-RUN npm install -g corepack
-RUN corepack enable
-RUN corepack prepare pnpm@10.2.0 --activate
+RUN corepack enable && npm install -g corepack@latest
+
 COPY . /app
 WORKDIR /app
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:20-slim AS base
+
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 LABEL fly_launch_runtime="Node.js"
+RUN npm install -g corepack
 RUN corepack enable
+RUN corepack prepare pnpm@10.2.0 --activate
 COPY . /app
 WORKDIR /app
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-l
 FROM base AS build
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
-RUN apt-get update -qq && apt-get install -y ca-certificates && update-ca-certificates
+RUN apt-get clean && apt-get update -qq && apt-get install -y ca-certificates && update-ca-certificates
 RUN pnpm install
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
     bash -c 'export SENTRY_AUTH_TOKEN="$(cat /run/secrets/SENTRY_AUTH_TOKEN)"; if [ -z $SENTRY_AUTH_TOKEN ]; then pnpm run build:nosentry; else pnpm run build; fi'

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/bash -e
 
+if [ $UID -eq 0 ]; then
+  set +e # disable failing on errror
+  ulimit -n 65535
+  echo "NEW ULIMIT: $(ulimit -n)"
+  set -e # enable failing on error
+else
+  echo ENTRYPOINT DID NOT RUN AS ROOT
+fi
+
 if [ $FLY_PROCESS_GROUP = "app" ]; then
   echo "RUNNING app"
   node --max-old-space-size=8192 dist/src/index.js

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -1,12 +1,5 @@
 #!/bin/bash -e
 
-if [ $UID -eq 0 ]; then
-  ulimit -n 65535
-  echo "NEW ULIMIT: $(ulimit -n)"
-else
-  echo ENTRYPOINT DID NOT RUN AS ROOT
-fi
-
 if [ $FLY_PROCESS_GROUP = "app" ]; then
   echo "RUNNING app"
   node --max-old-space-size=8192 dist/src/index.js

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,10 @@ name: firecrawl
 
 x-common-service: &common-service
   build: apps/api
+  ulimits:
+    nofile:
+      soft: 65535
+      hard: 65535
   networks:
     - backend
   extra_hosts:


### PR DESCRIPTION
This is a set of changes that addressed the corepack issue and some additional issues with running the docker compose file in my self-hosted environment.

See issue: #1126 

I fixed the corepack issue by following this approach:
* [pnpm corepack fix suggestion](https://github.com/pnpm/pnpm/issues/9029#issuecomment-2631400936)

After fixing the corepack issue, I was left with this error:
* `ulimit: open files: cannot modify limit: Operation not permitted`
* In my research, you cannot set the ulimit from the docker entrypoint script.
* You need to set it as part of running the image like `docker run --ulimit nofile=65535:65535 your-image` or in the docker compose file as i have implemented