### PR TITLE
fix(go): add mutex to prevent concurrent access issues in html-to-markdown

### DIFF
--- a/apps/api/sharedLibs/go-html-to-md/html-to-markdown.go
+++ b/apps/api/sharedLibs/go-html-to-md/html-to-markdown.go
@@ -5,6 +5,7 @@ package main
 */
 import "C"
 import (
+	"sync"
 	"unsafe"
 	// "log"
 
@@ -12,8 +13,13 @@ import (
 	"github.com/tomkosm/html-to-markdown/plugin"
 )
 
+var mutex sync.Mutex
+
 //export ConvertHTMLToMarkdown
 func ConvertHTMLToMarkdown(html *C.char) *C.char {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	converter := md.NewConverter("", true, nil)
 	converter.Use(plugin.GitHubFlavored())
 


### PR DESCRIPTION
Adds global mutex to serialize all calls to ConvertHTMLToMarkdown function
to prevent race conditions and heap corruption that was causing runtime panics.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a global mutex to the ConvertHTMLToMarkdown function to prevent race conditions and runtime panics caused by concurrent access.

- **Bug Fixes**
  - Serializes all calls to ConvertHTMLToMarkdown to avoid heap corruption.

<!-- End of auto-generated description by cubic. -->

