### PR TITLE
fix: prevent PDF scrapes with parsePDF:false from being indexed

### DIFF
--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -88,10 +88,11 @@ function execForward(fancyName: string, command: string): Promise<void> {
         })(),
     ]);
 
-    console.log("=== Starting API and Worker...");
+    console.log("=== Starting API, Worker, and Index Worker...");
 
     const api = execForward("api", "pnpm start:production:nobuild");
     const worker = execForward("worker", "pnpm worker:production");
+    const indexWorker = execForward("index-worker", "pnpm index-worker:production");
 
     try {
         await Promise.race([
@@ -107,14 +108,17 @@ function execForward(fancyName: string, command: string): Promise<void> {
             cmd,
             api,
             worker,
+            indexWorker,
         ]);
     } finally {
-        console.log("=== Tearing down API and Worker...");
+        console.log("=== Tearing down API, Worker, and Index Worker...");
         exec("pkill -f 'queue-worker.js'");
         exec("pkill -f 'index.js'");
+        exec("pkill -f 'index-worker.js'");
         await Promise.all([
             api,
             worker,
+            indexWorker,
         ]);
     }
     


### PR DESCRIPTION
## Summary
- Added logic to exclude PDF scrapes with `parsePDF:false` from being cached in the index
- Modified cache retrieval to check if cached content matches the `parsePDF` parameter
- Added comprehensive test to verify PDFs with `parsePDF:false` are not indexed

## Problem
When PDF files were scraped with `parsePDF: false`, they would return base64-encoded content. These base64 chunks were being indexed, causing issues for users using `maxAge` as they would receive large base64 strings instead of readable content.

## Solution
1. **Prevent indexing**: Modified `sendDocumentToIndex` to skip caching when `winnerEngine === "pdf"` and `parsePDF === false`
2. **Smart cache retrieval**: The index retrieval now checks if the cached content type matches the requested `parsePDF` setting:
   - If cached content is base64 PDF but `parsePDF:true` is requested → cache miss
   - If cached content is parsed PDF but `parsePDF:false` is requested → cache miss
   - Otherwise → cache hit

## Test Plan
- [x] Added comprehensive test that verifies PDFs with `parsePDF:false` are not indexed
- [x] Test verifies that subsequent requests with `parsePDF:true` correctly parse and cache the PDF
- [x] Test verifies that requests with different `parsePDF` settings don't interfere with each other
- [x] All existing tests pass

Resolves: [ENG-3092](https://linear.app/firecrawl/issue/ENG-3092/pdf-scrapes-with-parsepdf-false-should-not-be-indexed)

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
PDF scrapes with parsePDF:false are no longer indexed, preventing large base64 content from being returned to users when using maxAge. Cache retrieval now checks that the parsePDF setting matches the cached content to avoid mismatches.

- **Bug Fixes**
  - Skipped indexing for PDF scrapes with parsePDF:false.
  - Cache returns a miss if the parsePDF setting does not match the cached content.
  - Added tests to confirm correct cache and indexing behavior for different parsePDF settings.

<!-- End of auto-generated description by cubic. -->

