### PR TITLE
Fix protocol change in firecrawl services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,6 +66,7 @@ services:
       HOST: "0.0.0.0"
       PORT: ${INTERNAL_PORT:-3002}
       FLY_PROCESS_GROUP: app
+      ENV: local
     depends_on:
       - redis
       - playwright-service
@@ -78,6 +79,7 @@ services:
     environment:
       <<: *common-env
       FLY_PROCESS_GROUP: worker
+      ENV: local
     depends_on:
       - redis
       - playwright-service


### PR DESCRIPTION
Add `ENV: local` to docker-compose services to ensure correct HTTP protocol in API response URLs.

The API code checks `process.env.ENV === "local"` to determine whether to use the request's protocol or force `https://`. Without `ENV=local` set in the Docker environment, the API incorrectly defaults to `https://` in response URLs, even for `http://` requests.