### PR TITLE
Add health check and liveness check for Kubenetes

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -218,6 +218,20 @@ app.post('/scrape', async (req: Request, res: Response) => {
   });
 });
 
+// Health check for liveness
+app.get('/health/liveness', (req, res) => {
+  res.sendStatus(200);
+});
+
+// Health check for readiness
+app.get('/health/readiness', (req, res) => {
+  if (browser && context) {
+    res.sendStatus(200);
+  } else {
+    res.sendStatus(503);
+  }
+});
+
 app.listen(port, () => {
   initializeBrowser().then(() => {
     console.log(`Server is running on port ${port}`);


### PR DESCRIPTION
Hello,

I was deploying a self-hosted Kubernetes instance of Firecrawl and found that it is failing to see that the Playwright service is ready and healthy. When I went to check the code, it is missing in the express. I've added them back in.