### PR TITLE
fix(v1/search): if f-e search is available, only use that

### DIFF
--- a/apps/api/src/search/index.ts
+++ b/apps/api/src/search/index.ts
@@ -44,7 +44,7 @@ export async function search({
         country,
         location,
       });
-      if (results.length > 0) return results;
+      return results;
     }
     if (process.env.SERPER_API_KEY) {
       logger.info("Using serper search");


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Always use the front-end search when it’s available, even if it returns zero results. This removes the fallback to external search (e.g., Serper), fixing slow “no results” searches and aligning with ENG-3619.

<!-- End of auto-generated description by cubic. -->

