### PR TITLE
fix: [Dockerfile] Install Python and configure for node-gyp

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,7 +24,12 @@ RUN apt-get update && apt-get install -y \
     curl \
     build-essential \
     pkg-config \
+    python3 \
+    python3-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Configure Python for node-gyp
+ENV PYTHON=/usr/bin/python3
 
 # Install Rust
 ENV RUSTUP_HOME=/usr/local/rustup \


### PR DESCRIPTION
This pull request updates the Dockerfile to improve compatibility with Node.js native modules that require Python during build steps. The main change is the installation and configuration of Python 3 for use with `node-gyp`.

see #2173 

Dependency and build environment updates:

* Added installation of `python3` and `python3-dev` packages to ensure Python 3 is available in the build environment.
* Set the `PYTHON` environment variable to `/usr/bin/python3` to configure Python for `node-gyp` builds.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Install Python 3 in the API Docker image and configure node-gyp so Node.js native modules build successfully.

- **Dependencies**
  - Add python3 and python3-dev to the image.
  - Set PYTHON=/usr/bin/python3 for node-gyp.

<!-- End of auto-generated description by cubic. -->

