### PR TITLE
fix(queue-worker): turn off useWorkerThreads in sandboxed scrape worker

### DIFF
--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -348,7 +348,7 @@ const separateWorkerFun = (
   path: string,
 ): Worker => {
   // Extract memory size from --max-old-space-size flag if present
-  const maxOldSpaceSize = process.execArgv
+  const maxOldSpaceSize = process.env.SCRAPE_WORKER_MAX_OLD_SPACE_SIZE || process.execArgv
     .find(arg => arg.startsWith('--max-old-space-size='))
     ?.split('=')[1];
   
@@ -362,7 +362,12 @@ const separateWorkerFun = (
     stalledInterval: 60 * 1000, // 60 seconds
     maxStalledCount: 10, // 10 times
     concurrency: 8,
-    useWorkerThreads: true,
+    useWorkerThreads: false,
+    workerForkOptions: {
+      execArgv: filteredExecArgv.concat(maxOldSpaceSize ? (
+        ['--max-old-space-size=' + maxOldSpaceSize]
+      ) : []),
+    },
     workerThreadsOptions: {
       execArgv: filteredExecArgv,
       resourceLimits: maxOldSpaceSize ? {


### PR DESCRIPTION
This is needed because interaction with NAPI in a worker thread causes segmentation faults. nodejs/node#58484
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Disabled worker threads in the sandboxed scrape worker to prevent segmentation faults when using NAPI.

- **Bug Fixes**
 - Switched to forked processes instead of worker threads for scrape jobs.
 - Updated memory limit handling to support environment variable overrides.

<!-- End of auto-generated description by cubic. -->

