### PR TITLE
fix(python-sdk): map camelCase image fields (imageUrl, imageWidth, im…

### DIFF
--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -373,18 +373,30 @@ class SearchResultNews(BaseModel):
   url: Optional[str] = None
   snippet: Optional[str] = None
   date: Optional[str] = None
-  image_url: Optional[str] = None
+  # API returns camelCase: imageUrl
+  image_url: Optional[str] = Field(default=None, alias="imageUrl")
   position: Optional[int] = None
   category: Optional[str] = None
 
 class SearchResultImages(BaseModel):
   """An image search result with URL, title, image URL, image width, image height, and position."""
   title: Optional[str] = None
-  image_url: Optional[str] = None
-  image_width: Optional[int] = None
-  image_height: Optional[int] = None
+  # API returns camelCase: imageUrl, imageWidth, imageHeight
+  image_url: Optional[str] = Field(default=None, alias="imageUrl")
+  image_width: Optional[int] = Field(default=None, alias="imageWidth")
+  image_height: Optional[int] = Field(default=None, alias="imageHeight")
   url: Optional[str] = None
   position: Optional[int] = None
+
+  @field_validator('image_width', 'image_height', mode='before')
+  @classmethod
+  def _coerce_dimensions_to_int(cls, v):
+    if isinstance(v, str):
+      try:
+        return int(v)
+      except ValueError:
+        return v
+    return v
 
 class SearchData(BaseModel):
   """Search results grouped by source type."""


### PR DESCRIPTION
### Summary
Fix Python SDK image search results not populating `image_url`, `image_width`, `image_height`. Also map news `imageUrl` → `image_url`.

### Why this is helpful
- Enables downstream apps to display images from search results without custom parsing.
- Prevents crashes when code assumes `image_url` is a string.
- Restores parity with API responses and improves developer ergonomics.

### What this PR does
- Adds field aliases so API camelCase (`imageUrl`, `imageWidth`, `imageHeight`) maps to SDK snake_case.
- Coerces `image_width`/`image_height` to integers when provided as strings by the API.
- Applies the same mapping to news results for `image_url`.

### Changes
- apps/python-sdk/firecrawl/v2/types.py
  - `SearchResultImages`: aliases for `imageUrl`, `imageWidth`, `imageHeight`; dimension coercion to `int`.
  - `SearchResultNews`: alias for `imageUrl`.

### Repro
```python
from firecrawl import Firecrawl
fc = Firecrawl(api_key="MY-API-KEY")
res = fc.search(query="test", limit=2, sources=["images"])
for r in res.images:
    print(r.title, r.url, r.image_url, r.image_width, r.image_height)  # previously None
```

### Validation
- Editable install from repo; ran snippet.
- `image_url` populated; `image_width`/`image_height` integers when present (else None).

### Backward compatibility
- No breaking changes. Snake_case attributes preserved; camelCase accepted via aliases.

### Checklist
- [x] Lint passes on edited file
- [x] Verified against live API
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Python SDK search results so image_url, image_width, and image_height are correctly populated for images and news. Maps API camelCase fields to snake_case and coerces width/height to integers.

- **Bug Fixes**
  - Map API fields: imageUrl → image_url, imageWidth → image_width, imageHeight → image_height; and news.imageUrl → image_url.
  - Coerce image_width/image_height from strings to ints.
  - Backward compatible; no API changes.

<!-- End of auto-generated description by cubic. -->

