### PR TITLE
Fix SearxNG categories

### DIFF
--- a/apps/api/src/search/searxng.ts
+++ b/apps/api/src/search/searxng.ts
@@ -26,7 +26,7 @@ export async function searxng_search(
     // location: options.location, //not possible with SearXNG
     // num: options.num_results, //not possible with SearXNG
     engines: process.env.SEARXNG_ENGINES || "",
-    categories: process.env.SEARXNG_CATEGORIES || "general",
+    categories: process.env.SEARXNG_CATEGORIES || "",
     pageno: options.page ?? 1,
     format: "json"
   };


### PR DESCRIPTION
If categories is set, then the engines parameters don't have an effect.

You must use either categories OR engines. I propose to remove the default value for categories so the user can set en engine using the env var
