### PR TITLE
feat(scrapeURL): reintroduce default timeout for simple queries

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -231,7 +231,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
     meta.options.timeout !== undefined
       ? Math.round(meta.options.timeout / Math.min(fallbackList.length, 2))
       : (!meta.options.actions && !meta.options.jsonOptions && !meta.options.extract)
-        ? 120000
+        ? Math.round(120000 / Math.min(fallbackList.length, 2))
         : undefined;
 
   for (const { engine, unsupportedFeatures } of fallbackList) {

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -230,7 +230,9 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
   const timeToRun =
     meta.options.timeout !== undefined
       ? Math.round(meta.options.timeout / Math.min(fallbackList.length, 2))
-      : undefined;
+      : (!meta.options.actions && !meta.options.jsonOptions && !meta.options.extract)
+        ? 120000
+        : undefined;
 
   for (const { engine, unsupportedFeatures } of fallbackList) {
     meta.internalOptions.abort?.throwIfAborted();


### PR DESCRIPTION
Should help with infinite running job issues.