### PR TITLE
Fix pre-commit hook

### DIFF
--- a/apps/api/.husky/pre-commit
+++ b/apps/api/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm lint-staged
+cd apps/api && pnpm lint-staged


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix pre-commit hook to run lint-staged inside apps/api. Ensures API commits are linted correctly and aligns with ENG-3408 pre-commit linter hooks.

<!-- End of auto-generated description by cubic. -->

