### PR TITLE
fix(scrapeURL/f-e/scrape): bad failed schema

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -160,9 +160,6 @@ const processingSchema = z.object({
 });
 
 const failedSchema = z.object({
-  jobId: z.string(),
-  state: z.literal("failed"),
-  processing: z.literal(false),
   error: z.string(),
 });
 
@@ -217,7 +214,6 @@ export async function fireEngineScrape<
   } else if (failedParse.success) {
     logger.debug("Scrape job failed", {
       status,
-      jobId: failedParse.data.jobId,
     });
     if (
       typeof status.error === "string" &&
@@ -254,7 +250,6 @@ export async function fireEngineScrape<
     ) {
       logger.warn("CDP timed out while loading the page", {
         status,
-        jobId: failedParse.data.jobId,
       });
       throw new FEPageLoadFailed();
     } else if (
@@ -273,7 +268,6 @@ export async function fireEngineScrape<
       throw new EngineError("Scrape job failed", {
         cause: {
           status,
-          jobId: failedParse.data.jobId,
         },
       });
     }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the failed job schema in fire-engine scrape to match Firecrawl’s error payload. Removes invalid fields and cleans up logging to prevent parse failures and missing-field access, supporting DNS error handling in ENG-3450.

- **Bug Fixes**
  - Update failedSchema to only expect error: string.
  - Remove jobId/state/processing from schema and related logging.
  - Prevents schema mismatches and invalid log references.

<!-- End of auto-generated description by cubic. -->

