### PR TITLE
Fixes #1870: correct maxConcurrency calculation

### DIFF
--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -99,7 +99,7 @@ export async function crawlController(
     }, // NOTE: smart wait disabled for crawls to ensure contentful scrape, speed does not matter
     team_id: req.auth.team_id,
     createdAt: Date.now(),
-    maxConcurrency: req.body.maxConcurrency !== undefined ? Math.min(req.body.maxConcurrency, req.acuc.concurrency) : undefined,
+    maxConcurrency: req.body.maxConcurrency !== undefined ? (req.acuc?.concurrency !== undefined ? Math.min(req.body.maxConcurrency, req.acuc.concurrency) : req.body.maxConcurrency) : undefined,
     zeroDataRetention,
   };
 


### PR DESCRIPTION
* Adjusted the logic for determining `maxConcurrency` to ensure it respects the `req.acuc.concurrency` value when defined.
* This change prevents potential issues with exceeding allowed concurrency limits during crawls.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the maxConcurrency calculation in crawlController to always respect the allowed concurrency limit when set, preventing crawls from exceeding it.

<!-- End of auto-generated description by cubic. -->

