### PR TITLE
feat(api/ai-sdk): add labels to vertex/google calls

### DIFF
--- a/apps/api/src/lib/extract/fire-0/completions/analyzeSchemaAndPrompt-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/completions/analyzeSchemaAndPrompt-f0.ts
@@ -5,7 +5,6 @@ import {
   buildAnalyzeSchemaUserPrompt,
 } from "../../build-prompts";
 import { logger } from "../../../logger";
-import { jsonSchema } from "ai";
 import { getModel } from "../../../generic-ai";
 import {
   generateCompletions_F0,

--- a/apps/api/src/lib/extract/fire-0/llmExtract-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/llmExtract-f0.ts
@@ -207,6 +207,16 @@ export async function generateCompletions_F0({
         prompt: options.prompt + (markdown ? `\n\nData:${markdown}` : ""),
         temperature: options.temperature ?? 0,
         system: options.systemPrompt,
+        providerOptions: {
+          google: {
+            labels: {
+              functionId: metadata.functionId ?? "unspecified",
+              extractId: metadata.extractId ?? "unspecified",
+              scrapeId: metadata.scrapeId ?? "unspecified",
+              teamId: metadata.teamId,
+            }
+          }
+        },
         experimental_telemetry: {
           isEnabled: true,
           functionId: metadata.functionId,
@@ -291,6 +301,16 @@ export async function generateCompletions_F0({
           model: model,
           prompt: `Fix this JSON that had the following error: ${error}\n\nOriginal text:\n${text}\n\nReturn only the fixed JSON, no explanation.`,
           system: "You are a JSON repair expert. Your only job is to fix malformed JSON and return valid JSON that matches the original structure and intent as closely as possible. Do not include any explanation or commentary - only return the fixed JSON. Do not return it in a Markdown code block, just plain JSON.",
+          providerOptions: {
+            google: {
+              labels: {
+                functionId: metadata.functionId ?? "unspecified",
+                extractId: metadata.extractId ?? "unspecified",
+                scrapeId: metadata.scrapeId ?? "unspecified",
+                teamId: metadata.teamId,
+              }
+            }
+          },
           experimental_telemetry: {
             isEnabled: true,
             functionId: metadata.functionId,
@@ -318,6 +338,16 @@ export async function generateCompletions_F0({
           console.error(error);
         }
       }),
+      providerOptions: {
+        google: {
+          labels: {
+            functionId: metadata.functionId ?? "unspecified",
+            extractId: metadata.extractId ?? "unspecified",
+            scrapeId: metadata.scrapeId ?? "unspecified",
+            teamId: metadata.teamId,
+          }
+        }
+      },
       experimental_telemetry: {
         isEnabled: true,
         functionId: metadata.functionId,

--- a/apps/api/src/lib/extract/fire-0/url-processor-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/url-processor-f0.ts
@@ -16,8 +16,18 @@ export async function generateBasicCompletion_FO(prompt: string, metadata: { tea
     model: getModel("gpt-4o"),
     prompt: prompt,
     temperature: 0,
+    providerOptions: {
+      google: {
+        labels: {
+          functionId: "generateBasicCompletion_F0",
+          extractId: metadata.extractId ?? "unspecified",
+          teamId: metadata.teamId,
+        }
+      }
+    },
     experimental_telemetry: {
       isEnabled: true,
+      functionId: "generateBasicCompletion_F0",
       metadata: {
         ...(metadata.extractId ? { langfuseTraceId: "extract:" + metadata.extractId, extractId: metadata.extractId } : {}),
         teamId: metadata.teamId,

--- a/apps/api/src/lib/extract/url-processor.ts
+++ b/apps/api/src/lib/extract/url-processor.ts
@@ -20,9 +20,17 @@ export async function generateBasicCompletion(prompt: string, costTracking: Cost
         anthropic: {
           thinking: { type: "enabled", budgetTokens: 12000 },
         },
+        google: {
+          labels: {
+            functionId: "generateBasicCompletion",
+            teamId: metadata.teamId,
+            extractId: metadata.extractId ?? "unspecified",
+          }
+        }
       },
       experimental_telemetry: {
         isEnabled: true,
+        functionId: "generateBasicCompletion",
         metadata: {
           ...(metadata.extractId ? { langfuseTraceId: "extract:" + metadata.extractId, extractId: metadata.extractId } : {}),
           teamId: metadata.teamId,
@@ -54,6 +62,12 @@ export async function generateBasicCompletion(prompt: string, costTracking: Cost
             anthropic: {
               thinking: { type: "enabled", budgetTokens: 12000 },
             },
+            google: {
+              labels: {
+                teamId: metadata.teamId,
+                extractId: metadata.extractId ?? "unspecified",
+              }
+            }
           },
           experimental_telemetry: {
             isEnabled: true,

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -282,6 +282,16 @@ export async function generateCompletions({
             anthropic: {
               thinking: { type: "enabled", budgetTokens: 12000 },
             },
+            google: {
+              labels: {
+                teamId: metadata.teamId,
+                functionId: metadata.functionId ?? "unspecified",
+                extractId: metadata.extractId ?? "unspecified",
+                scrapeId: metadata.scrapeId ?? "unspecified",
+                deepResearchId: metadata.deepResearchId ?? "unspecified",
+                llmsTxtId: metadata.llmsTxtId ?? "unspecified",
+              }
+            }
           },
           experimental_telemetry: {
             isEnabled: true,
@@ -347,6 +357,16 @@ export async function generateCompletions({
                 anthropic: {
                   thinking: { type: "enabled", budgetTokens: 12000 },
                 },
+                google: {
+                  labels: {
+                    teamId: metadata.teamId,
+                    functionId: metadata.functionId ?? "unspecified",
+                    extractId: metadata.extractId ?? "unspecified",
+                    scrapeId: metadata.scrapeId ?? "unspecified",
+                    deepResearchId: metadata.deepResearchId ?? "unspecified",
+                    llmsTxtId: metadata.llmsTxtId ?? "unspecified",
+                  }
+                }
               },
               experimental_telemetry: {
                 isEnabled: true,
@@ -474,6 +494,16 @@ export async function generateCompletions({
               anthropic: {
                 thinking: { type: "enabled", budgetTokens: 12000 },
               },
+              google: {
+                labels: {
+                  teamId: metadata.teamId,
+                  functionId: metadata.functionId ?? "unspecified",
+                  extractId: metadata.extractId ?? "unspecified",
+                  scrapeId: metadata.scrapeId ?? "unspecified",
+                  deepResearchId: metadata.deepResearchId ?? "unspecified",
+                  llmsTxtId: metadata.llmsTxtId ?? "unspecified",
+                }
+              }
             },
             experimental_telemetry: {
               isEnabled: true,
@@ -518,7 +548,21 @@ export async function generateCompletions({
     const generateObjectConfig = {
       model: currentModel,
       prompt: prompt,
-      providerOptions: providerOptions || undefined,
+      providerOptions: {
+        ...(providerOptions || {}),
+        google: {
+          ...((providerOptions as any)?.vertex || {}),
+          labels: {
+            ...((providerOptions as any)?.vertex?.labels || {}),
+            teamId: metadata.teamId,
+            functionId: metadata.functionId ?? "unspecified",
+            extractId: metadata.extractId ?? "unspecified",
+            scrapeId: metadata.scrapeId ?? "unspecified",
+            deepResearchId: metadata.deepResearchId ?? "unspecified",
+            llmsTxtId: metadata.llmsTxtId ?? "unspecified",
+          }
+        }
+      },
       system: options.systemPrompt,
       ...(schema && {
         schema: schema instanceof z.ZodType ? schema : jsonSchema(schema),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for sending labels with all Vertex/Google API calls to improve traceability and debugging.

- **New Features**
  - Injected metadata labels (functionId, extractId, scrapeId, teamId, and others) into providerOptions for all relevant Google API requests.

<!-- End of auto-generated description by cubic. -->

