### PR TITLE
fix(scraper): improve charset detection regex to accurately parse met…

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fetch/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fetch/index.ts
@@ -74,7 +74,7 @@ export async function scrapeURLWithFetch(
 
       const buf = Buffer.from(await x.arrayBuffer());
       let text = buf.toString("utf8");
-      const charset = (text.match(/charset=["']?(.+?)["']?>/) ?? [])[1]
+      const charset = (text.match(/<meta\b[^>]*charset\s*=\s*["']?([^"'\s\/>]+)/i) ?? [])[1]
       try {
         if (charset) {
           text = new TextDecoder(charset.trim()).decode(buf);


### PR DESCRIPTION
improve charset detection to fully support legacy HTML4 declarations while maintaining HTML5 compatibility

works with both HTML4-style:
`<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">`
and HTML5-style:
`<meta charset="ISO-8859-1">`