### PR TITLE
Update pnpm and add minimumReleaseAge (ENG-3560)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -170,5 +170,5 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,md}": "prettier --write"
   },
-  "packageManager": "pnpm@10.15.1"
+  "packageManager": "pnpm@10.16.1"
 }

--- a/apps/api/pnpm-workspace.yaml
+++ b/apps/api/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "native"
 injectWorkspacePackages: true
+minimumReleaseAge: 720 # 12 hours


### PR DESCRIPTION
new feature to prevent installing newly released dependencies, defends against supply chain attacks
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Blocks installs of newly published dependencies for 12 hours to reduce supply‑chain risk (ENG-3560). Also updates pnpm to 10.16.1.

- New Features
  - Set minimumReleaseAge: 720 (12 hours) in pnpm-workspace.yaml to prevent installing packages published in the last 12 hours.

- Dependencies
  - Bump packageManager to pnpm@10.16.1 in apps/api/package.json.

<!-- End of auto-generated description by cubic. -->

