### PR TITLE
fix(search): get links and descriptions correctly

### DIFF
--- a/apps/api/src/search/googlesearch.ts
+++ b/apps/api/src/search/googlesearch.ts
@@ -160,9 +160,9 @@ export async function googleSearch(
       }
 
       for (const result of result_block) {
-          const link_tag = result.querySelector("a[href]") as HTMLAnchorElement;
+          const link_tag = result.querySelector("a[href].fuLhoc.ZWRArf") as HTMLAnchorElement;
           const title_tag = link_tag ? link_tag.querySelector("span.CVA68e") : null;
-          const description_tag = result.querySelector("span.FrIlee");
+          const description_tag = result.querySelector("span.FrIlee span.fYyStc");
 
           if (link_tag && title_tag && description_tag) {
               const link = decodeURIComponent(link_tag.href.split("&")[0].replace("/url?q=", ""));

--- a/apps/api/src/search/v2/googlesearch.ts
+++ b/apps/api/src/search/v2/googlesearch.ts
@@ -123,9 +123,9 @@ export async function googleSearch(
       }
 
       for (const result of result_block) {
-          const link_tag = result.querySelector("a[href]") as HTMLAnchorElement;
+          const link_tag = result.querySelector("a[href].fuLhoc.ZWRArf") as HTMLAnchorElement;
           const title_tag = link_tag ? link_tag.querySelector("span.CVA68e") : null;
-          const description_tag = result.querySelector("span.FrIlee");
+          const description_tag = result.querySelector("span.FrIlee span.fYyStc");
 
           if (link_tag && title_tag && description_tag) {
               const link = decodeURIComponent(link_tag.href.split("&")[0].replace("/url?q=", ""));


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes Google search scraping to return the correct result URLs and snippets. Addresses Linear ENG-3365 where the search endpoint returned strange descriptions.

- **Bug Fixes**
  - Target real result links via a[href].fuLhoc.ZWRArf instead of any a[href].
  - Read snippets from span.FrIlee span.fYyStc to avoid mixed/garbled text.
  - Applied to both v1 and v2 search endpoints.

<!-- End of auto-generated description by cubic. -->

