### PR TITLE
fix(crawl): only extend URLs at pre-finish if changeTracking is on (ENG-2900)

### DIFF
--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -149,7 +149,7 @@ async function finishCrawlIfNeeded(job: Job & { id: string }, sc: StoredCrawl) {
 
       let lastUrls: string[] = [];
       const useDbAuthentication = process.env.USE_DB_AUTHENTICATION === "true";
-      if (useDbAuthentication) {
+      if (useDbAuthentication && sc.scrapeOptions.formats.includes("changeTracking")) {
         lastUrls = (
           (
             await supabase_service.rpc("diff_get_last_crawl_urls", {


### PR DESCRIPTION
better perf
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Crawl jobs now only extend URLs at the pre-finish step if change tracking is enabled, improving performance.

<!-- End of auto-generated description by cubic. -->

