### PR TITLE
docs: add missing worker port envs to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,12 @@ USE_DB_AUTHENTICATION=false
 ## Using the PostgreSQL for queuing -- change if credentials, host, or DB is different
 NUQ_DATABASE_URL=postgres://postgres:postgres@localhost:5433/postgres
 
+# ===== Worker ports (must all be unique) ======
+WORKER_PORT=3003
+EXTRACT_WORKER_PORT=3004
+NUQ_WORKER_PORT=3005
+NUQ_PREFETCH_WORKER_PORT=3006
+
 # ===== Optional ENVS ======
 
 # Supabase Setup (used to support DB authentication, advanced logging, etc.)


### PR DESCRIPTION
This PR updates the CONTRIBUTING.md file to include all required worker port environment variables:

- WORKER_PORT
- EXTRACT_WORKER_PORT
- NUQ_WORKER_PORT
- NUQ_PREFETCH_WORKER_PORT

Without these, running the project locally can result in port collisions or failures. Verified locally that the project runs correctly after adding these.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Documented the worker port environment variables in CONTRIBUTING.md to ensure unique ports for local development and prevent collisions. Includes WORKER_PORT, EXTRACT_WORKER_PORT, NUQ_WORKER_PORT, and NUQ_PREFETCH_WORKER_PORT.

<!-- End of auto-generated description by cubic. -->

