### PR TITLE
fix: remove --max-old-space-size from worker startup to resolve BullM…

### DIFF
--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -14,10 +14,10 @@ if [ "$FLY_PROCESS_GROUP" = "app" ]; then
   node --max-old-space-size=8192 dist/src/index.js
 elif [ "$FLY_PROCESS_GROUP" = "worker" ]; then
   echo "RUNNING worker"
-  node --max-old-space-size=8192 dist/src/services/queue-worker.js
+  node dist/src/services/queue-worker.js
 elif [ "$FLY_PROCESS_GROUP" = "index-worker" ]; then
   echo "RUNNING index worker"
-  node --max-old-space-size=8192 dist/src/services/indexing/index-worker.js
+  node dist/src/services/indexing/index-worker.js
 else
   echo "NO FLY PROCESS GROUP"
   node --max-old-space-size=8192 dist/src/index.js

--- a/examples/kubernetes/cluster-install/worker.yaml
+++ b/examples/kubernetes/cluster-install/worker.yaml
@@ -20,7 +20,7 @@ spec:
           image: ghcr.io/mendableai/firecrawl:latest
           imagePullPolicy: Always
           command: [ "node" ]
-          args: [ "--max-old-space-size=3072", "dist/src/services/queue-worker.js" ]
+          args: [ "dist/src/services/queue-worker.js" ]
           env:
             - name: FLY_PROCESS_GROUP
               value: "worker"


### PR DESCRIPTION
…Q worker thread error
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the --max-old-space-size flag from worker startup scripts to fix BullMQ worker thread errors.

- **Bug Fixes**
 - Workers now start without memory limit flags, resolving thread initialization issues.

<!-- End of auto-generated description by cubic. -->

