### PR TITLE
feat: add news search support

### DIFF
--- a/apps/api/openapi-v0.json
+++ b/apps/api/openapi-v0.json
@@ -455,6 +455,31 @@
                       "limit": {
                         "type": "integer",
                         "description": "Maximum number of results. Max is 20 during beta."
+                      },
+                      "tbm": {
+                        "type": "string",
+                        "description": "Type of search. Use 'nws' for news search.",
+                        "enum": ["nws"]
+                      },
+                      "tbs": {
+                        "type": "string",
+                        "description": "Time-based filtering parameter for Google search."
+                      },
+                      "filter": {
+                        "type": "string",
+                        "description": "Filter parameter for Google search."
+                      },
+                      "lang": {
+                        "type": "string",
+                        "description": "Language code for the search (e.g. 'en', 'fr')."
+                      },
+                      "country": {
+                        "type": "string",
+                        "description": "Country code for the search (e.g. 'us', 'fr')."
+                      },
+                      "location": {
+                        "type": "string",
+                        "description": "Geographic location for the search."
                       }
                     }
                   }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -408,6 +408,31 @@
                       "limit": {
                         "type": "integer",
                         "description": "Maximum number of results. Max is 20 during beta."
+                      },
+                      "tbm": {
+                        "type": "string",
+                        "description": "Type of search. Use 'nws' for news search.",
+                        "enum": ["nws"]
+                      },
+                      "tbs": {
+                        "type": "string",
+                        "description": "Time-based filtering parameter for Google search."
+                      },
+                      "filter": {
+                        "type": "string",
+                        "description": "Filter parameter for Google search."
+                      },
+                      "lang": {
+                        "type": "string",
+                        "description": "Language code for the search (e.g. 'en', 'fr')."
+                      },
+                      "country": {
+                        "type": "string",
+                        "description": "Country code for the search (e.g. 'us', 'fr')."
+                      },
+                      "location": {
+                        "type": "string",
+                        "description": "Geographic location for the search."
                       }
                     }
                   }

--- a/apps/api/requests.http
+++ b/apps/api/requests.http
@@ -120,3 +120,18 @@ content-type: application/json
 GET {{baseUrl}}/v1/llmstxt/{{generateLlmsTxtId}} HTTP/1.1
 Authorization: Bearer {{$dotenv TEST_API_KEY}}
 
+### News Search Example
+POST http://localhost:3002/v0/search HTTP/1.1
+Authorization: Bearer fc-
+content-type: application/json
+
+{
+  "query": "artificial intelligence",
+  "searchOptions": {
+    "limit": 5,
+    "tbm": "nws",
+    "lang": "en",
+    "country": "us"
+  }
+}
+

--- a/apps/api/src/__tests__/e2e_full_withAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_full_withAuth/index.test.ts
@@ -1113,6 +1113,43 @@ describe("E2E Tests for API Routes", () => {
       },
       30000,
     ); // 30 seconds timeout
+
+    it.concurrent("should return news results when using tbm=nws parameter", async () => {
+      const response = await request(TEST_URL)
+        .post("/v0/search")
+        .set("Authorization", `Bearer ${process.env.TEST_API_KEY}`)
+        .set("Content-Type", "application/json")
+        .send({ 
+          query: "artificial intelligence", 
+          searchOptions: { 
+            tbm: "nws",
+            limit: 3,
+            lang: "en",
+            country: "us" 
+          },
+          pageOptions: {
+            fetchPageContent: false // Set to false to just get the search results without content
+          }
+        });
+      
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toHaveProperty("success");
+      expect(response.body.success).toBe(true);
+      expect(response.body).toHaveProperty("data");
+      expect(Array.isArray(response.body.data)).toBe(true);
+      
+      // Check if we have at least one result
+      if (response.body.data.length > 0) {
+        const firstResult = response.body.data[0];
+        expect(firstResult).toHaveProperty("url");
+        expect(firstResult).toHaveProperty("title");
+        expect(firstResult).toHaveProperty("description");
+        
+        // Check for news-specific fields
+        expect(firstResult).toHaveProperty("source");
+        expect(firstResult).toHaveProperty("date");
+      }
+    }, 30000); // 30 seconds timeout
   });
 
   describe("GET /v0/crawl/status/:jobId", () => {

--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -174,15 +174,19 @@ export class SearchResult {
   url: string;
   title: string;
   description: string;
+  source?: string;
+  date?: string;
 
-  constructor(url: string, title: string, description: string) {
+  constructor(url: string, title: string, description: string, source?: string, date?: string) {
     this.url = url;
     this.title = title;
     this.description = description;
+    this.source = source;
+    this.date = date;
   }
 
   toString(): string {
-    return `SearchResult(url=${this.url}, title=${this.title}, description=${this.description})`;
+    return `SearchResult(url=${this.url}, title=${this.title}, description=${this.description}, source=${this.source}, date=${this.date})`;
   }
 }
 

--- a/apps/api/v1-openapi.json
+++ b/apps/api/v1-openapi.json
@@ -1465,6 +1465,129 @@
         }
       }
     },
+    "/search": {
+      "post": {
+        "summary": "Search for information based on options",
+        "operationId": "search",
+        "tags": ["Search"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "The search query"
+                  },
+                  "searchOptions": {
+                    "type": "object",
+                    "properties": {
+                      "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of results. Max is 20 during beta."
+                      },
+                      "tbm": {
+                        "type": "string",
+                        "description": "Type of search. Use 'nws' for news search.",
+                        "enum": ["nws"]
+                      },
+                      "tbs": {
+                        "type": "string",
+                        "description": "Time-based filtering parameter for Google search."
+                      },
+                      "filter": {
+                        "type": "string",
+                        "description": "Filter parameter for Google search."
+                      },
+                      "lang": {
+                        "type": "string",
+                        "description": "Language code for the search (e.g. 'en', 'fr')."
+                      },
+                      "country": {
+                        "type": "string",
+                        "description": "Country code for the search (e.g. 'us', 'fr')."
+                      },
+                      "location": {
+                        "type": "string",
+                        "description": "Geographic location for the search."
+                      }
+                    }
+                  }
+                },
+                "required": ["query"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Payment required to access this resource."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Request rate limit exceeded. Please wait and try again later."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "An unexpected error occurred on the server."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/team/credit-usage": {
       "get": {
         "summary": "Get remaining credits for the authenticated team",
@@ -1906,6 +2029,42 @@
               },
               "<property2>": {
                 "type": "number"
+              }
+            }
+          }
+        }
+      },
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "description": "URL du résultat"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Titre du résultat"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Description du résultat"
+                },
+                "source": {
+                  "type": "string",
+                  "description": "Source du résultat (pour les actualités)"
+                },
+                "date": {
+                  "type": "string",
+                  "description": "Date de publication (pour les actualités)"
+                }
               }
             }
           }


### PR DESCRIPTION
Implement Google News Search Functionality

This PR adds support for Google News search by:
- Adding the 'tbm=nws' parameter to the search API
- Updating the OpenAPI definition to include news search capability
- Modifying relevant entities and search functions
- Adding test cases to verify news search functionality

The implementation allows users to search for news articles through our API, expanding the search capabilities of the application.