### PR TITLE
fix: handle UTF-8 encoding properly in Google search scraper

### DIFF
--- a/apps/api/src/search/googlesearch.ts
+++ b/apps/api/src/search/googlesearch.ts
@@ -116,7 +116,7 @@ export async function googleSearch(
       let htmlContent: string;
       try {
         // Try to decode as UTF-8 first
-        htmlContent = new TextDecoder('utf-8').decode(resp.data);
+        htmlContent = new TextDecoder('utf-8', { fatal: true }).decode(resp.data);
       } catch (e) {
         // Fallback to latin1 if UTF-8 fails
         logger.warn("UTF-8 decoding failed, trying latin1");


### PR DESCRIPTION
- Set responseType to arraybuffer to get raw bytes
- Added TextDecoder with charset detection from headers
- Added Unicode normalization (NFC) for text content
- Improved Accept headers for proper encoding negotiation
- Fixes corrupted characters in non-English search results

Before:
<img width="674" height="501" alt="Captura de ecrã 2025-08-06 130428" src="https://github.com/user-attachments/assets/d35ec849-cb64-4783-b3c1-f8727d72657a" />

After:
<img width="672" height="461" alt="Captura de ecrã 2025-08-06 130709" src="https://github.com/user-attachments/assets/d2d24981-ca11-424b-98cf-35d42825eb2d" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed character encoding issues in the Google search scraper to display non-English results correctly.

- **Bug Fixes**
  - Decodes response bytes using the correct charset from headers.
  - Normalizes Unicode text for titles and descriptions.
  - Updates Accept headers to request UTF-8 content.

<!-- End of auto-generated description by cubic. -->

