### PR TITLE
fix: replace hardcoded Gemini models with configurable environment va…

### DIFF
--- a/apps/api/src/lib/extract/completions/batchExtract.ts
+++ b/apps/api/src/lib/extract/completions/batchExtract.ts
@@ -74,8 +74,8 @@ export async function batchExtractPromise(options: BatchExtractOptions, logger: 
     },
     markdown: buildDocument(doc),
     isExtractEndpoint: true,
-    model: getModel("gemini-2.5-pro", "vertex"),
-    retryModel: getModel("gemini-2.5-pro", "google"),
+    model: getModel(process.env.MODEL_NAME || "gpt-4o-mini"),
+    retryModel: getModel("gpt-4o"),
     costTrackingOptions: {
       costTracking: options.costTracking,
       metadata: {

--- a/apps/api/src/lib/extract/completions/singleAnswer.ts
+++ b/apps/api/src/lib/extract/completions/singleAnswer.ts
@@ -51,8 +51,8 @@ export async function singleAnswerCompletion({
     },
     markdown: `${singleAnswerDocs.map((x, i) => `[START_PAGE (ID: ${i})]` + buildDocument(x)).join("\n")} [END_PAGE]\n`,
     isExtractEndpoint: true,
-    model: getModel("gemini-2.5-pro", "vertex"),
-    retryModel: getModel("gemini-2.5-pro", "google"),
+    model: getModel(process.env.MODEL_NAME || "gpt-4o-mini"),
+    retryModel: getModel("gpt-4o"),
     costTrackingOptions: {
       costTracking,
       metadata: {

--- a/apps/api/src/lib/extract/reranker.ts
+++ b/apps/api/src/lib/extract/reranker.ts
@@ -298,8 +298,8 @@ export async function rerankLinksWithLLM(
           let completion: any;
           try {
             const completionPromise = generateCompletions({
-              model: getModel("gemini-2.5-pro", "vertex"),
-              retryModel: getModel("gemini-2.5-pro", "google"),
+              model: getModel(process.env.MODEL_NAME || "gpt-4o-mini"),
+              retryModel: getModel("gpt-4o"),
               logger: logger.child({
                 method: "rerankLinksWithLLM",
                 chunk: chunkIndex + 1,

--- a/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
@@ -361,8 +361,8 @@ export async function extractData({
           const newExtractOptions = {
             ...extractOptions,
             markdown: markdown,
-            model: getModel("gemini-2.5-pro", "vertex"),
-            retryModel: getModel("gemini-2.5-pro", "google"),
+            model: getModel(process.env.MODEL_NAME || "gpt-4o-mini"),
+            retryModel: getModel("gpt-4o"),
             costTrackingOptions: {
               costTracking: extractOptions.costTrackingOptions.costTracking,
               metadata: {


### PR DESCRIPTION
…riables

This commit addresses a critical issue where Gemini models were hardcoded in multiple extraction endpoints, preventing users from using their configured OpenAI or other LLM providers.

Changes:
- Replace hardcoded "gemini-2.5-pro" with process.env.MODEL_NAME || "gpt-4o-mini"
- Replace hardcoded retry models with "gpt-4o"
- Affects 4 files: singleAnswer.ts, batchExtract.ts, reranker.ts, extractSmartScrape.ts

Fixes issues #1467, #1256, #1379, #1294 where users reported 500 errors due to missing Gemini credentials when trying to use the extract endpoint with OpenAI configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)