### PR TITLE
fix: Use port from env.PORT for API

### DIFF
--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -68,6 +68,9 @@ function formatDuration(nanoseconds: bigint): string {
 
 const stream = createWriteStream("firecrawl.log");
 
+// Get the port from environment variable, defaulting to 3002
+const PORT = process.env.PORT ?? "3002";
+
 const logger = {
   section(message: string) {
     console.log(
@@ -400,8 +403,8 @@ async function runDevMode(): Promise<void> {
 
     currentServices = startServices();
 
-    logger.info("Waiting for API on localhost:3002");
-    await waitForPort(3002, "localhost");
+    logger.info(`Waiting for API on localhost:${PORT}`);
+    await waitForPort(Number(PORT), "localhost");
     logger.success("API is ready");
 
     isFirstStart = false;
@@ -416,7 +419,7 @@ async function runDevMode(): Promise<void> {
 
       currentServices = startServices();
 
-      await waitForPort(3002, "localhost");
+      await waitForPort(Number(PORT), "localhost");
       logger.success("Services restarted");
     }
   });
@@ -442,8 +445,8 @@ async function runDevMode(): Promise<void> {
 async function runProductionMode(command: string[]): Promise<void> {
   const services = startServices(command);
 
-  logger.info("Waiting for API on localhost:3002");
-  await waitForPort(3002, "localhost");
+  logger.info(`Waiting for API on localhost:${PORT}`);
+  await waitForPort(Number(PORT), "localhost");
 
   await waitForTermination(services);
 }


### PR DESCRIPTION
This pull request updates the API harness to allow the port number to be configurable via an environment variable, instead of being hardcoded. This makes it easier to run the API on different ports and improves flexibility in various environments.

Configuration improvements:

* Introduced a new `PORT` constant in `apps/api/src/harness.ts` that reads the port number from the environment variable, defaulting to `"3002"` if not set.

Port usage updates:

* Updated all instances where the port was previously hardcoded (`3002`) to use the new `PORT` constant in log messages and when waiting for the API to be ready, both in development and production modes. [[1]](diffhunk://#diff-2e4ed36a25f740c3c1e68ec159a3082da40a8efa78f2f0e4145ca72cf4c010e3L403-R407) [[2]](diffhunk://#diff-2e4ed36a25f740c3c1e68ec159a3082da40a8efa78f2f0e4145ca72cf4c010e3L419-R422) [[3]](diffhunk://#diff-2e4ed36a25f740c3c1e68ec159a3082da40a8efa78f2f0e4145ca72cf4c010e3L445-R449)

Fixes #2204