### PR TITLE
feat: modified docker image to be runable by any UID

### DIFF
--- a/apps/playwright-service-ts/Dockerfile
+++ b/apps/playwright-service-ts/Dockerfile
@@ -6,6 +6,8 @@ RUN npm install
 
 COPY . .
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/tmp/.cache
+
 # Install Playwright dependencies
 RUN npx playwright install --with-deps
 


### PR DESCRIPTION
## Motivation
I would like to run firecrawl on OpenShift. By default, OpenShift enforces random UID on pods. Therefore, running playwright as a pod on OpenShift resulted an permission denied error, regarding the browser installation location, like the one below:

```
> playwright-scraper-api@1.0.0 start
> node dist/api.js

node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^

browserType.launch: Executable doesn't exist at /home/<user>/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell
╔═════════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just installed or updated. ║
║ Please run the following command to download new browsers:              ║
║                                                                         ║
║     npx playwright install                                              ║
║                                                                         ║
║ <3 Playwright Team                                                      ║
╚═════════════════════════════════════════════════════════════════════════╝
    at /usr/src/app/dist/api.js:47:43
    at /usr/src/app/dist/api.js:8:71
    at __awaiter (/usr/src/app/dist/api.js:4:12)
    at initializeBrowser (/usr/src/app/dist/api.js:46:33)
    at Server.<anonymous> (/usr/src/app/dist/api.js:214:5) {
  name: 'Error'
}

Node.js v18.20.8
```

The reason is the installed playwright browser were installed on the `root` home directory (`/root/.cache`) which is inaccessible to any other users. This PR changes the browser installation to a directory with permissions for everyone (`/tmp/.cache`), so this image can be ran using any UID. This is done by leveraging the `PLAYWRIGHT_BROWSERS_PATH` playwright environment variable which determines the browser installation path.

## Testing
I have tested this with both user root and some random UID, both seems to work fine, and firecrawl seems to be working fine as well (using the provided docker compose with sample crawl query).
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the Docker image so it can run as any user by setting the Playwright browser path to a shared directory.

- **Dependencies**
  - Set PLAYWRIGHT_BROWSERS_PATH to /tmp/.cache to allow browser installation for all UIDs.

<!-- End of auto-generated description by cubic. -->

