### PR TITLE
(feat/rtxt) Improved robots control on scrape via flags 

### DIFF
--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -74,6 +74,7 @@ export async function scrapeController(
         unnormalizedSourceURL: preNormalizedBody.url,
         bypassBilling: isDirectToBullMQ,
         zeroDataRetention,
+        teamFlags: req.acuc?.flags ?? null,
       },
       origin,
       integration: req.body.integration,

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1044,6 +1044,7 @@ export type TeamFlags = {
   forceZDR?: boolean;
   allowZDR?: boolean;
   zdrCost?: number;
+  checkRobotsOnScrape?: boolean;
 } | null;
 
 export type AuthCreditUsageChunkFromTeam = Omit<AuthCreditUsageChunk, "api_key">;

--- a/apps/api/src/lib/robots-txt.ts
+++ b/apps/api/src/lib/robots-txt.ts
@@ -1,0 +1,99 @@
+import robotsParser, { Robot } from "robots-parser";
+import axios from "axios";
+import { axiosTimeout } from "./timeout";
+import https from "https";
+import { Logger } from "winston";
+
+export interface RobotsTxtChecker {
+  robotsTxtUrl: string;
+  robotsTxt: string;
+  robots: Robot;
+}
+
+export async function fetchRobotsTxt(
+  url: string,
+  skipTlsVerification: boolean = false,
+  abort?: AbortSignal,
+): Promise<string> {
+  const urlObj = new URL(url);
+  const robotsTxtUrl = `${urlObj.protocol}//${urlObj.host}/robots.txt`;
+
+  let extraArgs: any = {};
+  if (skipTlsVerification) {
+    extraArgs.httpsAgent = new https.Agent({
+      rejectUnauthorized: false,
+    });
+  }
+
+  const response = await axios.get(robotsTxtUrl, {
+    timeout: axiosTimeout,
+    signal: abort,
+    ...extraArgs,
+  });
+
+  return response.data;
+}
+
+export function createRobotsChecker(
+  url: string,
+  robotsTxt: string,
+): RobotsTxtChecker {
+  const urlObj = new URL(url);
+  const robotsTxtUrl = `${urlObj.protocol}//${urlObj.host}/robots.txt`;
+  const robots = robotsParser(robotsTxtUrl, robotsTxt);
+  return {
+    robotsTxtUrl,
+    robotsTxt,
+    robots,
+  };
+}
+
+export function isUrlAllowedByRobots(
+  url: string,
+  robots: Robot | null,
+  userAgents: string[] = ["FireCrawlAgent", "FirecrawlAgent"],
+): boolean {
+  if (!robots) return true;
+
+  for (const userAgent of userAgents) {
+    let isAllowed = robots.isAllowed(url, userAgent);
+
+    // Also check with trailing slash if URL doesn't have one
+    // This catches cases like "Disallow: /path/" when user requests "/path"
+    if (isAllowed && !url.endsWith("/")) {
+      const urlWithSlash = url + "/";
+      const isAllowedWithSlash = robots.isAllowed(urlWithSlash, userAgent);
+      // If the trailing slash version is explicitly disallowed, block it
+      if (!isAllowedWithSlash) {
+        isAllowed = false;
+      }
+    }
+
+    if (isAllowed) {
+      //   console.log("isAllowed: true, " + userAgent);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export async function checkRobotsTxt(
+  url: string,
+  skipTlsVerification: boolean = false,
+  logger?: Logger,
+  abort?: AbortSignal,
+): Promise<boolean> {
+  try {
+    const robotsTxt = await fetchRobotsTxt(url, skipTlsVerification, abort);
+    const checker = createRobotsChecker(url, robotsTxt);
+    return isUrlAllowedByRobots(url, checker.robots);
+  } catch (error) {
+    // If we can't fetch robots.txt, assume it's allowed
+    logger?.debug("Failed to fetch robots.txt, allowing scrape", {
+      error,
+      url,
+    });
+    return true;
+  }
+}

--- a/apps/api/src/lib/robots-txt.ts
+++ b/apps/api/src/lib/robots-txt.ts
@@ -57,14 +57,21 @@ export function isUrlAllowedByRobots(
 
   for (const userAgent of userAgents) {
     let isAllowed = robots.isAllowed(url, userAgent);
+    
+    // Handle null/undefined responses - default to true (allowed)
+    if (isAllowed === null || isAllowed === undefined) {
+      isAllowed = true;
+    }
 
     // Also check with trailing slash if URL doesn't have one
     // This catches cases like "Disallow: /path/" when user requests "/path"
     if (isAllowed && !url.endsWith("/")) {
       const urlWithSlash = url + "/";
       const isAllowedWithSlash = robots.isAllowed(urlWithSlash, userAgent);
-      // If the trailing slash version is explicitly disallowed, block it
-      if (!isAllowedWithSlash) {
+      
+      // Handle null/undefined responses for trailing slash check
+      if (isAllowedWithSlash === false) {
+        // Only block if explicitly disallowed (not null/undefined)
         isAllowed = false;
       }
     }

--- a/apps/api/src/main/runWebScraper.ts
+++ b/apps/api/src/main/runWebScraper.ts
@@ -5,7 +5,7 @@ import {
   RunWebScraperResult,
 } from "../types";
 import { billTeam } from "../services/billing/credit_billing";
-import { Document } from "../controllers/v1/types";
+import { Document, TeamFlags } from "../controllers/v1/types";
 import { supabase_service } from "../services/supabase";
 import { logger as _logger } from "../lib/logger";
 import { configDotenv } from "dotenv";

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -92,8 +92,10 @@ const allowedKeywords = [
   "://ads.tiktok.com",
   "://tiktok.com/business",
   "://developers.facebook.com",
+  "://developers.meta.com",
   "://facebook.com/ads/library",
   "://www.facebook.com/ads/library",
+  "://meta.com/experiences",
 ];
 
 export function decryptedBlocklist(list: string[]): string[] {
@@ -104,7 +106,7 @@ export function decryptedBlocklist(list: string[]): string[] {
 
 export function isUrlBlocked(url: string, flags: TeamFlags): boolean {
   const lowerCaseUrl = url.trim().toLowerCase();
-  
+
   let blockedlist = decryptedBlocklist(urlBlocklist);
 
   if (flags?.unblockedDomains) {

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -1,8 +1,8 @@
 import { Logger } from "winston";
 import * as Sentry from "@sentry/node";
 
-import { Document, ScrapeOptions, TimeoutSignal } from "../../controllers/v1/types";
-import { logger as _logger } from "../../lib/logger";
+import { Document, ScrapeOptions, TimeoutSignal, TeamFlags } from "../../controllers/v1/types";
+import { logger as _logger, logger } from "../../lib/logger";
 import {
   buildFallbackList,
   Engine,
@@ -35,6 +35,7 @@ import { urlSpecificParams } from "./lib/urlSpecificParams";
 import { loadMock, MockState } from "./lib/mock";
 import { CostTracking } from "../../lib/extract/extraction-service";
 import { addIndexRFInsertJob, generateDomainSplits, hashURL, index_supabase_service, normalizeURLForIndex, useIndex } from "../../services/index";
+import { checkRobotsTxt } from "../../lib/robots-txt";
 
 export type ScrapeUrlResponse = (
   | {
@@ -220,6 +221,7 @@ export type InternalOptions = {
   saveScrapeResultToGCS?: boolean; // Passed along to fire-engine
   bypassBilling?: boolean;
   zeroDataRetention?: boolean;
+  teamFlags?: TeamFlags;
 };
 
 export type EngineResultsTracker = {
@@ -503,6 +505,31 @@ export async function scrapeURL(
 
   if (meta.rewrittenUrl) {
     meta.logger.info("Rewriting URL");
+  }
+
+  if (internalOptions.teamFlags?.checkRobotsOnScrape) {
+    logger.info("Checking robots.txt", {
+      checkRobotsOnScrape: internalOptions.teamFlags?.checkRobotsOnScrape,
+      url: meta.rewrittenUrl || meta.url,
+    });
+    const urlToCheck = meta.rewrittenUrl || meta.url;
+    const isAllowed = await checkRobotsTxt(
+      urlToCheck, 
+      options.skipTlsVerification, 
+      meta.logger,
+      internalOptions.abort
+    );
+
+    
+    if (!isAllowed) {
+      meta.logger.info("URL blocked by robots.txt", { url: urlToCheck });
+      return {
+        success: false,
+        error: new Error("URL blocked by robots.txt"),
+        logs: meta.logs,
+        engines: meta.results,
+      };
+    }
   }
 
   const shouldRecordFrequency = useIndex

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -508,7 +508,7 @@ export async function scrapeURL(
   }
 
   if (internalOptions.teamFlags?.checkRobotsOnScrape) {
-    logger.info("Checking robots.txt", {
+    meta.logger.info("Checking robots.txt", {
       checkRobotsOnScrape: internalOptions.teamFlags?.checkRobotsOnScrape,
       url: meta.rewrittenUrl || meta.url,
     });

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -1159,6 +1159,7 @@ async function processJob(job: Job & { id: string }, token: string) {
       }
     }
 
+
     const pipeline = await Promise.race([
       startWebScraperPipeline({
         job,

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -76,7 +76,6 @@ export interface RunWebScraperParams {
   is_crawl?: boolean;
   urlInvisibleInCurrentCrawl?: boolean;
   costTracking: CostTracking;
-  teamFlags?: TeamFlags;
 }
 
 export type RunWebScraperResult =

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -5,6 +5,7 @@ import {
   ScrapeOptions,
   Document as V1Document,
   webhookSchema,
+  TeamFlags,
 } from "./controllers/v1/types";
 import { ExtractorOptions, Document } from "./lib/entities";
 import { InternalOptions } from "./scraper/scrapeURL";
@@ -75,6 +76,7 @@ export interface RunWebScraperParams {
   is_crawl?: boolean;
   urlInvisibleInCurrentCrawl?: boolean;
   costTracking: CostTracking;
+  teamFlags?: TeamFlags;
 }
 
 export type RunWebScraperResult =


### PR DESCRIPTION
# Fix robots.txt handling to allow URLs when robots.txt doesn't exist

## Summary

Fixed a bug in the `isUrlAllowedByRobots` function where URLs were incorrectly blocked when the target site had no robots.txt file (404 response). This was causing billing tests to fail when crawling `firecrawl.dev` URLs.

**Root Cause**: The refactored `isUrlAllowedByRobots` function in `robots-txt.ts` was missing null/undefined handling that existed in the original WebCrawler logic. When robots.txt doesn't exist, `robots.isAllowed()` returns `null`, but the new function treated this as `false` and blocked the URLs.

**Fix**: Added explicit null checks (`isAllowed == null`) with default behavior of `true`, matching the original `?? true` fallback logic.

## Review & Testing Checklist for Human

- [ ] **Test the original failing scenario**: Run the billing tests that crawl `firecrawl.dev` URLs to verify they now pass
- [ ] **Verify legitimate robots.txt blocking still works**: Test against a site with actual robots.txt restrictions to ensure blocking functionality isn't broken  
- [ ] **Test edge cases**: Verify behavior with empty robots.txt files, malformed content, and different user agents
- [ ] **Run full test suite**: Ensure no regressions in other robots.txt related functionality

**⚠️ Important**: I was unable to test locally due to Redis environment issues, so this fix relies on CI validation. Please verify the specific failing tests now pass.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["apps/api/src/__tests__/snips/<br/>billing.test.ts"]:::context --> B["WebCrawler<br/>crawler.ts"]:::context
    B --> C["isUrlAllowedByRobots()<br/>robots-txt.ts"]:::major-edit
    C --> D["robots.isAllowed()"]:::context
    
    E["firecrawl.dev<br/>(no robots.txt - 404)"]:::context --> C
    
    C --> F["OLD: returned false<br/>NEW: returns true"]:::major-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit    
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The fix is minimal and targeted - only adds null checks to handle missing robots.txt files
- Original failing tests showed "URL blocked by robots.txt" errors for firecrawl.dev URLs despite no robots.txt file existing
- This maintains security by still respecting actual robots.txt restrictions when they exist
- Session: https://app.devin.ai/sessions/563fc74310a84bb3929cfd434b4ee842, requested by Nick (@nickscamara)