### PR TITLE
feat: update deploy-image.yml to use GitHub repo variables and add pl…

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -9,26 +9,48 @@ on:
       - main
     paths:
       - apps/api/**
+      - apps/playwright-service-ts/**
   workflow_dispatch:
 
 jobs:
-      push-app-image:
-        runs-on: ubuntu-latest
-        defaults:
-          run:
-            working-directory: './apps/api'
-        steps:
-          - name: 'Checkout GitHub Action'
-            uses: actions/checkout@main
+  push-api-image:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: './apps/api'
+    steps:
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@main
 
-          - name: 'Login to GitHub Container Registry'
-            uses: docker/login-action@v1
-            with:
-              registry: ghcr.io
-              username: ${{github.actor}}
-              password: ${{secrets.GITHUB_TOKEN}}
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-          - name: 'Build Inventory Image'
-            run: |
-              docker build . --tag ghcr.io/mendableai/firecrawl:latest
-              docker push ghcr.io/mendableai/firecrawl:latest
+      - name: 'Build and Push API Image'
+        run: |
+          docker build . --tag ghcr.io/${{ github.repository_owner }}/firecrawl:latest
+          docker push ghcr.io/${{ github.repository_owner }}/firecrawl:latest
+
+  push-playwright-service-ts-image:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: './apps/playwright-service-ts'
+    steps:
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@main
+
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Build and Push Playwright Service TS Image'
+        run: |
+          docker build . --tag ghcr.io/${{ github.repository_owner }}/firecrawl-playwright-service-ts:latest
+          docker push ghcr.io/${{ github.repository_owner }}/firecrawl-playwright-service-ts:latest


### PR DESCRIPTION
**Title:**  
Update deploy-image.yml: Use GitHub repo variables and add playwright-service-ts image build

**Description:**  
- Replaced hardcoded image names with `${{ github.repository_owner }}` for portability across forks and organizations.
- Added a new job to build and push the `apps/playwright-service-ts` Docker image to GHCR alongside the API image.
- Trigger workflow on changes to either `apps/api` or `apps/playwright-service-ts`.