### PR TITLE
fix(auto_charge): bad hourly counter logic

### DIFF
--- a/apps/api/src/services/billing/auto_charge.ts
+++ b/apps/api/src/services/billing/auto_charge.ts
@@ -185,6 +185,7 @@ export async function autoCharge(
                 await redisRateLimitClient.expire(
                   hourlyCounterKey,
                   HOURLY_COUNTER_EXPIRY,
+                  "NX",
                 );
 
                 try {


### PR DESCRIPTION
"Increment hourly counter and set expiry if it doesn't exist” is untrue — the command used just sets the expiry over and over again every time it’s called. Added “NX” to alter to intended behaviour.