### PR TITLE
Fix v1 API JSON/extract format backward compatibility on v2

### DIFF
--- a/apps/api/src/__tests__/snips/v1-json-extract-format.test.ts
+++ b/apps/api/src/__tests__/snips/v1-json-extract-format.test.ts
@@ -1,0 +1,175 @@
+import { scrape, scrapeTimeout, idmux, Identity } from "./lib";
+
+let identity: Identity;
+
+beforeAll(async () => {
+  identity = await idmux({
+    name: "v1-json-extract-format",
+    concurrency: 100,
+    credits: 1000000,
+  });
+}, 10000 + scrapeTimeout);
+
+describe("V1 JSON/Extract Format Backward Compatibility", () => {
+  describe("extract format", () => {
+    it.concurrent("should return extracted data in 'extract' field when using format='extract'", async () => {
+      const response = await scrape({
+        url: "https://jsonplaceholder.typicode.com/posts/1",
+        formats: ["extract"],
+        extract: {
+          schema: {
+            type: "object",
+            properties: {
+              userId: { type: "number" },
+              id: { type: "number" },
+              title: { type: "string" },
+              body: { type: "string" }
+            },
+            required: ["userId", "id", "title", "body"]
+          }
+        },
+        timeout: scrapeTimeout,
+      }, identity);
+
+      // Data should be in extract field, not json field
+      expect(response.extract).toBeDefined();
+      expect(response.json).toBeUndefined();
+      expect(response.extract.userId).toBe(1);
+      expect(response.extract.id).toBe(1);
+      expect(response.extract.title).toBeDefined();
+      expect(response.extract.body).toBeDefined();
+    }, scrapeTimeout);
+
+    it.concurrent("should work with extract format and custom prompt", async () => {
+      const response = await scrape({
+        url: "https://example.com",
+        formats: ["extract"],
+        extract: {
+          prompt: "Extract the main heading and domain name from the page",
+          schema: {
+            type: "object", 
+            properties: {
+              mainHeading: { type: "string" },
+              domain: { type: "string" }
+            },
+            required: ["mainHeading", "domain"]
+          }
+        },
+        timeout: scrapeTimeout,
+      }, identity);
+
+      // Data should be in extract field, not json field
+      expect(response.extract).toBeDefined();
+      expect(response.json).toBeUndefined();
+      expect(response.extract.mainHeading).toBeDefined();
+      expect(response.extract.domain).toBe("example.com");
+    }, scrapeTimeout);
+  });
+
+  describe("json format", () => {
+    it.concurrent("should return extracted data in 'json' field when using format='json'", async () => {
+      const response = await scrape({
+        url: "https://jsonplaceholder.typicode.com/posts/1",
+        formats: ["json"],
+        jsonOptions: {
+          schema: {
+            type: "object",
+            properties: {
+              userId: { type: "number" },
+              id: { type: "number" },
+              title: { type: "string" },
+              body: { type: "string" }
+            },
+            required: ["userId", "id", "title", "body"]
+          }
+        },
+        timeout: scrapeTimeout,
+      }, identity);
+
+      // Data should be in json field, not extract field
+      expect(response.json).toBeDefined();
+      expect(response.extract).toBeUndefined();
+      expect(response.json.userId).toBe(1);
+      expect(response.json.id).toBe(1);
+      expect(response.json.title).toBeDefined();
+      expect(response.json.body).toBeDefined();
+    }, scrapeTimeout);
+
+    it.concurrent("should work with json format and custom prompt", async () => {
+      const response = await scrape({
+        url: "https://example.com",
+        formats: ["json"],
+        jsonOptions: {
+          prompt: "Extract the main heading and domain name from the page",
+          schema: {
+            type: "object",
+            properties: {
+              mainHeading: { type: "string" },
+              domain: { type: "string" }
+            },
+            required: ["mainHeading", "domain"]
+          }
+        },
+        timeout: scrapeTimeout,
+      }, identity);
+
+      // Data should be in json field, not extract field
+      expect(response.json).toBeDefined();
+      expect(response.extract).toBeUndefined();
+      expect(response.json.mainHeading).toBeDefined();
+      expect(response.json.domain).toBe("example.com");
+    }, scrapeTimeout);
+  });
+
+  describe("multiple formats", () => {
+    it.concurrent("should return markdown and extracted data in correct fields", async () => {
+      const response = await scrape({
+        url: "https://example.com",
+        formats: ["markdown", "extract"],
+        extract: {
+          schema: {
+            type: "object",
+            properties: {
+              mainHeading: { type: "string" },
+              hasLinks: { type: "boolean" }
+            },
+            required: ["mainHeading", "hasLinks"]
+          }
+        },
+        timeout: scrapeTimeout,
+      }, identity);
+
+      // Both markdown and extract should be present
+      expect(response.markdown).toBeDefined();
+      expect(response.extract).toBeDefined();
+      expect(response.json).toBeUndefined();
+      expect(response.extract.mainHeading).toBeDefined();
+      expect(typeof response.extract.hasLinks).toBe("boolean");
+    }, scrapeTimeout);
+
+    it.concurrent("should return markdown and json data in correct fields", async () => {
+      const response = await scrape({
+        url: "https://example.com", 
+        formats: ["markdown", "json"],
+        jsonOptions: {
+          schema: {
+            type: "object",
+            properties: {
+              mainHeading: { type: "string" },
+              hasLinks: { type: "boolean" }
+            },
+            required: ["mainHeading", "hasLinks"]
+          }
+        },
+        timeout: scrapeTimeout,
+      }, identity);
+
+      // Both markdown and json should be present
+      expect(response.markdown).toBeDefined();
+      expect(response.json).toBeDefined();
+      expect(response.extract).toBeUndefined();
+      expect(response.json.mainHeading).toBeDefined();
+      expect(typeof response.json.hasLinks).toBe("boolean");
+    }, scrapeTimeout);
+  });
+});

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1121,6 +1121,14 @@ export function fromV1ScrapeOptions(
   delete spreadScrapeOptions.geolocation;
   delete (spreadScrapeOptions as any).parsePDF;
   
+  // Track the original format for v1 backward compatibility
+  let v1OriginalFormat: "extract" | "json" | undefined;
+  if (v1ScrapeOptions.formats.includes("extract")) {
+    v1OriginalFormat = "extract";
+  } else if (v1ScrapeOptions.formats.includes("json")) {
+    v1OriginalFormat = "json";
+  }
+  
   return {
     scrapeOptions: scrapeOptions.parse({
       ...spreadScrapeOptions,
@@ -1162,6 +1170,7 @@ export function fromV1ScrapeOptions(
       v1Agent: v1ScrapeOptions.agent,
       v1JSONSystemPrompt: (v1ScrapeOptions.jsonOptions || v1ScrapeOptions.extract)?.systemPrompt,
       v1JSONAgent: (v1ScrapeOptions.jsonOptions || v1ScrapeOptions.extract)?.agent,
+      v1OriginalFormat,
     },
   };
 }

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -236,6 +236,7 @@ export type InternalOptions = {
   v1Agent?: ScrapeOptionsV1["agent"];
   v1JSONAgent?: Exclude<ScrapeOptionsV1["jsonOptions"], undefined>["agent"];
   v1JSONSystemPrompt?: string;
+  v1OriginalFormat?: "extract" | "json"; // Track original v1 format for backward compatibility
 };
 
 export type EngineResultsTracker = {

--- a/apps/api/src/scraper/scrapeURL/transformers/index.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/index.ts
@@ -183,6 +183,7 @@ export function coerceFieldsToFormats(
       "Removed json from Document because it wasn't in formats -- this is extremely wasteful and indicates a bug.",
     );
     delete document.extract;
+    delete document.json;
   } else if (hasJson && document.extract === undefined && document.json === undefined) {
     meta.logger.warn(
       "Request had format json, but there was no json field in the result.",

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -787,7 +787,12 @@ export async function performLLMExtract(
     // }
 
     // Assign the final extracted data
-    document.json = extractedData;
+    // For v1 API backward compatibility, check the original format
+    if (meta.internalOptions.v1OriginalFormat === "extract") {
+      document.extract = extractedData;
+    } else {
+      document.json = extractedData;
+    }
     // document.warning = warning;
   }
 


### PR DESCRIPTION
## Summary
- Fixes backward compatibility issue where v1 API json/extract formats were not placing results in the correct field
- When using format=`extract`, results now go to the `extract` field 
- When using format=`json`, results now go to the `json` field

## Problem
When using the v1 API on the v2 branch (`nsc/v2`), there was a bug where the result of using JSON mode (formats `json` or `extract`) would always put the result in the `json` field on the document, whereas the result should be in the `extract` field if the `extract` format was used.

This was due to the consolidation of both formats into the singular `json` format in the V2 API - the backwards compatibility was not being handled properly.

## Solution
1. Added `v1OriginalFormat` field to `InternalOptions` to track whether the original v1 request was for "extract" or "json" format
2. Updated `performLLMExtract` function to check `v1OriginalFormat` and place the extracted data in the correct field
3. Added comprehensive tests to verify both formats work correctly

## Test plan
- [x] Added v1 API tests for extract format returning data in extract field
- [x] Added v1 API tests for json format returning data in json field  
- [x] Tests verify field placement with various extraction scenarios
- [ ] CI tests pass

Linear Issue: [ENG-3064](https://linear.app/firecrawl/issue/ENG-3064)

🤖 Generated with [Claude Code](https://claude.ai/code)