### PR TITLE
Fix: Add missing crypto import in crawl controller

### DIFF
--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -1,5 +1,6 @@
 import { Response } from "express";
 import { v4 as uuidv4 } from "uuid";
+import crypto from "crypto";
 import {
   CrawlRequest,
   crawlRequestSchema,


### PR DESCRIPTION
This PR fixes issue #1431 by adding the missing import statement for the crypto module.

The file was using crypto.randomUUID() but didn't import the crypto module, which would cause errors when running the code. I've added the import statement at the top of the file with the other imports.

Fixes #1431