### PR TITLE
Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,9 @@ updates:
     commit-message:
       prefix: "apps/test-suite"
       include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adding GitHub Actions to the Dependabot configuration, reference https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#github-actions
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable Dependabot updates for GitHub Actions with a weekly schedule at the repo root. Keeps workflows current and reduces security risk.

<!-- End of auto-generated description by cubic. -->

