### PR TITLE
Ignore scripts during CI build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -8,7 +8,7 @@ COPY . /app
 WORKDIR /app
 
 FROM base AS prod-deps
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile --ignore-scripts
 
 FROM base AS build
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install && pnpm run build


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added --ignore-scripts to pnpm install in the prod-deps stage of apps/api Dockerfile. This speeds up CI builds and prevents lifecycle hooks (e.g., Husky/prepare) from running, supporting ENG-3408 by keeping pre-commit lint hooks out of Docker builds.

<!-- End of auto-generated description by cubic. -->

