### PR TITLE
feat(scrape): support Google Slides

### DIFF
--- a/apps/api/src/__tests__/snips/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/scrape.test.ts
@@ -777,6 +777,15 @@ describe("Scrape tests", () => {
 
         expect(response.markdown).toContain("This is a test to confirm Google Docs scraping abilities.");
       }, 310000);
+
+      it.concurrent("scrapes Google Slides links as PDFs", async () => {
+        const response = await scrape({
+          url: "https://docs.google.com/presentation/d/1pDKL1UULpr6siq_eVWE1hjqt5MKCgSSuKS_MWahnHAQ/view",
+          timeout: 300000,
+        });
+
+        expect(response.markdown).toContain("This is a test to confirm Google Slides scraping abilities.");
+      }, 310000);
     });
   }
 

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -163,6 +163,11 @@ async function buildMetaObject(
     if (id) {
       rewrittenUrl = `https://docs.google.com/document/d/${id}/export?format=pdf`;
     }
+  } else if (url.startsWith("https://docs.google.com/presentation/d/") || url.startsWith("http://docs.google.com/presentation/d/")) {
+    const id = url.match(/\/presentation\/d\/([-\w]+)/)?.[1];
+    if (id) {
+      rewrittenUrl = `https://docs.google.com/presentation/d/${id}/export?format=pdf`;
+    }
   }
 
   return {


### PR DESCRIPTION
- Add a similar implementation like Google Docs for Google Slides, so we will also be able to scrape Google Slides links