### PR TITLE
fix(crawl-status): keep working even if jobs are ejected from bullmq

### DIFF
--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -769,11 +769,13 @@ const workerFun = async (
       }
 
       async function afterJobDone(job: Job<any, any, string>) {
-        if (job.id) {
-          runningJobs.delete(job.id);
+        try {
+          await concurrentJobDone(job);
+        } finally {
+          if (job.id) {
+            runningJobs.delete(job.id);
+          }
         }
-
-        await concurrentJobDone(job);
       }
 
       if (job.data && job.data.sentry && Sentry.isInitialized()) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved crawl status reporting so it continues to work even if jobs are removed from BullMQ.

- **Bug Fixes**
 - Added a fallback to fetch job statuses from the database when BullMQ data is missing.
 - Ensured job cleanup logic always runs, even if errors occur.

<!-- End of auto-generated description by cubic. -->

