### PR TITLE
fix(queue-worker): improve stalled job cleaner (ENG-2907)

### DIFF
--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -1636,8 +1636,8 @@ app.listen(workerPort, () => {
         return;
       }
 
-      let logger = _logger.child({ jobId: args.jobId, scrapeId: args.jobId, module: "queue-worker", method: "failedListener" });
       const job = await getScrapeQueue().getJob(args.jobId);
+      let logger = _logger.child({ jobId: args.jobId, scrapeId: args.jobId, module: "queue-worker", method: "failedListener", zeroDataRetention: job?.data.zeroDataRetention });
       if (job && job.data.crawl_id) {
         logger = logger.child({ crawlId: job.data.crawl_id });
         logger.warn("Job stalled more than allowable limit");


### PR DESCRIPTION
- only clean 1 job once (lock via eviction redis)
- clean up kickoff jobs correctly
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved the stalled job cleaner to ensure each stalled job is only cleaned once and to handle kickoff jobs correctly.

- **Bug Fixes**
  - Added a Redis lock to prevent duplicate cleaning of the same stalled job.
  - Fixed cleanup logic for kickoff jobs to ensure proper completion.

<!-- End of auto-generated description by cubic. -->

