### PR TITLE
fix(queue-service): reduce redis connections to BullMQ

### DIFF
--- a/apps/api/src/__tests__/deep-research/unit/deep-research-redis.test.ts
+++ b/apps/api/src/__tests__/deep-research/unit/deep-research-redis.test.ts
@@ -1,4 +1,4 @@
-import { redisConnection } from "../../../services/queue-service";
+import { redisEvictConnection } from "../../../services/redis";
 import {
   saveDeepResearch,
   getDeepResearch,
@@ -40,11 +40,11 @@ describe("Deep Research Redis Operations", () => {
     it("should save research data to Redis with TTL", async () => {
       await saveDeepResearch("test-id", mockResearch);
 
-      expect(redisConnection.set).toHaveBeenCalledWith(
+      expect(redisEvictConnection.set).toHaveBeenCalledWith(
         "deep-research:test-id",
         JSON.stringify(mockResearch)
       );
-      expect(redisConnection.expire).toHaveBeenCalledWith(
+      expect(redisEvictConnection.expire).toHaveBeenCalledWith(
         "deep-research:test-id",
         6 * 60 * 60
       );
@@ -53,17 +53,17 @@ describe("Deep Research Redis Operations", () => {
 
   describe("getDeepResearch", () => {
     it("should retrieve research data from Redis", async () => {
-      (redisConnection.get as jest.Mock).mockResolvedValue(
+      (redisEvictConnection.get as jest.Mock).mockResolvedValue(
         JSON.stringify(mockResearch)
       );
 
       const result = await getDeepResearch("test-id");
       expect(result).toEqual(mockResearch);
-      expect(redisConnection.get).toHaveBeenCalledWith("deep-research:test-id");
+      expect(redisEvictConnection.get).toHaveBeenCalledWith("deep-research:test-id");
     });
 
     it("should return null when research not found", async () => {
-      (redisConnection.get as jest.Mock).mockResolvedValue(null);
+      (redisEvictConnection.get as jest.Mock).mockResolvedValue(null);
 
       const result = await getDeepResearch("non-existent-id");
       expect(result).toBeNull();
@@ -72,7 +72,7 @@ describe("Deep Research Redis Operations", () => {
 
   describe("updateDeepResearch", () => {
     it("should update existing research with new data", async () => {
-      (redisConnection.get as jest.Mock).mockResolvedValue(
+      (redisEvictConnection.get as jest.Mock).mockResolvedValue(
         JSON.stringify(mockResearch)
       );
 
@@ -98,30 +98,30 @@ describe("Deep Research Redis Operations", () => {
         activities: [...mockResearch.activities, ...update.activities],
       };
 
-      expect(redisConnection.set).toHaveBeenCalledWith(
+      expect(redisEvictConnection.set).toHaveBeenCalledWith(
         "deep-research:test-id",
         JSON.stringify(expectedUpdate)
       );
-      expect(redisConnection.expire).toHaveBeenCalledWith(
+      expect(redisEvictConnection.expire).toHaveBeenCalledWith(
         "deep-research:test-id",
         6 * 60 * 60
       );
     });
 
     it("should do nothing if research not found", async () => {
-      (redisConnection.get as jest.Mock).mockResolvedValue(null);
+      (redisEvictConnection.get as jest.Mock).mockResolvedValue(null);
 
       await updateDeepResearch("test-id", { status: "completed" });
 
-      expect(redisConnection.set).not.toHaveBeenCalled();
-      expect(redisConnection.expire).not.toHaveBeenCalled();
+      expect(redisEvictConnection.set).not.toHaveBeenCalled();
+      expect(redisEvictConnection.expire).not.toHaveBeenCalled();
     });
   });
 
   describe("getDeepResearchExpiry", () => {
     it("should return correct expiry date", async () => {
       const mockTTL = 3600000; // 1 hour in milliseconds
-      (redisConnection.pttl as jest.Mock).mockResolvedValue(mockTTL);
+      (redisEvictConnection.pttl as jest.Mock).mockResolvedValue(mockTTL);
 
       const result = await getDeepResearchExpiry("test-id");
       

--- a/apps/api/src/__tests__/queue-concurrency-integration.test.ts
+++ b/apps/api/src/__tests__/queue-concurrency-integration.test.ts
@@ -1,4 +1,4 @@
-import { redisConnection } from "../services/queue-service";
+import { redisEvictConnection } from "../services/redis";
 import { addScrapeJob, addScrapeJobs } from "../services/queue-jobs";
 import {
   cleanOldConcurrencyLimitEntries,
@@ -85,18 +85,18 @@ describe("Queue Concurrency Integration", () => {
 
     it("should add job directly to BullMQ when under concurrency limit", async () => {
       // Mock current active jobs to be under limit
-      (redisConnection.zrangebyscore as jest.Mock).mockResolvedValue([]);
+      (redisEvictConnection.zrangebyscore as jest.Mock).mockResolvedValue([]);
 
       await addScrapeJob(mockWebScraperOptions);
 
       // Should have checked concurrency
-      expect(redisConnection.zrangebyscore).toHaveBeenCalled();
+      expect(redisEvictConnection.zrangebyscore).toHaveBeenCalled();
 
       // Should have added to BullMQ
       expect(mockAdd).toHaveBeenCalled();
 
       // Should have added to active jobs
-      expect(redisConnection.zadd).toHaveBeenCalledWith(
+      expect(redisEvictConnection.zadd).toHaveBeenCalledWith(
         expect.stringContaining("concurrency-limiter"),
         expect.any(Number),
         expect.any(String),
@@ -109,20 +109,20 @@ describe("Queue Concurrency Integration", () => {
         concurrency: 15,
       } as any);
       const activeJobs = Array(15).fill("active-job");
-      (redisConnection.zrangebyscore as jest.Mock).mockResolvedValue(
+      (redisEvictConnection.zrangebyscore as jest.Mock).mockResolvedValue(
         activeJobs,
       );
 
       await addScrapeJob(mockWebScraperOptions);
 
       // Should have checked concurrency
-      expect(redisConnection.zrangebyscore).toHaveBeenCalled();
+      expect(redisEvictConnection.zrangebyscore).toHaveBeenCalled();
 
       // Should NOT have added to BullMQ
       expect(mockAdd).not.toHaveBeenCalled();
 
       // Should have added to concurrency queue
-      expect(redisConnection.zadd).toHaveBeenCalledWith(
+      expect(redisEvictConnection.zadd).toHaveBeenCalledWith(
         expect.stringContaining("concurrency-limit-queue"),
         expect.any(Number),
         expect.stringContaining("mock-uuid"),
@@ -157,7 +157,7 @@ describe("Queue Concurrency Integration", () => {
       const mockJobs = createMockJobs(totalJobs);
 
       // Mock current active jobs to be empty
-      (redisConnection.zrangebyscore as jest.Mock).mockResolvedValue([]);
+      (redisEvictConnection.zrangebyscore as jest.Mock).mockResolvedValue([]);
 
       await addScrapeJobs(mockJobs);
 
@@ -165,7 +165,7 @@ describe("Queue Concurrency Integration", () => {
       expect(mockAdd).toHaveBeenCalledTimes(maxConcurrency);
 
       // Should have added remaining jobs to concurrency queue
-      expect(redisConnection.zadd).toHaveBeenCalledWith(
+      expect(redisEvictConnection.zadd).toHaveBeenCalledWith(
         expect.stringContaining("concurrency-limit-queue"),
         expect.any(Number),
         expect.any(String),
@@ -176,7 +176,7 @@ describe("Queue Concurrency Integration", () => {
       const result = await addScrapeJobs([]);
       expect(result).toBe(true);
       expect(mockAdd).not.toHaveBeenCalled();
-      expect(redisConnection.zadd).not.toHaveBeenCalled();
+      expect(redisEvictConnection.zadd).not.toHaveBeenCalled();
     });
   });
 
@@ -196,7 +196,7 @@ describe("Queue Concurrency Integration", () => {
         data: { test: "data" },
         opts: {},
       };
-      (redisConnection.zmpop as jest.Mock).mockResolvedValueOnce([
+      (redisEvictConnection.zmpop as jest.Mock).mockResolvedValueOnce([
         "key",
         [[JSON.stringify(queuedJob)]],
       ]);
@@ -212,7 +212,7 @@ describe("Queue Concurrency Integration", () => {
 
       // Should have added new job to active jobs
       await pushConcurrencyLimitActiveJob(mockTeamId, nextJob!.id, 2 * 60 * 1000);
-      expect(redisConnection.zadd).toHaveBeenCalledWith(
+      expect(redisEvictConnection.zadd).toHaveBeenCalledWith(
         expect.stringContaining("concurrency-limiter"),
         expect.any(Number),
         nextJob!.id,
@@ -235,7 +235,7 @@ describe("Queue Concurrency Integration", () => {
       await cleanOldConcurrencyLimitEntries(mockTeamId);
 
       // Verify job was removed from active jobs
-      expect(redisConnection.zrem).toHaveBeenCalledWith(
+      expect(redisEvictConnection.zrem).toHaveBeenCalledWith(
         expect.stringContaining("concurrency-limiter"),
         mockJob.id,
       );
@@ -247,14 +247,14 @@ describe("Queue Concurrency Integration", () => {
       const stalledTime = mockNow - 3 * 60 * 1000; // 3 minutes ago
 
       // Mock stalled jobs in Redis
-      (redisConnection.zrangebyscore as jest.Mock).mockResolvedValueOnce([
+      (redisEvictConnection.zrangebyscore as jest.Mock).mockResolvedValueOnce([
         "stalled-job",
       ]);
 
       await cleanOldConcurrencyLimitEntries(mockTeamId, mockNow);
 
       // Should have cleaned up stalled jobs
-      expect(redisConnection.zremrangebyscore).toHaveBeenCalledWith(
+      expect(redisEvictConnection.zremrangebyscore).toHaveBeenCalledWith(
         expect.stringContaining("concurrency-limiter"),
         -Infinity,
         mockNow,
@@ -263,7 +263,7 @@ describe("Queue Concurrency Integration", () => {
 
     it("should handle race conditions in job queue processing", async () => {
       // Mock a race condition where job is taken by another worker
-      (redisConnection.zmpop as jest.Mock).mockResolvedValueOnce(null);
+      (redisEvictConnection.zmpop as jest.Mock).mockResolvedValueOnce(null);
 
       const nextJob = await takeConcurrencyLimitedJob(mockTeamId);
 

--- a/apps/api/src/services/indexing/index-worker.ts
+++ b/apps/api/src/services/indexing/index-worker.ts
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/node";
 import { Job, Queue, Worker } from "bullmq";
 import { logger as _logger, logger } from "../../lib/logger";
 import {
-  redisConnection,
+  getRedisConnection,
   getBillingQueue,
   getPrecrawlQueue,
   precrawlQueueName,
@@ -218,7 +218,7 @@ const workerFun = async (queue: Queue, jobProcessor: (token: string, job: Job) =
   const logger = _logger.child({ module: "index-worker", method: "workerFun" });
 
   const worker = new Worker(queue.name, null, {
-    connection: redisConnection,
+    connection: getRedisConnection(),
     lockDuration: workerLockDuration,
     stalledInterval: workerStalledCheckInterval,
     maxStalledCount: queue.name === precrawlQueueName ? 0 : 10,

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -5,10 +5,9 @@ import {
   getScrapeQueue,
   getExtractQueue,
   getDeepResearchQueue,
-  redisConnection,
   getGenerateLlmsTxtQueue,
   scrapeQueueName,
-  createRedisConnection,
+  getRedisConnection,
 } from "./queue-service";
 import { Job, Queue, QueueEvents } from "bullmq";
 import { logger as _logger } from "../lib/logger";
@@ -357,7 +356,7 @@ const separateWorkerFun = (
     .filter(arg => !arg.startsWith('--max-old-space-size'));
 
   const worker = new Worker(queue.name, path, {
-    connection: createRedisConnection(),
+    connection: getRedisConnection(),
     lockDuration: 60 * 1000, // 60 seconds
     stalledInterval: 60 * 1000, // 60 seconds
     maxStalledCount: 10, // 10 times
@@ -386,7 +385,7 @@ const workerFun = async (
   const logger = _logger.child({ module: "queue-worker", method: "workerFun" });
 
   const worker = new Worker(queue.name, null, {
-    connection: redisConnection,
+    connection: getRedisConnection(),
     lockDuration: 60 * 1000, // 60 seconds
     stalledInterval: 60 * 1000, // 60 seconds
     maxStalledCount: 10, // 10 times
@@ -534,7 +533,7 @@ app.listen(workerPort, () => {
     }
   }
 
-  const scrapeQueueEvents = new QueueEvents(scrapeQueueName, { connection: redisConnection });
+  const scrapeQueueEvents = new QueueEvents(scrapeQueueName, { connection: getRedisConnection() });
   scrapeQueueEvents.on("failed", failedListener);
 
   const results = await Promise.all([


### PR DESCRIPTION
According to metrics, each worker is opening up to 35 connections to BullMQ.
This is heavily hurting performance.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduced the number of Redis connections used by BullMQ workers to improve performance and resource usage.

- **Refactors**
 - Replaced per-queue Redis connections with a shared singleton connection across all BullMQ queues and workers.

<!-- End of auto-generated description by cubic. -->

