### PR TITLE
Fixed build issue on MacOS - E0308

### DIFF
--- a/apps/api/sharedLibs/html-transformer/src/lib.rs
+++ b/apps/api/sharedLibs/html-transformer/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{collections::HashMap, ffi::{CStr, CString}};
-
+use libc::c_char;
 use kuchikiki::{parse_html, traits::TendrilSink};
 use serde::Deserialize;
 use serde_json::Value;
@@ -376,5 +376,5 @@ pub unsafe extern "C" fn get_inner_json(html: *const libc::c_char) -> *mut libc:
 /// ptr must be a non-freed string pointer returned by Rust code.
 #[no_mangle]
 pub unsafe extern "C" fn free_string(ptr: *mut i8) {
-    drop(unsafe { CString::from_raw(ptr) })
+    drop(unsafe { CString::from_raw(ptr as *mut c_char) })
 }


### PR DESCRIPTION
When deploying locally using docker build on MacOS 15.3, when compiling html-transformer I encounter a E0308 error. The error occurred because CString::from_raw expected a *mut u8, but received a *mut i8.

To resolve this, I changed the pointer type to *mut c_char (from the libc crate) instead of *mut i8. This ensures compatibility with platform-specific character types (e.g., i8 on some systems, u8 on macOS). The updated function is:

```
pub unsafe extern "C" fn free_string(ptr: *mut i8) {
    drop(unsafe { CString::from_raw(ptr as *mut c_char) })
}
```

This change allowed the Docker build to work on macOS.