### PR TITLE
fix(logger): correct method names in logger.child calls

### DIFF
--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -343,7 +343,7 @@ export async function lockURLs(
   const logger = _logger.child({
     crawlId: id,
     module: "crawl-redis",
-    method: "lockURL",
+    method: "lockURLs",
     teamId: sc.team_id,
   });
 

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -322,7 +322,7 @@ export async function scrapeURLWithFireEnginePlaywright(
   let response = await performFireEngineScrape(
     meta,
     meta.logger.child({
-      method: "scrapeURLWithFireEngineChromeCDP/callFireEngine",
+      method: "scrapeURLWithFireEnginePlaywright/callFireEngine",
       request,
     }),
     request,
@@ -383,7 +383,7 @@ export async function scrapeURLWithFireEngineTLSClient(
   let response = await performFireEngineScrape(
     meta,
     meta.logger.child({
-      method: "scrapeURLWithFireEngineChromeCDP/callFireEngine",
+      method: "scrapeURLWithFireEngineTLSClient/callFireEngine",
       request,
     }),
     request,


### PR DESCRIPTION
## Changes
- Fixed incorrect function names passed to `logger.child()`.