### PR TITLE
feat(api/admin): prometheus metrics about cc limit queue

### DIFF
--- a/apps/api/src/controllers/v0/admin/metrics.ts
+++ b/apps/api/src/controllers/v0/admin/metrics.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from "express";
+import { redisEvictConnection } from "../../../services/redis";
+
+export async function metricsController(_: Request, res: Response) {
+    let cursor: string = "0";
+    const metrics: Record<string, number> = {};
+    do {
+        const res = await redisEvictConnection.scan(cursor, "MATCH", "concurrency-limit-queue:*");
+        cursor = res[0];
+
+        const keys = res[1];
+
+        for (const key of keys) {
+            const teamId = key.split(":")[1];
+            const jobCount = await redisEvictConnection.zcard(key);
+            metrics[teamId] = jobCount;
+        }
+    } while (cursor !== "0");
+
+    res.contentType("text/plain").send(`\
+# HELP concurrency_limit_queue_job_count The number of jobs in the concurrency limit queue per team
+# TYPE concurrency_limit_queue_job_count gauge
+${Object.entries(metrics).map(([key, value]) => `concurrency_limit_queue_job_count{team_id="${key}"} ${value}`).join("\n")}
+`);
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -13,6 +13,7 @@ import { cclogController } from "../controllers/v0/admin/cclog";
 import { indexQueuePrometheus } from "../controllers/v0/admin/index-queue-prometheus";
 import { zdrcleanerController } from "../controllers/v0/admin/zdrcleaner";
 import { triggerPrecrawl } from "../controllers/v0/admin/precrawl";
+import { metricsController } from "../controllers/v0/admin/metrics";
 
 export const adminRouter = express.Router();
 
@@ -67,4 +68,9 @@ adminRouter.get(
 adminRouter.get(
   `/admin/${process.env.BULL_AUTH_KEY}/precrawl`,
   wrap(triggerPrecrawl),
+);
+
+adminRouter.get(
+  `/admin/${process.env.BULL_AUTH_KEY}/metrics`,
+  wrap(metricsController),
 );


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a new Prometheus metrics endpoint to report the number of jobs in the concurrency limit queue for each team.

- **New Features**
 - Exposes `/admin/<auth_key>/metrics` to show per-team job counts in Prometheus format.

<!-- End of auto-generated description by cubic. -->

