### PR TITLE
Create datadog-synthetics.yml

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -1,0 +1,38 @@
+# This workflow will trigger Datadog Synthetic tests within your Datadog organisation
+# For more information on running Synthetic tests within your GitHub workflows see: https://docs.datadoghq.com/synthetics/cicd_integrations/github_actions/
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# To get started:
+
+# 1. Add your Datadog API (DD_API_KEY) and Application Key (DD_APP_KEY) as secrets to your GitHub repository. For more information, see: https://docs.datadoghq.com/account_management/api-app-keys/.
+# 2. Start using the action within your workflow
+
+name: Run Datadog Synthetic tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Run Synthetic tests within your GitHub workflow.
+    # For additional configuration options visit the action within the marketplace: https://github.com/marketplace/actions/datadog-synthetics-ci
+    - name: Run Datadog Synthetic tests
+      uses: DataDog/synthetics-ci-github-action@87b505388a22005bb8013481e3f73a367b9a53eb # v1.4.0
+      with:
+        api_key: ${{secrets.DD_API_KEY}}
+        app_key: ${{secrets.DD_APP_KEY}}
+        test_search_query: 'tag:e2e-tests' #Modify this tag to suit your tagging strategy
+
+


### PR DESCRIPTION
            - nome: Configurar ambiente Node.js
  usos: ações/setup-node@v5.0.0
  com:
    # Defina always-auth em npmrc.
    always-auth: # opcional, o padrão é falso
    # Versão: Especificação da versão a ser usada. Exemplos: 12.x, 10.15.1, >=10.15.0.
    node-version: # opcional
    # Arquivo contendo a especificação da versão a ser usada. Exemplos: package.json, .nvmrc, .node-version, .tool-versions.
    node-version-file: # opcional
    # Arquitetura de destino para uso do Node. Exemplos: x86, x64. Usará a arquitetura do sistema por padrão.
    arquitetura: # opcional
    # Defina esta opção se quiser que a ação verifique a versão mais recente disponível que satisfaça a especificação da versão.
    check-latest: # opcional
    # Registro opcional para configurar a autenticação. Definirá o registro em um arquivo .npmrc e .yarnrc no nível do projeto e configurará a autenticação para ler de env.NODE_AUTH_TOKEN.
    url-de-registro: # opcional
    # Escopo opcional para autenticação em registros com escopo. Retornará ao proprietário do repositório ao usar o registro de pacotes do GitHub (https://npm.pkg.github.com/).
    escopo: # opcional
    # Usado para extrair distribuições de nós de versões de nós. Como há um valor padrão, ele normalmente não é fornecido pelo usuário. Ao executar esta ação em github.com, o valor padrão é suficiente. Ao executar em GHES, você pode passar um token de acesso pessoal para github.com se estiver enfrentando limitação de taxa.
    token: # opcional, o padrão é ${{ github.server_url == 'https://github.com' && github.token || '' }}
    # Usado para especificar um gerenciador de pacotes para armazenamento em cache no diretório padrão. Valores suportados: npm, yarn, pnpm.
    cache: # opcional
    # Defina como falso para desabilitar o cache automático com base no campo do gerenciador de pacotes em package.json. Por padrão, o cache é habilitado se o campo do gerenciador de pacotes estiver presente.
    package-manager-cache: # opcional, o padrão é verdadeiro
    # Usado para especificar o caminho para um arquivo de dependência: package-lock.json, yarn.lock, etc. Suporta curingas ou uma lista de nomes de arquivos para armazenar em cache várias dependências.
    cache-dependency-path: # opcional
    # Usado para especificar um espelho alternativo para baixar binários do Node.js de
    espelho: # opcional
    # O token usado como cabeçalho de autorização ao buscar no espelho
    mirror-token: # opcional
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a GitHub Actions workflow to run Datadog Synthetic tests on pushes and PRs to main. It runs tests tagged "e2e-tests" to catch issues early in CI.

- **Migration**
  - Add DD_API_KEY and DD_APP_KEY as repository secrets.
  - Update test_search_query if you use a different tag.

<!-- End of auto-generated description by cubic. -->

