### PR TITLE
feat(api): return job IDs consistently

### DIFF
--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -29,6 +29,7 @@ export async function batchScrapeController(
   req: RequestWithAuth<{}, BatchScrapeResponse, BatchScrapeRequest>,
   res: Response<BatchScrapeResponse>,
 ) {
+  const id = req.body?.appendToId ?? uuidv4();
   const preNormalizedBody = { ...req.body };
   if (req.body?.ignoreInvalidURLs === true) {
     req.body = batchScrapeRequestSchemaNoURLValidation.parse(req.body);
@@ -41,13 +42,12 @@ export async function batchScrapeController(
     return res.status(403).json({
       success: false,
       error: permissions.error,
+      id,
     });
   }
 
   const zeroDataRetention =
     req.acuc?.flags?.forceZDR || req.body.zeroDataRetention;
-
-  const id = req.body.appendToId ?? uuidv4();
   const logger = _logger.child({
     crawlId: id,
     batchScrapeId: id,

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -18,6 +18,7 @@ export async function crawlController(
   req: RequestWithAuth<{}, CrawlResponse, CrawlRequest>,
   res: Response<CrawlResponse>,
 ) {
+  const id = uuidv4();
   const preNormalizedBody = req.body;
   req.body = crawlRequestSchema.parse(req.body);
 
@@ -26,13 +27,12 @@ export async function crawlController(
     return res.status(403).json({
       success: false,
       error: permissions.error,
+      id,
     });
   }
 
   const zeroDataRetention =
     req.acuc?.flags?.forceZDR || req.body.zeroDataRetention;
-
-  const id = uuidv4();
   const logger = _logger.child({
     crawlId: id,
     module: "api/v2",
@@ -86,6 +86,7 @@ export async function crawlController(
         success: false,
         error:
           "Failed to process natural language prompt. Please try rephrasing or use explicit crawler options.",
+        id,
       });
     }
   }
@@ -115,7 +116,7 @@ export async function crawlController(
       try {
         new RegExp(x);
       } catch (e) {
-        return res.status(400).json({ success: false, error: e.message });
+        return res.status(400).json({ success: false, error: e.message, id });
       }
     }
   }
@@ -125,7 +126,7 @@ export async function crawlController(
       try {
         new RegExp(x);
       } catch (e) {
-        return res.status(400).json({ success: false, error: e.message });
+        return res.status(400).json({ success: false, error: e.message, id });
       }
     }
   }

--- a/apps/api/src/controllers/v2/map.ts
+++ b/apps/api/src/controllers/v2/map.ts
@@ -100,6 +100,7 @@ async function getMapResults({
   flags,
   useIndex = true,
   location,
+  id,
 }: {
   url: string;
   search?: string;
@@ -116,8 +117,8 @@ async function getMapResults({
   flags: TeamFlags;
   useIndex?: boolean;
   location?: ScrapeOptions["location"];
+  id: string;
 }): Promise<MapResult> {
-  const id = uuidv4();
   let mapResults: MapDocument[] = [];
   const zeroDataRetention = flags?.forceZDR ?? false;
 
@@ -354,6 +355,7 @@ export async function mapController(
   req: RequestWithAuth<{}, MapResponse, MapRequest>,
   res: Response<MapResponse>,
 ) {
+  const jobId = uuidv4();
   const originalRequest = req.body;
   req.body = mapRequestSchema.parse(req.body);
 
@@ -362,6 +364,7 @@ export async function mapController(
     return res.status(403).json({
       success: false,
       error: permissions.error,
+      id: jobId,
     });
   }
 
@@ -369,6 +372,7 @@ export async function mapController(
     request: req.body,
     originalRequest,
     teamId: req.auth.team_id,
+    jobId,
   });
 
   let result: Awaited<ReturnType<typeof getMapResults>>;
@@ -376,6 +380,7 @@ export async function mapController(
   try {
     result = (await Promise.race([
       getMapResults({
+        id: jobId,
         url: req.body.url,
         search: req.body.search,
         limit: req.body.limit,
@@ -410,6 +415,7 @@ export async function mapController(
         success: false,
         code: error.code,
         error: error.message,
+        id: jobId,
       });
     } else {
       throw error;

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -28,6 +28,7 @@ export async function scrapeController(
     return res.status(403).json({
       success: false,
       error: permissions.error,
+      id: jobId,
     });
   }
 
@@ -128,11 +129,13 @@ export async function scrapeController(
         success: false,
         code: e.code,
         error: e.message,
+        id: jobId,
       });
     } else {
       return res.status(500).json({
         success: false,
         error: `(Internal server error) - ${e && e.message ? e.message : e}`,
+        id: jobId,
       });
     }
   }

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -215,6 +215,7 @@ export async function searchController(
       success: false,
       error:
         "Your team has zero data retention enabled. This is not supported on search. Please contact support@firecrawl.com to unblock this feature.",
+      id: jobId,
     });
   }
 
@@ -671,6 +672,7 @@ export async function searchController(
         success: false,
         error: "Invalid request body",
         details: error.errors,
+        id: jobId,
       });
     }
 
@@ -679,6 +681,7 @@ export async function searchController(
         success: false,
         code: error.code,
         error: error.message,
+        id: jobId,
       });
     }
 
@@ -687,6 +690,7 @@ export async function searchController(
     return res.status(500).json({
       success: false,
       error: error.message,
+      id: jobId,
     });
   }
 }

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -780,6 +780,7 @@ export type ErrorResponse = {
   code?: ErrorCodes;
   error: string;
   details?: any;
+  id?: string;
 };
 
 export type ScrapeResponse =


### PR DESCRIPTION
## The problem

Right now, v2 endpoints are inconsistent about returning job IDs:
- Async endpoints like crawl and batch-scrape always return an `id`
- Sync endpoints like scrape and search sometimes don't return IDs

This makes it hard when you're building an application, because you can't reliably get the job ID to track what happened.

## Rational

When an application triggers a Firecrawl job, we need the job ID so we can:
- Link it back to our own records ("this user request corresponds to Firecrawl job X")
- Check if the job succeeded or failed
- Look up the job in Firecrawl logs when something goes wrong
- Potentially: Show users a link to the Firecrawl dashboard for their job

**NOTE:** Ideally, even failed jobs should return the jobid, but that's a different thing and it required more analysis. We can discuss that here.

## What changed

All V2 sync endpoints now return job IDs:
- `/v2/scrape` - returns `id` and `scrape_id`
- `/v2/search` - returns `id` for both sync and async modes
- `/v2/map` - returns `id` alongside the existing `job_id`

## Backward compatibility

No breaking changes. All the existing fields are still there (`scrape_id`, `scrapeIds`, `job_id`). We just added the `id` field to make things consistent.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Return job IDs consistently across v2 endpoints so apps can track and debug jobs reliably. Adds id to scrape, search, and map responses without breaking existing fields.

- **New Features**
  - v2/scrape: adds id alongside scrape_id (for website-origin requests).
  - v2/search: returns id in both sync and async responses.
  - v2/map: returns id alongside existing job_id.
  - Updated TypeScript response types to include the new id fields.

- **Migration**
  - No changes required. Existing fields (scrape_id, scrapeIds, job_id) remain.

<!-- End of auto-generated description by cubic. -->

