### PR TITLE
fix(js-sdk): remove $schema property from Zod-converted schema (#1836)

### DIFF
--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -1500,9 +1500,6 @@ export default class FirecrawlApp {
           ) {
             delete jsonSchema.$schema;
           }
-          console.log(
-            "✅ Applied manual Zod-to-JSON conversion and removed $schema for workaround test."
-          );
         } catch (_) {
           // If conversion fails, assume it's already a JSON schema object
           jsonSchema = params.schema;


### PR DESCRIPTION
This PR fixes issue #1836.

**The Problem:**
When you tried to use a Zod schema with the `extract` function in the JS SDK, it didn't work and returned empty data `{}`. The reason is that the tool used to convert the Zod schema (`zod-to-json-schema`) automatically adds a `$schema` property. The Firecrawl backend doesn't like this extra property and rejects the request.

**The Solution:**
I changed the code in `src/index.ts` for both the `extract` and `asyncExtract` functions. Right after the Zod schema is converted to a regular JSON schema, I added a small piece of code to check if the `$schema` property is there, and if it is, it deletes it. This matches the workaround that the person who reported the bug found.

Here's the code I added:
```typescript
// Inside the schema processing try...catch block in both extract and asyncExtract
try {
  jsonSchema = zodToJsonSchema(params.schema as zt.ZodType);
  // My fix: Remove the $schema property if it was added
  if (jsonSchema && typeof jsonSchema === 'object' && jsonSchema.$schema) {
    delete jsonSchema.$schema;
  }
} catch (_) {
  jsonSchema = params.schema;
}
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed extract and asyncExtract functions in the JS SDK to remove the $schema property from Zod-converted schemas, preventing backend errors when using Zod schemas.

- **Bug Fixes**
  - Strips the $schema property after converting Zod schemas to JSON schema before sending to the backend, matching the workaround in issue #1836.

<!-- End of auto-generated description by cubic. -->

