### PR TITLE
Add network:host to Docker build process

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,9 @@ x-common-service: &common-service
   # NOTE: If you want to build the service locally,
   # uncomment the build: statement and comment out the image: statement
   # image: ghcr.io/mendableai/firecrawl
-  build: apps/api
+  build:
+    context: apps/api
+    network: host
 
   ulimits:
     nofile:
@@ -47,7 +49,9 @@ x-common-env: &common-env
 
 services:
   playwright-service:
-    build: apps/playwright-service-ts
+    build:
+      context: apps/playwright-service-ts
+      network: host
     environment:
       PORT: 3000
       PROXY_SERVER: ${PROXY_SERVER}


### PR DESCRIPTION
Resolves Docker build networking issues:
```
Error was:
npm error code EAI_AGAIN
npm error syscall getaddrinfo
npm error errno EAI_AGAIN
npm error request to https://registry.npmjs.org/pnpm failed, reason: getaddrinfo EAI_AGAIN registry.npmjs.org

Added network: host option to build configurations in docker-compose.yaml to allow
containers to use the host network during build, improving DNS resolution.
```