### PR TITLE
doc(readme): add links to translated README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@
   </p>
 </div>
 
+<div align="center">
+  <!-- Keep these links. Translations will automatically update with the README. -->
+  <a href="https://zdoc.app/de/mendableai/firecrawl">Deutsch</a> | 
+  <a href="https://zdoc.app/es/mendableai/firecrawl">Español</a> | 
+  <a href="https://zdoc.app/fr/mendableai/firecrawl">français</a> | 
+  <a href="https://zdoc.app/ja/mendableai/firecrawl">日本語</a> | 
+  <a href="https://zdoc.app/ko/mendableai/firecrawl">한국어</a> | 
+  <a href="https://zdoc.app/pt/mendableai/firecrawl">Português</a> | 
+  <a href="https://zdoc.app/ru/mendableai/firecrawl">Русский</a> | 
+  <a href="https://zdoc.app/zh/mendableai/firecrawl">中文</a>
+</div>
+
 # 🔥 Firecrawl
 
 Empower your AI apps with clean data from any website. Featuring advanced scraping, crawling, and data extraction capabilities.


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added language selector links to the README for quick access to translated versions (Deutsch, Español, Français, 日本語, 한국어, Português, Русский, 中文). Links auto-update with the README and improve accessibility for non-English readers.

<!-- End of auto-generated description by cubic. -->

