### PR TITLE
feat(v2): extract

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -9,7 +9,7 @@ import {
   Document as V0Document,
   WebSearchResult,
 } from "../../lib/entities";
-import { ScrapeOptions as V1ScrapeOptions } from "../v1/types";
+import { agentOptionsExtract, ScrapeOptions as V1ScrapeOptions } from "../v1/types";
 import { InternalOptions } from "../../scraper/scrapeURL";
 
 export enum IntegrationEnum {
@@ -391,7 +391,7 @@ import type { CostTracking } from "../../lib/extract/extraction-service";
 
 const ajv = new Ajv();
 
-export const extractV1Options = z
+export const extractOptions = z
   .object({
     urls: url
       .array()
@@ -426,6 +426,7 @@ export const extractV1Options = z
     integration: z.nativeEnum(IntegrationEnum).optional().transform(val => val || null),
     urlTrace: z.boolean().default(false),
     timeout: z.number().int().positive().finite().safe().optional(),
+    agent: agentOptionsExtract.optional(),
     __experimental_streamSteps: z.boolean().default(false),
     __experimental_llmUsage: z.boolean().default(false),
     __experimental_showSources: z.boolean().default(false),
@@ -457,8 +458,8 @@ export const extractV1Options = z
       : x.scrapeOptions,
   }));
 
-export type ExtractV1Options = z.infer<typeof extractV1Options>;
-export const extractRequestSchema = extractV1Options;
+export type ExtractOptions = z.infer<typeof extractOptions>;
+export const extractRequestSchema = extractOptions;
 export type ExtractRequest = z.infer<typeof extractRequestSchema>;
 export type ExtractRequestInput = z.input<typeof extractRequestSchema>;
 

--- a/apps/api/src/lib/extract/document-scraper.ts
+++ b/apps/api/src/lib/extract/document-scraper.ts
@@ -1,13 +1,10 @@
-import { Document, ScrapeOptions, TeamFlags, URLTrace, scrapeOptions as scrapeOptionsSchema } from "../../controllers/v1/types";
-import { logger } from "../logger";
+import { Document, ScrapeOptions, TeamFlags, URLTrace, scrapeOptions as scrapeOptionsSchema } from "../../controllers/v2/types";
 import { getScrapeQueue } from "../../services/queue-service";
 import { waitForJob } from "../../services/queue-jobs";
 import { addScrapeJob } from "../../services/queue-jobs";
 import { getJobPriority } from "../job-priority";
 import type { Logger } from "winston";
-import { getJobFromGCS } from "../gcs-jobs";
 import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
-import { fromV1ScrapeOptions } from "../../controllers/v2/types";
 
 interface ScrapeDocumentOptions {
   url: string;
@@ -42,19 +39,16 @@ export async function scrapeDocument(
       from_extract: true,
     });
 
-    const { scrapeOptions, internalOptions } = fromV1ScrapeOptions(scrapeOptionsSchema.parse({
-      ...internalScrapeOptions,
-      maxAge: 4 * 60 * 60 * 1000,
-    }), internalScrapeOptions.timeout, options.teamId)
-
     await addScrapeJob(
       {
         url: options.url,
         mode: "single_urls",
         team_id: options.teamId,
-        scrapeOptions: scrapeOptions,
+        scrapeOptions: scrapeOptionsSchema.parse({
+          ...internalScrapeOptions,
+          maxAge: 4 * 60 * 60 * 1000,
+        }),
         internalOptions: {
-          ...internalOptions,
           teamId: options.teamId,
           saveScrapeResultToGCS: process.env.GCS_FIRE_ENGINE_BUCKET_NAME ? true : false,
           bypassBilling: true,

--- a/apps/api/src/lib/extract/extraction-service.ts
+++ b/apps/api/src/lib/extract/extraction-service.ts
@@ -1,10 +1,10 @@
 import {
   Document,
   ExtractRequest,
-  isAgentExtractModelValid,
   TokenUsage,
   URLTrace,
-} from "../../controllers/v1/types";
+} from "../../controllers/v2/types";
+import { isAgentExtractModelValid } from "../../controllers/v1/types";
 import { logger as _logger } from "../logger";
 import { generateBasicCompletion, processUrl } from "./url-processor";
 import { scrapeDocument } from "./document-scraper";

--- a/apps/api/src/lib/extract/fire-0/document-scraper-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/document-scraper-f0.ts
@@ -1,12 +1,10 @@
-import { Document, ScrapeOptions, TeamFlags, URLTrace, scrapeOptions as scrapeOptionsSchema } from "../../../controllers/v1/types";
-import { logger } from "../../logger";
+import { Document, ScrapeOptions, TeamFlags, URLTrace, scrapeOptions as scrapeOptionsSchema } from "../../../controllers/v2/types";
 import { getScrapeQueue } from "../../../services/queue-service";
 import { waitForJob } from "../../../services/queue-jobs";
 import { addScrapeJob } from "../../../services/queue-jobs";
 import { getJobPriority } from "../../job-priority";
 import type { Logger } from "winston";
 import { isUrlBlocked } from "../../../scraper/WebScraper/utils/blocklist";
-import { fromV1ScrapeOptions } from "../../../controllers/v2/types";
 
 interface ScrapeDocumentOptions {
   url: string;
@@ -41,10 +39,10 @@ export async function scrapeDocument_F0(
       from_extract: true,
     });
 
-    const { scrapeOptions, internalOptions } = fromV1ScrapeOptions(scrapeOptionsSchema.parse({
+    const scrapeOptions = scrapeOptionsSchema.parse({
       ...internalScrapeOptions,
       maxAge: 4 * 60 * 60 * 1000,
-    }), internalScrapeOptions.timeout, options.teamId);
+    });
 
     await addScrapeJob(
       {
@@ -53,7 +51,6 @@ export async function scrapeDocument_F0(
         team_id: options.teamId,
         scrapeOptions,
         internalOptions: {
-          ...internalOptions,
           teamId: options.teamId,
           bypassBilling: true,
         },

--- a/apps/api/src/lib/extract/fire-0/extraction-service-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/extraction-service-f0.ts
@@ -3,7 +3,7 @@ import {
     ExtractRequest,
     TokenUsage,
     URLTrace,
-  } from "../../../controllers/v1/types";
+  } from "../../../controllers/v2/types";
   import { logger as _logger } from "../../logger";
   import { scrapeDocument_F0 } from "./document-scraper-f0";
   import { billTeam } from "../../../services/billing/credit_billing";


### PR DESCRIPTION
Adds extract endpoint to v2 and rebases extract scraping on v2 scrape option types.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new v2 extract endpoint and updated extract logic to use v2 scrape option types for better consistency and future support.

- **New Features**
 - Introduced v2 extract controller with improved request validation and job handling.
 - Updated related services and types to use v2 scrape options.

<!-- End of auto-generated description by cubic. -->

