### PR TITLE
Add a couple exceptions to our blocked list

### DIFF
--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -94,6 +94,7 @@ const allowedKeywords = [
   "://developers.facebook.com",
   "://developers.meta.com",
   "://facebook.com/ads/library",
+  "://www.facebook.com/ads/library",
   "://meta.com/experiences",
 ];
 

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -92,8 +92,9 @@ const allowedKeywords = [
   "://ads.tiktok.com",
   "://tiktok.com/business",
   "://developers.facebook.com",
+  "://developers.meta.com",
   "://facebook.com/ads/library",
-  "://www.facebook.com/ads/library",
+  "://meta.com/experiences",
 ];
 
 export function decryptedBlocklist(list: string[]): string[] {
@@ -104,7 +105,7 @@ export function decryptedBlocklist(list: string[]): string[] {
 
 export function isUrlBlocked(url: string, flags: TeamFlags): boolean {
   const lowerCaseUrl = url.trim().toLowerCase();
-  
+
   let blockedlist = decryptedBlocklist(urlBlocklist);
 
   if (flags?.unblockedDomains) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added "developers.meta.com" and "meta.com/experiences" as exceptions to the blocked list so these URLs are now allowed.

<!-- End of auto-generated description by cubic. -->

