### PR TITLE
fix(worker/antistall/kickoff): bad check (ENG-2936)

### DIFF
--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -1644,7 +1644,7 @@ app.listen(workerPort, () => {
 
         const sc = (await getCrawl(job.data.crawl_id)) as StoredCrawl;
 
-        if (job.mode === "kickoff") {
+        if (job.data.mode === "kickoff") {
           await finishCrawlKickoff(job.data.crawl_id);
           if (sc) {
             await finishCrawlIfNeeded(job, sc);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a bug where the kickoff mode check in the queue worker used the wrong property, which could prevent proper crawl completion.

<!-- End of auto-generated description by cubic. -->

