### PR TITLE
Fix a self-hosted docker-compose.yaml bug caused by a recent firecrawl change

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,6 +66,7 @@ services:
       <<: *common-env
       HOST: "0.0.0.0"
       PORT: ${INTERNAL_PORT:-3002}
+      EXTRACT_WORKER_PORT: ${EXTRACT_WORKER_PORT:-3004}
       WORKER_PORT: ${WORKER_PORT:-3005}
       ENV: local
     depends_on:


### PR DESCRIPTION
Add EXTRACT_WORKER_PORT to docker-compose environment

## The Original Error

The Firecrawl container was **failing to start** with this error:

```
Error: listen EADDRINUSE: address already in use 0.0.0.0:3002
    at Server.setupListenHandle [as _listen2] (node:net:1940:16)
```

The **API service** was crashing because port 3002 was already occupied by another service inside the same container.

## Root Cause Analysis

After extracting and analyzing the compiled JavaScript from inside the container, I discovered a **port configuration mismatch**:

1. **The `extract-worker` service** (`/app/dist/src/services/extract-worker.js`) checks for the environment variable `EXTRACT_WORKER_PORT`:
   ```javascript
   const workerPort = process.env.EXTRACT_WORKER_PORT || process.env.PORT || 3005;
   ```

2. **The variable wasn't set**, so it fell back to the global `PORT` environment variable, which was set to `3002`

3. **Race condition**: The harness script spawns multiple services concurrently:
   - `extract-worker` started first and successfully bound to port 3002
   - Then the `api` service tried to start and also bind to port 3002
   - **CRASH**: `EADDRINUSE` error because the port was already taken

4. **Additional conflict discovered**: The `WORKER_PORT` was set to 3005, but the harness script was also trying to configure extract-worker to use port 3005 via a different variable name (`NUQ_WORKER_PORT`), which wasn't being read by the code.

## The Fix

Set **unique ports** for each service by adding the missing environment variable:

```yaml
EXTRACT_WORKER_PORT: ${EXTRACT_WORKER_PORT:-3004}
```

**Final port allocation**:
- API: `3002` (via `PORT`)
- Extract Worker: `3004` (via `EXTRACT_WORKER_PORT`)  
- Queue Worker: `3005` (via `WORKER_PORT`)
- NUQ Workers: `3006-3010` (via `NUQ_WORKER_PORT`)

This ensures each service inside the container binds to its own dedicated port without conflicts.