### PR TITLE
feat(nuq/rabbitmq): add prefetching jobs from psql to rabbitmq

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,8 @@
     "worker:production": "node --import ./dist/src/otel.js dist/src/services/queue-worker.js",
     "nuq-worker": "tsc-watch --onSuccess \"node --import ./dist/src/otel.js dist/src/services/worker/nuq-worker.js\"",
     "nuq-worker:production": "node --import ./dist/src/otel.js dist/src/services/worker/nuq-worker.js",
+    "nuq-prefetch-worker": "tsc-watch --onSuccess \"node --import ./dist/src/otel.js dist/src/services/worker/nuq-prefetch-worker.js\"",
+    "nuq-prefetch-worker:production": "node --import ./dist/src/otel.js dist/src/services/worker/nuq-prefetch-worker.js",
     "index-worker": "tsc-watch --onSuccess \"node --import ./dist/src/otel.js dist/src/services/indexing/index-worker.js\"",
     "index-worker:production": "node --import ./dist/src/otel.js dist/src/services/indexing/index-worker.js",
     "mongo-docker": "docker run -d -p 2717:27017 -v ./mongo-data:/data/db --name mongodb mongo:latest",

--- a/apps/api/src/__tests__/snips/v1/zdr.test.ts
+++ b/apps/api/src/__tests__/snips/v1/zdr.test.ts
@@ -30,6 +30,9 @@ const logIgnoreList = [
   "Added billing operation to queue",
   "Index RF inserter found",
   "Redis connected",
+  "Prefetched jobs",
+  "nuqPrefetchJobs metrics",
+  "request completed",
 ];
 
 if (process.env.TEST_SUITE_SELF_HOSTED) {

--- a/apps/api/src/__tests__/snips/v2/zdr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/zdr.test.ts
@@ -30,6 +30,9 @@ const logIgnoreList = [
   "Added billing operation to queue",
   "Index RF inserter found",
   "Redis connected",
+  "Prefetched jobs",
+  "nuqPrefetchJobs metrics",
+  "request completed",
 ];
 
 if (process.env.TEST_SUITE_SELF_HOSTED) {

--- a/apps/api/src/services/worker/nuq-prefetch-worker.ts
+++ b/apps/api/src/services/worker/nuq-prefetch-worker.ts
@@ -1,0 +1,35 @@
+import "dotenv/config";
+import { scrapeQueue, nuqGetLocalMetrics, nuqHealthCheck, nuqShutdown } from "./nuq";
+import Express from "express";
+import { logger } from "../../lib/logger";
+
+(async () => {
+    const app = Express();
+
+    app.get("/metrics", (_, res) => res.contentType("text/plain").send(nuqGetLocalMetrics()));
+    app.get("/health", async (_, res) => {
+        if (await nuqHealthCheck()) {
+            res.status(200).send("OK");
+        } else {
+            res.status(500).send("Not OK");
+        }
+    });
+
+    const server = app.listen(Number(process.env.NUQ_PREFETCH_WORKER_PORT ?? process.env.PORT ?? 3011), () => {
+        logger.info("NuQ prefetch worker metrics server started");
+    });
+
+    async function shutdown() {
+        server.close();
+        await nuqShutdown();
+        process.exit(0);
+    }
+
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+
+    while (true) {
+        await scrapeQueue.prefetchJobs();
+        await new Promise(resolve => setTimeout(resolve, 250));
+    }
+})();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a RabbitMQ-backed prefetch layer for NuQ. A new prefetch worker moves jobs from Postgres to a RabbitMQ prefetch queue, and workers consume from it for lower DB contention and faster job pickup. Supports ENG-3662 job distribution.

- New Features
  - Added nuq-prefetch-worker with /metrics and /health; loops prefetchJobs every 250ms.
  - Prefetches up to 500 queued jobs per batch, marks them active with a UUID lock, and publishes to queueName.prefetch (durable, TTL 30s, max 20k).
  - Workers now consume from the prefetch queue when NUQ_RABBITMQ_URL is set, falling back to Postgres if not. Uses job.lock for renew/finish/fail and avoids exponential backoff under RabbitMQ.
  - Sender/channel robustness: close handlers, renamed sendJobEnd, and prefetch(1) for listener channel.
  - Harness/scripts: added nuq-prefetch-worker scripts and lifecycle; auto-starts when NUQ_RABBITMQ_URL is present.
  - Tests updated to ignore new prefetch metrics logs.

- Migration
  - Set NUQ_RABBITMQ_URL to enable prefetching.
  - Run nuq-prefetch-worker (pnpm nuq-prefetch-worker:production). Default port 3011 (override with NUQ_PREFETCH_WORKER_PORT).
  - No schema changes; deploy alongside existing NuQ workers.

<!-- End of auto-generated description by cubic. -->

