### PR TITLE
feat(types): add JSON schema validation to schema options in extractO…

### DIFF
--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -95,7 +95,23 @@ export type AgentOptions = z.infer<typeof agentOptionsExtract>;
 export const extractOptions = z
   .object({
     mode: z.enum(["llm"]).default("llm"),
-    schema: z.any().optional(),
+    schema: z
+      .any()
+      .optional()
+      .refine(
+        (val) => {
+          if (!val) return true; // Allow undefined schema
+          try {
+            const validate = ajv.compile(val);
+            return typeof validate === "function";
+          } catch (e) {
+            return false;
+          }
+        },
+        {
+          message: "Invalid JSON schema.",
+        },
+      ),
     systemPrompt: z
       .string()
       .max(10000)
@@ -112,7 +128,23 @@ export const extractOptions = z
 export const extractOptionsWithAgent = z
   .object({
     mode: z.enum(["llm"]).default("llm"),
-    schema: z.any().optional(),
+    schema: z
+      .any()
+      .optional()
+      .refine(
+        (val) => {
+          if (!val) return true; // Allow undefined schema
+          try {
+            const validate = ajv.compile(val);
+            return typeof validate === "function";
+          } catch (e) {
+            return false;
+          }
+        },
+        {
+          message: "Invalid JSON schema.",
+        },
+      ),
     systemPrompt: z
       .string()
       .max(10000)
@@ -286,7 +318,23 @@ const baseScrapeOptions = z
     changeTrackingOptions: z
       .object({
         prompt: z.string().optional(),
-        schema: z.any().optional(),
+        schema: z
+          .any()
+          .optional()
+          .refine(
+            (val) => {
+              if (!val) return true; // Allow undefined schema
+              try {
+                const validate = ajv.compile(val);
+                return typeof validate === "function";
+              } catch (e) {
+                return false;
+              }
+            },
+            {
+              message: "Invalid JSON schema.",
+            },
+          ),
         modes: z.enum(["json", "git-diff"]).array().optional().default([]),
         tag: z.string().or(z.null()).default(null),
       })


### PR DESCRIPTION
…ptions and baseScrapeOptions

@micahstairs we're now using the same avj to validate every json schemas

@mogery can you pls take a look?
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added JSON schema validation to the schema fields in extractOptions and baseScrapeOptions to ensure only valid schemas are accepted.

- **Validation**
 - Now checks that provided schemas compile with ajv, returning an error if invalid.

<!-- End of auto-generated description by cubic. -->

