### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ REDIS_RATE_LIMIT_URL=redis://localhost:6379
 USE_DB_AUTHENTICATION=false
 
 ## Using the PostgreSQL for queuing -- change if credentials, host, or DB is different
-NUQ_DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
+NUQ_DATABASE_URL=postgres://postgres:postgres@localhost:5433/postgres
 
 # ===== Optional ENVS ======
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated CONTRIBUTING.md to change the NUQ_DATABASE_URL example from port 5432 to 5433 so the queue database uses the correct local Postgres port and avoids connection errors during setup.

<!-- End of auto-generated description by cubic. -->

