### PR TITLE
fix: PLAYWRIGHT_MICROSERVICE_URL in apps/api/.env.example

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,7 +4,7 @@ PORT=3002
 HOST=0.0.0.0
 REDIS_URL=redis://redis:6379 #for self-hosting using docker, use redis://redis:6379. For running locally, use redis://localhost:6379
 REDIS_RATE_LIMIT_URL=redis://redis:6379 #for self-hosting using docker, use redis://redis:6379. For running locally, use redis://localhost:6379
-PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/html
+PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/scrape
 
 ## To turn on DB authentication, you need to set up supabase.
 USE_DB_AUTHENTICATION=true


### PR DESCRIPTION
The correct environment variable should be PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/scrape instead of PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/html

Using the /html endpoint causes a 404 error when calling http://localhost:3002/v1/scrape in self-hosted deployments. Looking at the source code for the playwright-service the actual endpoint is /scrape, not/html.