### PR TITLE
fix(html-transformer): Update free_string function parameter type

### DIFF
--- a/apps/api/sharedLibs/html-transformer/src/lib.rs
+++ b/apps/api/sharedLibs/html-transformer/src/lib.rs
@@ -375,6 +375,6 @@ pub unsafe extern "C" fn get_inner_json(html: *const libc::c_char) -> *mut libc:
 /// # Safety
 /// ptr must be a non-freed string pointer returned by Rust code.
 #[no_mangle]
-pub unsafe extern "C" fn free_string(ptr: *mut i8) {
+pub unsafe extern "C" fn free_string(ptr: *mut libc::c_char) {
     drop(unsafe { CString::from_raw(ptr) })
 }


### PR DESCRIPTION
Correct the parameter type to use libc::c_char for better type consistency 

Fixes #1152 