### PR TITLE
Fix ARM builds

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     build-essential \
     pkg-config \
+    python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rust


### PR DESCRIPTION
Closes #2173 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add python3 to apt-get install in apps/api Dockerfile to unblock linux/arm64v8 builds. Addresses Linear ENG-3586 by providing required build tooling for dependencies that need Python during compile.

<!-- End of auto-generated description by cubic. -->

