### PR TITLE
Add exceptions to blocklist

### DIFF
--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -90,6 +90,8 @@ const allowedKeywords = [
   "://creditcards.aa.com",
   "://aa.org",
   "://www.aa.org",
+  "://www.reddit.com/dev/api",
+  "://ads-api.reddit.com",
 ];
 
 function decryptedBlocklist(list: string[]): string[] {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Allow Reddit API endpoints in the scraper by adding exceptions to the blocklist: https://www.reddit.com/dev/api and https://ads-api.reddit.com. This enables needed API calls while keeping other Reddit URLs blocked.

<!-- End of auto-generated description by cubic. -->

