### PR TITLE
fix(crawler/sitemap): improvements

### DIFF
--- a/apps/api/sharedLibs/crawler/src/lib.rs
+++ b/apps/api/sharedLibs/crawler/src/lib.rs
@@ -220,7 +220,10 @@ pub unsafe extern "C" fn filter_links(data: *const libc::c_char) -> *mut libc::c
 }
 
 fn _parse_sitemap_xml(xml_content: &str) -> Result<ParsedSitemap, Box<dyn std::error::Error>> {
-    let doc = roxmltree::Document::parse(xml_content)?;
+    let doc = roxmltree::Document::parse_with_options(
+        xml_content,
+        roxmltree::ParsingOptions { allow_dtd: true, ..Default::default() },
+    )?;
     let root = doc.root_element();
     
     match root.tag_name().name() {

--- a/apps/api/src/scraper/WebScraper/sitemap.ts
+++ b/apps/api/src/scraper/WebScraper/sitemap.ts
@@ -109,6 +109,11 @@ export async function getLinksFromSitemap(
       try {
         parsed = await parseSitemapXml(content);
       } catch (parseError) {
+        logger.warn("Rust XML parsing failed, falling back to JavaScript logic", {
+          method: "getLinksFromSitemap",
+          sitemapUrl,
+          error: parseError.message,
+        });
         parsed = await parseStringPromise(content);
       }
       


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved sitemap XML parsing by allowing DTDs in the Rust parser and adding a JavaScript fallback with better error logging.

- **Bug Fixes**
  - Enabled DTD support in Rust XML parsing to handle more sitemap formats.
  - Added warning logs and a JavaScript fallback if Rust parsing fails.

<!-- End of auto-generated description by cubic. -->

