### PR TITLE
fix(html-to-markdown): reinitialize converter lib for every conversion (ENG-2956)

### DIFF
--- a/apps/api/src/lib/html-to-markdown.ts
+++ b/apps/api/src/lib/html-to-markdown.ts
@@ -17,7 +17,6 @@ const goExecutablePath = join(
 );
 
 class GoMarkdownConverter {
-  private static instance: GoMarkdownConverter;
   private convert: any;
 
   private constructor() {
@@ -26,15 +25,12 @@ class GoMarkdownConverter {
   }
 
   public static async getInstance(): Promise<GoMarkdownConverter> {
-    if (!GoMarkdownConverter.instance) {
-      try {
-        await stat(goExecutablePath);
-      } catch (_) {
-        throw Error("Go shared library not found");
-      }
-      GoMarkdownConverter.instance = new GoMarkdownConverter();
+    try {
+      await stat(goExecutablePath);
+    } catch (_) {
+      throw Error("Go shared library not found");
     }
-    return GoMarkdownConverter.instance;
+    return new GoMarkdownConverter();
   }
 
   public async convertHTMLToMarkdown(html: string): Promise<string> {


### PR DESCRIPTION
creating a new converter on the same instance is prone to crashing due to race conditions
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed race conditions in the HTML-to-Markdown converter by creating a new converter instance for each conversion. This prevents crashes when multiple conversions run at the same time.

<!-- End of auto-generated description by cubic. -->

