### PR TITLE
Improve error handling in Python SDK for non-JSON responses

### DIFF
--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -13,7 +13,7 @@ import os
 
 from .firecrawl import FirecrawlApp, AsyncFirecrawlApp, JsonConfig, ScrapeOptions, ChangeTrackingOptions # noqa
 
-__version__ = "2.16.3"
+__version__ = "2.16.4"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/firecrawl.py
+++ b/apps/python-sdk/firecrawl/firecrawl.py
@@ -2349,7 +2349,7 @@ class FirecrawlApp:
                 else:
                     error_message = f"Server returned empty response with status {response.status_code}"
                     error_details = "No additional details available"
-            except:
++        except ValueError:
                 error_message = f"Server returned unreadable response with status {response.status_code}"
                 error_details = "No additional details available"
         

--- a/apps/python-sdk/firecrawl/firecrawl.py
+++ b/apps/python-sdk/firecrawl/firecrawl.py
@@ -2336,10 +2336,22 @@ class FirecrawlApp:
             Exception: An exception with a message containing the status code and error details from the response.
         """
         try:
-            error_message = response.json().get('error', 'No error message provided.')
-            error_details = response.json().get('details', 'No additional error details provided.')
+            response_json = response.json()
+            error_message = response_json.get('error', 'No error message provided.')
+            error_details = response_json.get('details', 'No additional error details provided.')
         except:
-            raise requests.exceptions.HTTPError(f'Failed to parse Firecrawl error response as JSON. Status code: {response.status_code}', response=response)
+            # If we can't parse JSON, provide a helpful error message with response content
+            try:
+                response_text = response.text[:500]  # Limit to first 500 chars
+                if response_text.strip():
+                    error_message = f"Server returned non-JSON response: {response_text}"
+                    error_details = f"Full response status: {response.status_code}"
+                else:
+                    error_message = f"Server returned empty response with status {response.status_code}"
+                    error_details = "No additional details available"
+            except:
+                error_message = f"Server returned unreadable response with status {response.status_code}"
+                error_details = "No additional details available"
         
         message = self._get_error_message(response.status_code, action, error_message, error_details)
 
@@ -2362,7 +2374,7 @@ class FirecrawlApp:
         if status_code == 402:
             return f"Payment Required: Failed to {action}. {error_message} - {error_details}"
         elif status_code == 403:
-            message = f"Website Not Supported: Failed to {action}. {error_message} - {error_details}"
+            return f"Website Not Supported: Failed to {action}. {error_message} - {error_details}"
         elif status_code == 408:
             return f"Request Timeout: Failed to {action} as the request timed out. {error_message} - {error_details}"
         elif status_code == 409:


### PR DESCRIPTION
- Enhanced _handle_error method to gracefully handle non-JSON server responses
- Added fallback error messages when JSON parsing fails
- Improved error details with response content preview (limited to 500 chars)
- Fixed return statement bug in _get_error_message for 403 status code
- Better user experience when server returns HTML error pages or empty responses
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved error handling in the Python SDK to show clearer messages when the server returns non-JSON or empty responses.

- **Bug Fixes**
  - Added fallback error messages with a preview of the server response when JSON parsing fails.
  - Fixed a bug in the 403 error message logic.

<!-- End of auto-generated description by cubic. -->

