### PR TITLE
fix(crawl-status, extract-status): reduce the use of BullMQ getState

### DIFF
--- a/apps/api/src/controllers/v0/crawl-status.ts
+++ b/apps/api/src/controllers/v0/crawl-status.ts
@@ -55,7 +55,7 @@ export async function getJobs(crawlId: string, ids: string[]): Promise<PseudoJob
   
       const job: PseudoJob<any> = {
         id,
-        getState: bullJob ? (() => bullJob.getState()) : (() => dbJob!.success ? "completed" : "failed"),
+        getState: dbJob ? (() => dbJob.success ? "completed" : "failed") : bullJob!.getState,
         returnvalue: Array.isArray(data)
           ? data[0]
           : data,

--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -58,7 +58,7 @@ export async function getJob(id: string): Promise<PseudoJob<any> | null> {
 
   const job: PseudoJob<any> = {
     id,
-    getState: bullJob ? bullJob.getState : (() => dbJob!.success ? "completed" : "failed"),
+    getState: dbJob ? (() => dbJob.success ? "completed" : "failed") : bullJob!.getState,
     returnvalue: Array.isArray(data)
       ? data[0]
       : data,
@@ -111,10 +111,9 @@ export async function getJobs(ids: string[]): Promise<PseudoJob<any>[]> {
       });
     }
 
-    const state = await bullJob?.getState();
     const job: PseudoJob<any> = {
       id,
-      getState: bullJob ? (() => state!) : (() => dbJob!.success ? "completed" : "failed"),
+      getState: dbJob ? (() => dbJob.success ? "completed" : "failed") : bullJob!.getState,
       returnvalue: Array.isArray(data)
         ? data[0]
         : data,

--- a/apps/api/src/controllers/v1/extract-status.ts
+++ b/apps/api/src/controllers/v1/extract-status.ts
@@ -18,7 +18,7 @@ export async function getExtractJob(id: string): Promise<PseudoJob<ExtractResult
 
   const job: PseudoJob<any> = {
     id,
-    getState: bullJob ? bullJob.getState.bind(bullJob) : (() => dbJob!.success ? "completed" : "failed"),
+    getState: dbJob ? (() => dbJob.success ? "completed" : "failed") : bullJob!.getState,
     returnvalue: data,
     data: {
       scrapeOptions: bullJob ? bullJob.data.scrapeOptions : dbJob!.page_options,


### PR DESCRIPTION
Leads to overloading Dragonfly and outages.