### PR TITLE
docs: remove undefined "required" field

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,6 @@ curl -X POST https://api.firecrawl.dev/v1/extract \
         },
         "required": [
           "company_mission",
-          "supports_sso",
           "is_open_source",
           "is_in_yc"
         ]


### PR DESCRIPTION
The documentation example has a "supports_SSO" field that is specified neither in the prompt nor in the schema.
Removing it will make the docs more understandable.