### PR TITLE
feat(v2): Add viewport parameter for screenshots

### DIFF
--- a/apps/api/src/__tests__/snips/v2-scrape-viewport.test.ts
+++ b/apps/api/src/__tests__/snips/v2-scrape-viewport.test.ts
@@ -4,174 +4,180 @@ import { Identity, idmux } from "./lib";
 const TEST_URL = process.env.TEST_URL || "http://127.0.0.1:3002";
 
 describe("V2 Scrape Screenshot Viewport", () => {
-  let identity: Identity;
+  if (!process.env.TEST_SUITE_SELF_HOSTED) {
+    let identity: Identity;
 
-  beforeAll(async () => {
-    identity = await idmux({
-      name: "v2-scrape-viewport",
-      concurrency: 100,
-      credits: 1000000,
+    beforeAll(async () => {
+      identity = await idmux({
+        name: "v2-scrape-viewport",
+        concurrency: 100,
+        credits: 1000000,
+      });
+    }, 10000);
+
+    test("should take screenshot with custom viewport dimensions", async () => {
+      const response = await request(TEST_URL)
+        .post("/v2/scrape")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          url: "https://example.com",
+          formats: [
+            "markdown",
+            {
+              type: "screenshot",
+              viewport: {
+                width: 1920,
+                height: 1080
+              }
+            }
+          ],
+          timeout: 30000,
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toBeDefined();
+      expect(response.body.data.screenshot).toBeDefined();
+      expect(response.body.data.markdown).toBeDefined();
+    }, 60000);
+
+    test("should take full page screenshot with custom viewport width", async () => {
+      const response = await request(TEST_URL)
+        .post("/v2/scrape")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          url: "https://example.com",
+          formats: [
+            {
+              type: "screenshot",
+              fullPage: true,
+              viewport: {
+                width: 1440,
+                height: 900
+              }
+            }
+          ],
+          timeout: 30000,
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toBeDefined();
+      expect(response.body.data.screenshot).toBeDefined();
+    }, 60000);
+
+    test("should work with screenshot format without viewport (backwards compatibility)", async () => {
+      const response = await request(TEST_URL)
+        .post("/v2/scrape")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          url: "https://example.com",
+          formats: ["screenshot"],
+          timeout: 30000,
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toBeDefined();
+      expect(response.body.data.screenshot).toBeDefined();
+    }, 60000);
+
+    test("should work with object screenshot format without viewport", async () => {
+      const response = await request(TEST_URL)
+        .post("/v2/scrape")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          url: "https://example.com",
+          formats: [
+            {
+              type: "screenshot",
+              fullPage: false
+            }
+          ],
+          timeout: 30000,
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toBeDefined();
+      expect(response.body.data.screenshot).toBeDefined();
+    }, 60000);
+
+    test("should reject invalid viewport dimensions", async () => {
+      const response = await request(TEST_URL)
+        .post("/v2/scrape")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          url: "https://example.com",
+          formats: [
+            {
+              type: "screenshot",
+              viewport: {
+                width: -100,
+                height: 0
+              }
+            }
+          ],
+          timeout: 30000,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+    }, 60000);
+
+    test("should reject non-integer viewport dimensions", async () => {
+      const response = await request(TEST_URL)
+        .post("/v2/scrape")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          url: "https://example.com",
+          formats: [
+            {
+              type: "screenshot",
+              viewport: {
+                width: "1920",
+                height: 1080.5
+              }
+            }
+          ],
+          timeout: 30000,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+    }, 60000);
+
+    test("should reject viewport dimensions exceeding maximum limits", async () => {
+      const response = await request(TEST_URL)
+        .post("/v2/scrape")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          url: "https://example.com",
+          formats: [
+            {
+              type: "screenshot",
+              viewport: {
+                width: 8000, // exceeds max of 7680
+                height: 5000 // exceeds max of 4320
+              }
+            }
+          ],
+          timeout: 30000,
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+    }, 60000);
+  } else {
+    it("mocked", () => {
+      expect(true).toBe(true);
     });
-  }, 10000);
-
-  test("should take screenshot with custom viewport dimensions", async () => {
-    const response = await request(TEST_URL)
-      .post("/v2/scrape")
-      .set("Authorization", `Bearer ${identity.apiKey}`)
-      .set("Content-Type", "application/json")
-      .send({
-        url: "https://example.com",
-        formats: [
-          "markdown",
-          {
-            type: "screenshot",
-            viewport: {
-              width: 1920,
-              height: 1080
-            }
-          }
-        ],
-        timeout: 30000,
-      });
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-    expect(response.body.data).toBeDefined();
-    expect(response.body.data.screenshot).toBeDefined();
-    expect(response.body.data.markdown).toBeDefined();
-  }, 60000);
-
-  test("should take full page screenshot with custom viewport width", async () => {
-    const response = await request(TEST_URL)
-      .post("/v2/scrape")
-      .set("Authorization", `Bearer ${identity.apiKey}`)
-      .set("Content-Type", "application/json")
-      .send({
-        url: "https://example.com",
-        formats: [
-          {
-            type: "screenshot",
-            fullPage: true,
-            viewport: {
-              width: 1440,
-              height: 900
-            }
-          }
-        ],
-        timeout: 30000,
-      });
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-    expect(response.body.data).toBeDefined();
-    expect(response.body.data.screenshot).toBeDefined();
-  }, 60000);
-
-  test("should work with screenshot format without viewport (backwards compatibility)", async () => {
-    const response = await request(TEST_URL)
-      .post("/v2/scrape")
-      .set("Authorization", `Bearer ${identity.apiKey}`)
-      .set("Content-Type", "application/json")
-      .send({
-        url: "https://example.com",
-        formats: ["screenshot"],
-        timeout: 30000,
-      });
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-    expect(response.body.data).toBeDefined();
-    expect(response.body.data.screenshot).toBeDefined();
-  }, 60000);
-
-  test("should work with object screenshot format without viewport", async () => {
-    const response = await request(TEST_URL)
-      .post("/v2/scrape")
-      .set("Authorization", `Bearer ${identity.apiKey}`)
-      .set("Content-Type", "application/json")
-      .send({
-        url: "https://example.com",
-        formats: [
-          {
-            type: "screenshot",
-            fullPage: false
-          }
-        ],
-        timeout: 30000,
-      });
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-    expect(response.body.data).toBeDefined();
-    expect(response.body.data.screenshot).toBeDefined();
-  }, 60000);
-
-  test("should reject invalid viewport dimensions", async () => {
-    const response = await request(TEST_URL)
-      .post("/v2/scrape")
-      .set("Authorization", `Bearer ${identity.apiKey}`)
-      .set("Content-Type", "application/json")
-      .send({
-        url: "https://example.com",
-        formats: [
-          {
-            type: "screenshot",
-            viewport: {
-              width: -100,
-              height: 0
-            }
-          }
-        ],
-        timeout: 30000,
-      });
-
-    expect(response.status).toBe(400);
-    expect(response.body.success).toBe(false);
-  }, 60000);
-
-  test("should reject non-integer viewport dimensions", async () => {
-    const response = await request(TEST_URL)
-      .post("/v2/scrape")
-      .set("Authorization", `Bearer ${identity.apiKey}`)
-      .set("Content-Type", "application/json")
-      .send({
-        url: "https://example.com",
-        formats: [
-          {
-            type: "screenshot",
-            viewport: {
-              width: "1920",
-              height: 1080.5
-            }
-          }
-        ],
-        timeout: 30000,
-      });
-
-    expect(response.status).toBe(400);
-    expect(response.body.success).toBe(false);
-  }, 60000);
-
-  test("should reject viewport dimensions exceeding maximum limits", async () => {
-    const response = await request(TEST_URL)
-      .post("/v2/scrape")
-      .set("Authorization", `Bearer ${identity.apiKey}`)
-      .set("Content-Type", "application/json")
-      .send({
-        url: "https://example.com",
-        formats: [
-          {
-            type: "screenshot",
-            viewport: {
-              width: 8000, // exceeds max of 7680
-              height: 5000 // exceeds max of 4320
-            }
-          }
-        ],
-        timeout: 30000,
-      });
-
-    expect(response.status).toBe(400);
-    expect(response.body.success).toBe(false);
-  }, 60000);
+  }
 });

--- a/apps/api/src/__tests__/snips/v2-scrape-viewport.test.ts
+++ b/apps/api/src/__tests__/snips/v2-scrape-viewport.test.ts
@@ -151,4 +151,27 @@ describe("V2 Scrape Screenshot Viewport", () => {
     expect(response.status).toBe(400);
     expect(response.body.success).toBe(false);
   }, 60000);
+
+  test("should reject viewport dimensions exceeding maximum limits", async () => {
+    const response = await request(TEST_URL)
+      .post("/v2/scrape")
+      .set("Authorization", `Bearer ${identity.apiKey}`)
+      .set("Content-Type", "application/json")
+      .send({
+        url: "https://example.com",
+        formats: [
+          {
+            type: "screenshot",
+            viewport: {
+              width: 8000, // exceeds max of 7680
+              height: 5000 // exceeds max of 4320
+            }
+          }
+        ],
+        timeout: 30000,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  }, 60000);
 });

--- a/apps/api/src/__tests__/snips/v2-scrape-viewport.test.ts
+++ b/apps/api/src/__tests__/snips/v2-scrape-viewport.test.ts
@@ -1,0 +1,154 @@
+import request from "supertest";
+import { Identity, idmux } from "./lib";
+
+const TEST_URL = process.env.TEST_URL || "http://127.0.0.1:3002";
+
+describe("V2 Scrape Screenshot Viewport", () => {
+  let identity: Identity;
+
+  beforeAll(async () => {
+    identity = await idmux({
+      name: "v2-scrape-viewport",
+      concurrency: 100,
+      credits: 1000000,
+    });
+  }, 10000);
+
+  test("should take screenshot with custom viewport dimensions", async () => {
+    const response = await request(TEST_URL)
+      .post("/v2/scrape")
+      .set("Authorization", `Bearer ${identity.apiKey}`)
+      .set("Content-Type", "application/json")
+      .send({
+        url: "https://example.com",
+        formats: [
+          "markdown",
+          {
+            type: "screenshot",
+            viewport: {
+              width: 1920,
+              height: 1080
+            }
+          }
+        ],
+        timeout: 30000,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.data.screenshot).toBeDefined();
+    expect(response.body.data.markdown).toBeDefined();
+  }, 60000);
+
+  test("should take full page screenshot with custom viewport width", async () => {
+    const response = await request(TEST_URL)
+      .post("/v2/scrape")
+      .set("Authorization", `Bearer ${identity.apiKey}`)
+      .set("Content-Type", "application/json")
+      .send({
+        url: "https://example.com",
+        formats: [
+          {
+            type: "screenshot",
+            fullPage: true,
+            viewport: {
+              width: 1440,
+              height: 900
+            }
+          }
+        ],
+        timeout: 30000,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.data.screenshot).toBeDefined();
+  }, 60000);
+
+  test("should work with screenshot format without viewport (backwards compatibility)", async () => {
+    const response = await request(TEST_URL)
+      .post("/v2/scrape")
+      .set("Authorization", `Bearer ${identity.apiKey}`)
+      .set("Content-Type", "application/json")
+      .send({
+        url: "https://example.com",
+        formats: ["screenshot"],
+        timeout: 30000,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.data.screenshot).toBeDefined();
+  }, 60000);
+
+  test("should work with object screenshot format without viewport", async () => {
+    const response = await request(TEST_URL)
+      .post("/v2/scrape")
+      .set("Authorization", `Bearer ${identity.apiKey}`)
+      .set("Content-Type", "application/json")
+      .send({
+        url: "https://example.com",
+        formats: [
+          {
+            type: "screenshot",
+            fullPage: false
+          }
+        ],
+        timeout: 30000,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toBeDefined();
+    expect(response.body.data.screenshot).toBeDefined();
+  }, 60000);
+
+  test("should reject invalid viewport dimensions", async () => {
+    const response = await request(TEST_URL)
+      .post("/v2/scrape")
+      .set("Authorization", `Bearer ${identity.apiKey}`)
+      .set("Content-Type", "application/json")
+      .send({
+        url: "https://example.com",
+        formats: [
+          {
+            type: "screenshot",
+            viewport: {
+              width: -100,
+              height: 0
+            }
+          }
+        ],
+        timeout: 30000,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  }, 60000);
+
+  test("should reject non-integer viewport dimensions", async () => {
+    const response = await request(TEST_URL)
+      .post("/v2/scrape")
+      .set("Authorization", `Bearer ${identity.apiKey}`)
+      .set("Content-Type", "application/json")
+      .send({
+        url: "https://example.com",
+        formats: [
+          {
+            type: "screenshot",
+            viewport: {
+              width: "1920",
+              height: 1080.5
+            }
+          }
+        ],
+        timeout: 30000,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  }, 60000);
+});

--- a/apps/api/src/__tests__/snips/v2-system-prompt-rejection.test.ts
+++ b/apps/api/src/__tests__/snips/v2-system-prompt-rejection.test.ts
@@ -13,58 +13,64 @@ async function scrapeV2Raw(body: ScrapeRequestInput, identity: Identity) {
 }
 
 describe("V2 System Prompt Rejection", () => {
-  let identity: Identity;
-
-  beforeAll(async () => {
-    identity = await idmux({
-      name: "v2-system-prompt-rejection",
-      concurrency: 100,
-      credits: 1000000,
+  if (!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL) {
+    let identity: Identity;
+    
+    beforeAll(async () => {
+      identity = await idmux({
+        name: "v2-system-prompt-rejection",
+        concurrency: 100,
+        credits: 1000000,
+      });
     });
-  });
 
-  it("should reject systemPrompt in json format options for v2 scrape", async () => {
-    const response = await scrapeV2Raw(
-      {
-        url: "https://example.com",
-        formats: [
-          {
-            type: "json",
-            schema: {
-              type: "object",
-              properties: { title: { type: "string" } },
+    it("should reject systemPrompt in json format options for v2 scrape", async () => {
+      const response = await scrapeV2Raw(
+        {
+          url: "https://example.com",
+          formats: [
+            {
+              type: "json",
+              schema: {
+                type: "object",
+                properties: { title: { type: "string" } },
+              },
+              systemPrompt: "Custom system prompt that should be rejected",
             },
-            systemPrompt: "Custom system prompt that should be rejected",
-          },
-        ],
-      } as any,
-      identity,
-    );
+          ],
+        } as any,
+        identity,
+      );
 
-    expect(response.statusCode).toBe(400);
-    expect(response.body.success).toBe(false);
-    expect(response.body.error).toBe("Bad Request");
-  });
+      expect(response.statusCode).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe("Bad Request");
+    });
 
-  it("should accept valid json format options without systemPrompt", async () => {
-    const response = await scrapeV2Raw(
-      {
-        url: "https://example.com",
-        formats: [
-          {
-            type: "json",
-            schema: {
-              type: "object",
-              properties: { title: { type: "string" } },
+    it("should accept valid json format options without systemPrompt", async () => {
+      const response = await scrapeV2Raw(
+        {
+          url: "https://example.com",
+          formats: [
+            {
+              type: "json",
+              schema: {
+                type: "object",
+                properties: { title: { type: "string" } },
+              },
+              prompt: "Extract the title",
             },
-            prompt: "Extract the title",
-          },
-        ],
-      } as any,
-      identity,
-    );
+          ],
+        } as any,
+        identity,
+      );
 
-    expect(response.statusCode).toBe(200);
-    expect(response.body.success).toBe(true);
-  });
+      expect(response.statusCode).toBe(200);
+      expect(response.body.success).toBe(true);
+    });
+  } else {
+    it("mocked", () => {
+      expect(true).toBe(true);
+    });
+  }
 });

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -131,6 +131,10 @@ export const actionSchema = z
       type: z.literal("screenshot"),
       fullPage: z.boolean().default(false),
       quality: z.number().min(1).max(100).optional(),
+      viewport: z.object({
+        width: z.number().int().positive().finite().max(7680), // 8K resolution width
+        height: z.number().int().positive().finite().max(4320), // 8K resolution height
+      }).optional(),
     }),
     z.object({
       type: z.literal("write"),

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -197,6 +197,10 @@ export const screenshotFormatWithOptions = z.object({
   type: z.literal("screenshot"),
   fullPage: z.boolean().default(false),
   quality: z.number().min(1).max(100).optional(),
+  viewport: z.object({
+    width: z.number().int().positive().finite(),
+    height: z.number().int().positive().finite(),
+  }).optional(),
 });
 
 export type ScreenshotFormatWithOptions = z.output<typeof screenshotFormatWithOptions>;

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -198,8 +198,8 @@ export const screenshotFormatWithOptions = z.object({
   fullPage: z.boolean().default(false),
   quality: z.number().min(1).max(100).optional(),
   viewport: z.object({
-    width: z.number().int().positive().finite(),
-    height: z.number().int().positive().finite(),
+    width: z.number().int().positive().finite().max(7680), // 8K resolution width
+    height: z.number().int().positive().finite().max(4320), // 8K resolution height
   }).optional(),
 });
 

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -190,10 +190,6 @@ export async function scrapeURLWithFireEngineChromeCDP(
   meta: Meta,
   timeToRun: number | undefined,
 ): Promise<EngineScrapeResult> {
-  // Extract viewport from screenshot format options
-  const screenshotFormat = meta.options.formats.find(x => typeof x === "object" && x.type === "screenshot");
-  const viewport = screenshotFormat?.viewport;
-
   const actions: Action[] = [
     // Transform waitFor option into an action (unsupported by chrome-cdp)
     ...(meta.options.waitFor !== 0
@@ -217,6 +213,8 @@ export async function scrapeURLWithFireEngineChromeCDP(
             type: "screenshot" as const,
             fullPage: meta.options.formats.includes("screenshot@fullPage") || 
                      meta.options.formats.find(x => typeof x === "object" && x.type === "screenshot")?.fullPage || false,
+            ...(meta.options.formats.find(x => typeof x === "object" && x.type === "screenshot")?.viewport ? 
+              { viewport: meta.options.formats.find(x => typeof x === "object" && x.type === "screenshot")?.viewport } : {}),
           },
         ]
       : []),
@@ -252,10 +250,6 @@ export async function scrapeURLWithFireEngineChromeCDP(
     mobileProxy: meta.featureFlags.has("stealthProxy"),
     saveScrapeResultToGCS: !meta.internalOptions.zeroDataRetention && meta.internalOptions.saveScrapeResultToGCS,
     zeroDataRetention: meta.internalOptions.zeroDataRetention,
-    ...(viewport ? {
-      screenshotWidth: viewport.width,
-      screenshotHeight: viewport.height,
-    } : {}),
   };
 
   if (shouldABTest) {
@@ -353,10 +347,6 @@ export async function scrapeURLWithFireEnginePlaywright(
   meta: Meta,
   timeToRun: number | undefined,
 ): Promise<EngineScrapeResult> {
-  // Extract viewport from screenshot format options
-  const screenshotFormat = meta.options.formats.find(x => typeof x === "object" && x.type === "screenshot");
-  const viewport = screenshotFormat?.viewport;
-
   const totalWait = meta.options.waitFor;
   const timeout = (timeToRun ?? 300000) + totalWait;
 
@@ -380,10 +370,6 @@ export async function scrapeURLWithFireEnginePlaywright(
     timeout,
     saveScrapeResultToGCS: !meta.internalOptions.zeroDataRetention && meta.internalOptions.saveScrapeResultToGCS,
     zeroDataRetention: meta.internalOptions.zeroDataRetention,
-    ...(viewport ? {
-      screenshotWidth: viewport.width,
-      screenshotHeight: viewport.height,
-    } : {}),
   };
 
   let response = await performFireEngineScrape(

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -190,6 +190,10 @@ export async function scrapeURLWithFireEngineChromeCDP(
   meta: Meta,
   timeToRun: number | undefined,
 ): Promise<EngineScrapeResult> {
+  // Extract viewport from screenshot format options
+  const screenshotFormat = meta.options.formats.find(x => typeof x === "object" && x.type === "screenshot");
+  const viewport = screenshotFormat?.viewport;
+
   const actions: Action[] = [
     // Transform waitFor option into an action (unsupported by chrome-cdp)
     ...(meta.options.waitFor !== 0
@@ -248,6 +252,10 @@ export async function scrapeURLWithFireEngineChromeCDP(
     mobileProxy: meta.featureFlags.has("stealthProxy"),
     saveScrapeResultToGCS: !meta.internalOptions.zeroDataRetention && meta.internalOptions.saveScrapeResultToGCS,
     zeroDataRetention: meta.internalOptions.zeroDataRetention,
+    ...(viewport ? {
+      screenshotWidth: viewport.width,
+      screenshotHeight: viewport.height,
+    } : {}),
   };
 
   if (shouldABTest) {
@@ -345,6 +353,10 @@ export async function scrapeURLWithFireEnginePlaywright(
   meta: Meta,
   timeToRun: number | undefined,
 ): Promise<EngineScrapeResult> {
+  // Extract viewport from screenshot format options
+  const screenshotFormat = meta.options.formats.find(x => typeof x === "object" && x.type === "screenshot");
+  const viewport = screenshotFormat?.viewport;
+
   const totalWait = meta.options.waitFor;
   const timeout = (timeToRun ?? 300000) + totalWait;
 
@@ -368,6 +380,10 @@ export async function scrapeURLWithFireEnginePlaywright(
     timeout,
     saveScrapeResultToGCS: !meta.internalOptions.zeroDataRetention && meta.internalOptions.saveScrapeResultToGCS,
     zeroDataRetention: meta.internalOptions.zeroDataRetention,
+    ...(viewport ? {
+      screenshotWidth: viewport.width,
+      screenshotHeight: viewport.height,
+    } : {}),
   };
 
   let response = await performFireEngineScrape(

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -40,6 +40,8 @@ export type FireEngineScrapeRequestChromeCDP = {
   blockMedia?: true; // cannot be false
   mobile?: boolean;
   disableSmartWaitCache?: boolean;
+  screenshotWidth?: number;
+  screenshotHeight?: number;
 };
 
 export type FireEngineScrapeRequestPlaywright = {
@@ -51,6 +53,8 @@ export type FireEngineScrapeRequestPlaywright = {
   fullPageScreenshot?: boolean;
 
   wait?: number; // default: 0
+  screenshotWidth?: number;
+  screenshotHeight?: number;
 };
 
 export type FireEngineScrapeRequestTLSClient = {

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -40,8 +40,6 @@ export type FireEngineScrapeRequestChromeCDP = {
   blockMedia?: true; // cannot be false
   mobile?: boolean;
   disableSmartWaitCache?: boolean;
-  screenshotWidth?: number;
-  screenshotHeight?: number;
 };
 
 export type FireEngineScrapeRequestPlaywright = {
@@ -53,8 +51,6 @@ export type FireEngineScrapeRequestPlaywright = {
   fullPageScreenshot?: boolean;
 
   wait?: number; // default: 0
-  screenshotWidth?: number;
-  screenshotHeight?: number;
 };
 
 export type FireEngineScrapeRequestTLSClient = {


### PR DESCRIPTION
## Summary
- Adds optional viewport parameter to screenshot format options
- Passes viewport dimensions to fire-engine as `screenshotWidth` and `screenshotHeight`
- Maintains backwards compatibility with string screenshot format

## Changes
- Updated `screenshotFormatWithOptions` schema to include optional viewport with width/height
- Modified ChromeCDP integration to extract viewport and pass dimensions to fire-engine
- Modified Playwright integration to extract viewport and pass dimensions to fire-engine  
- Added comprehensive E2E tests covering happy paths and error cases

## Test plan
- [x] Added E2E tests for viewport functionality
- [x] Tests cover custom viewport dimensions
- [x] Tests cover full page screenshots with custom viewport
- [x] Tests verify backwards compatibility
- [x] Tests validate error handling for invalid dimensions

Resolves: [ENG-2926](https://linear.app/firecrawl/issue/ENG-2926)

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an optional viewport parameter to screenshot format options in v2 scrape, allowing custom screenshot dimensions and passing them to the fire-engine. This keeps backwards compatibility and covers all cases required by ENG-2926.

- **New Features**
  - Supports custom width and height for screenshots via a new viewport option.
  - Passes viewport dimensions to both ChromeCDP and Playwright engines.

- **Bug Fixes**
  - Validates viewport input and returns errors for invalid or non-integer dimensions.

<!-- End of auto-generated description by cubic. -->

