### PR TITLE
fix(api/search): log page options correctly (FIR-2015)

### DIFF
--- a/apps/api/src/controllers/v0/search.ts
+++ b/apps/api/src/controllers/v0/search.ts
@@ -218,6 +218,7 @@ export async function searchController(req: Request, res: Response) {
       team_id: team_id,
       mode: "search",
       url: req.body.query,
+      scrapeOptions: fromLegacyScrapeOptions(req.body.pageOptions, undefined, 60000, team_id),
       crawlerOptions: crawlerOptions,
       origin: origin,
     });

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -274,6 +274,7 @@ export async function searchController(
       team_id: req.auth.team_id,
       mode: "search",
       url: req.body.query,
+      scrapeOptions: req.body.scrapeOptions,
       origin: req.body.origin,
       cost_tracking: costTracking,
     });


### PR DESCRIPTION
It was only missing on search, seems like.