### PR TITLE
create openAI provider using base url parameter

### DIFF
--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -1,4 +1,4 @@
-import { openai } from "@ai-sdk/openai";
+import { createOpenAI } from "@ai-sdk/openai";
 import { createOllama } from "ollama-ai-provider";
 import { anthropic } from "@ai-sdk/anthropic";
 import { groq } from "@ai-sdk/groq";
@@ -23,7 +23,10 @@ const defaultProvider: Provider = process.env.OLLAMA_BASE_URL
   : "openai";
 
 const providerList: Record<Provider, any> = {
-  openai, //OPENAI_API_KEY
+  openai: createOpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      baseURL: process.env.OPENAI_BASE_URL,
+  }), //OPENAI_API_KEY
   ollama: createOllama({
     baseURL: process.env.OLLAMA_BASE_URL,
   }),


### PR DESCRIPTION
Since #1462 has been merged, it's not possible anymore to use an OpenAI compatible API. Just reuse what was done in #1245.