### PR TITLE
fix(queue-service): get rid of done billing jobs much faster

### DIFF
--- a/apps/api/src/services/queue-service.ts
+++ b/apps/api/src/services/queue-service.ts
@@ -104,7 +104,7 @@ export function getBillingQueue() {
       connection: redisConnection,
       defaultJobOptions: {
         removeOnComplete: {
-          age: 3600, // 1 hour
+          age: 60, // 1 minute
         },
         removeOnFail: {
           age: 3600, // 1 hour


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reduced the retention time for completed billing jobs in the queue from 1 hour to 1 minute to clear finished jobs faster.

<!-- End of auto-generated description by cubic. -->

