### PR TITLE
fix(v1): check credits variable scope collision

### DIFF
--- a/apps/api/src/routes/v1.ts
+++ b/apps/api/src/routes/v1.ts
@@ -38,9 +38,10 @@ import { tokenUsageController } from "../controllers/v1/token-usage";
 import { ongoingCrawlsController } from "../controllers/v1/crawl-ongoing";
 
 function checkCreditsMiddleware(
-  minimum?: number,
+  _minimum?: number,
 ): (req: RequestWithAuth, res: Response, next: NextFunction) => void {
   return (req, res, next) => {
+    let minimum = _minimum;
     (async () => {
       if (!minimum && req.body) {
         minimum =


### PR DESCRIPTION
This is what’s been causing the weird insufficient credits errors.