### PR TITLE
fix(crawl-redis): attempt to cleanup crawl memory post finish

### DIFF
--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -200,6 +200,10 @@ export async function finishCrawl(id: string, __logger: Logger = _logger) {
     await redisEvictConnection.srem("crawls_by_team_id:" + crawl.team_id, id);
     await redisEvictConnection.expire("crawls_by_team_id:" + crawl.team_id, 24 * 60 * 60);
   }
+
+  // Clear visited sets to save memory
+  await redisEvictConnection.del("crawl:" + id + ":visited");
+  await redisEvictConnection.del("crawl:" + id + ":visited_unique");
 }
 
 export async function getCrawlJobs(id: string): Promise<string[]> {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Cleared crawl-related Redis memory by deleting visited sets after a crawl finishes to reduce memory usage.

<!-- End of auto-generated description by cubic. -->

