### PR TITLE
feat(scrapeURL/index): index metrics

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index/index.ts
@@ -340,7 +340,7 @@ export async function scrapeURLWithIndex(
   meta.logger.debug("Index metrics", {
     module: "index/metrics",
     hit: true,
-    age: new Date(selectedRow.created_at).getTime() - Date.now(),
+    age: Date.now() - new Date(selectedRow.created_at).getTime(),
     maxAge,
     dynamicMaxAge: meta.options.maxAge === undefined,
   });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add debug metrics for index hits and misses in scrapeURLWithIndex to improve observability and help tune maxAge. Supports ENG-3555 by adding structured index logs for GCP distribution analysis.

- **New Features**
  - Logs index metrics on hit/miss via meta.logger.debug with module: "index/metrics".
  - Fields: hit (bool), age (ms, on hit), maxAge, dynamicMaxAge.

- **Refactors**
  - Removed unused imports (addDomainFrequencyJob, storage).

<!-- End of auto-generated description by cubic. -->

