### PR TITLE
fix(scrapeURL/fire-engine): perform format screenshot after specified actions (FIR-985)

### DIFF
--- a/apps/api/src/__tests__/snips/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/scrape.test.ts
@@ -88,5 +88,27 @@ describe("Scrape tests", () => {
       const obj = JSON.parse(response.body.data.rawHtml);
       expect(obj.id).toBe(1);
     }, 25000); // TODO: mock and shorten
+  });
+
+  describe("Screenshot", () => {
+    it.concurrent("screenshot format works", async () => {
+      const response = await scrape({
+        url: "http://firecrawl.dev",
+        formats: ["screenshot"]
+      });
+  
+      expectScrapeToSucceed(response);
+      expect(response.body.data.screenshot).toBeTruthy();
+    }, 15000);
+
+    it.concurrent("screenshot@fullPage format works", async () => {
+      const response = await scrape({
+        url: "http://firecrawl.dev",
+        formats: ["screenshot@fullPage"]
+      });
+  
+      expectScrapeToSucceed(response);
+      expect(response.body.data.screenshot).toBeTruthy();
+    }, 15000);
   })
 });

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -167,6 +167,9 @@ export async function scrapeURLWithFireEngineChromeCDP(
         ]
       : []),
 
+    // Include specified actions
+    ...(meta.options.actions ?? []),
+
     // Transform screenshot format into an action (unsupported by chrome-cdp)
     ...(meta.options.formats.includes("screenshot") ||
     meta.options.formats.includes("screenshot@fullPage")
@@ -177,9 +180,6 @@ export async function scrapeURLWithFireEngineChromeCDP(
           },
         ]
       : []),
-
-    // Include specified actions
-    ...(meta.options.actions ?? []),
   ];
 
   const totalWait = actions.reduce(
@@ -228,8 +228,10 @@ export async function scrapeURLWithFireEngineChromeCDP(
       "Transforming screenshots from actions into screenshot field",
       { screenshots: response.screenshots },
     );
-    response.screenshot = (response.screenshots ?? [])[0];
-    (response.screenshots ?? []).splice(0, 1);
+    if (response.screenshots) {
+      response.screenshot = response.screenshots.slice(-1, 0)[0];
+      response.screenshots = response.screenshots.slice(0, -1);
+    }
     meta.logger.debug("Screenshot transformation done", {
       screenshots: response.screenshots,
       screenshot: response.screenshot,


### PR DESCRIPTION
If a user performs page-manipulating actions in the `actions` fields, they usually want their `screenshot` to capture after the actions were made, not before. Fixes a few support tickets.