### PR TITLE
fix(crawl-status): move count_jobs_of_crawl_team after checks

### DIFF
--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -312,7 +312,7 @@ export async function crawlStatusController(
 
     if (scrapeJobError || !scrapeJobCounts || scrapeJobCounts.length === 0) {
       logger.error("Error getting scrape job count", { error: scrapeJobError });
-      throw scrapeJobError;
+      throw (scrapeJobError ?? new Error("Unknown error getting scrape job count"));
     }
 
     const scrapeJobCount: number = scrapeJobCounts[0].count ?? 0;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the count_jobs_of_crawl_team RPC call to after crawl job checks in the crawl status controller to prevent unnecessary database queries and errors.

<!-- End of auto-generated description by cubic. -->

