### PR TITLE
fix: harness

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,8 @@
     "nuq-worker:production": "node --import ./dist/src/otel.js dist/src/services/worker/nuq-worker.js",
     "nuq-prefetch-worker": "tsc-watch --onSuccess \"node --import ./dist/src/otel.js dist/src/services/worker/nuq-prefetch-worker.js\"",
     "nuq-prefetch-worker:production": "node --import ./dist/src/otel.js dist/src/services/worker/nuq-prefetch-worker.js",
+    "extract-worker": "tsc-watch --onSuccess \"node --import ./dist/src/otel.js dist/src/services/extract-worker.js\"",
+    "extract-worker:production": "node --import ./dist/src/otel.js dist/src/services/extract-worker.js",
     "index-worker": "tsc-watch --onSuccess \"node --import ./dist/src/otel.js dist/src/services/indexing/index-worker.js\"",
     "index-worker:production": "node --import ./dist/src/otel.js dist/src/services/indexing/index-worker.js",
     "mongo-docker": "docker run -d -p 2717:27017 -v ./mongo-data:/data/db --name mongodb mongo:latest",

--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -1,10 +1,23 @@
 import { v4 as uuidv4 } from "uuid";
-import { TeamFlags, MapDocument, scrapeOptions, ScrapeOptions } from "../controllers/v2/types";
+import {
+  TeamFlags,
+  MapDocument,
+  scrapeOptions,
+  ScrapeOptions,
+} from "../controllers/v2/types";
 import { crawlToCrawler, StoredCrawl } from "./crawl-redis";
-import { checkAndUpdateURLForMap, isSameDomain, isSameSubdomain } from "./validateUrl";
+import {
+  checkAndUpdateURLForMap,
+  isSameDomain,
+  isSameSubdomain,
+} from "./validateUrl";
 import { fireEngineMap } from "../search/fireEngine";
 import { redisEvictConnection } from "../services/redis";
-import { generateURLSplits, queryIndexAtDomainSplitLevelWithMeta, queryIndexAtSplitLevelWithMeta } from "../services/index";
+import {
+  generateURLSplits,
+  queryIndexAtDomainSplitLevelWithMeta,
+  queryIndexAtSplitLevelWithMeta,
+} from "../services/index";
 import { performCosineSimilarityV2 } from "./map-cosine";
 import { Logger } from "winston";
 
@@ -19,7 +32,7 @@ export interface MapResult {
   mapResults: MapDocument[];
 }
 
-export function dedupeMapDocumentArray(documents: MapDocument[]): MapDocument[] {
+function dedupeMapDocumentArray(documents: MapDocument[]): MapDocument[] {
   const urlMap = new Map<string, MapDocument>();
 
   for (const doc of documents) {
@@ -35,7 +48,7 @@ export function dedupeMapDocumentArray(documents: MapDocument[]): MapDocument[] 
   return Array.from(urlMap.values());
 }
 
-export async function queryIndex(
+async function queryIndex(
   url: string,
   limit: number,
   useIndex: boolean,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable extract worker in the harness and improve multi-service logs for readability. Minor refactor to make map-utils helpers internal.

- **New Features**
  - Added extract-worker scripts and wired the harness to start it with NUQ_WORKER_PORT=3005.
  - Improved log labels for clarity (wider padding; colors updated: extract magenta, index yellow).

- **Refactors**
  - Made dedupeMapDocumentArray and queryIndex internal in map-utils and cleaned up imports.

<!-- End of auto-generated description by cubic. -->

