### PR TITLE
fix(queue-worker/crawl): only report successful page count in num_docs (FIR-960)

### DIFF
--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -29,6 +29,7 @@ import {
   getCrawl,
   getCrawlJobCount,
   getCrawlJobs,
+  getDoneJobsOrderedLength,
   lockURL,
   lockURLs,
   lockURLsIndividually,
@@ -185,7 +186,7 @@ async function finishCrawlIfNeeded(job: Job & { id: string }, sc: StoredCrawl) {
         );
       }
     } else {
-      const num_docs = await getCrawlJobCount(job.data.crawl_id);
+      const num_docs = await getDoneJobsOrderedLength(job.data.crawl_id);
       const jobStatus = sc.cancelled ? "failed" : "completed";
 
       await logJob(


### PR DESCRIPTION
Fixes bad activity log document count for crawls with failed jobs, causing customer confusion wrt limits not working.