### PR TITLE
Test new mu alternative

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -276,6 +276,51 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     process.env.RUNPOD_MU_API_KEY &&
     process.env.RUNPOD_MU_POD_ID
   ) {
+    // Minimal experiment: fire MU v2 in background if enabled; do not await
+    if (
+      process.env.PDF_MU_V2_EXPERIMENT === "true" &&
+      process.env.PDF_MU_V2_BASE_URL
+    ) {
+      (async () => {
+        const startedAt = Date.now();
+        const logger = meta.logger.child({ method: "scrapePDF/MUv2Experiment" });
+        try {
+          const resp = await robustFetch({
+            url: process.env.PDF_MU_V2_BASE_URL ?? "",
+            method: "POST",
+            body: {
+              input: {
+                file_content: base64Content,
+                filename: path.basename(tempFilePath) + ".pdf",
+                timeout: meta.abort.scrapeTimeout(),
+                created_at: Date.now(),
+                ...(maxPages !== undefined && { max_pages: maxPages }),
+              },
+            },
+            logger,
+            schema: z.any(),
+            mock: meta.mock,
+            abort: meta.abort.asSignal(),
+          });
+          const body: any = resp as any;
+          const tokensIn = body?.metadata?.["total-input-tokens"];
+          const tokensOut = body?.metadata?.["total-output-tokens"];
+          const pages = body?.metadata?.["pdf-total-pages"];
+          const durationMs = Date.now() - startedAt;
+          logger.info("MU v2 experiment completed", {
+            durationMs,
+            url: meta.rewrittenUrl ?? meta.url,
+            tokensIn,
+            tokensOut,
+            pages,
+          });
+        } catch (error) {
+          const durationMs = Date.now() - startedAt;
+          logger.warn("MU v2 experiment failed", { error, durationMs });
+        }
+      })();
+    }
+    const muV1StartedAt = Date.now();
     try {
       result = await scrapePDFWithRunPodMU(
         {
@@ -288,6 +333,15 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         base64Content,
         maxPages,
       );
+      const muV1DurationMs = Date.now() - muV1StartedAt;
+      meta.logger
+        .child({ method: "scrapePDF/MUv1Experiment" })
+        .info("MU v1 completed", {
+          durationMs: muV1DurationMs,
+          url: meta.rewrittenUrl ?? meta.url,
+          pages: effectivePageCount,
+          success: true,
+        });
     } catch (error) {
       if (
         error instanceof RemoveFeatureError ||
@@ -300,6 +354,15 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         { error },
       );
       Sentry.captureException(error);
+      const muV1DurationMs = Date.now() - muV1StartedAt;
+      meta.logger
+        .child({ method: "scrapePDF/MUv1Experiment" })
+        .info("MU v1 failed", {
+          durationMs: muV1DurationMs,
+          url: meta.rewrittenUrl ?? meta.url,
+          pages: effectivePageCount,
+          success: false,
+        });
     }
   }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds an optional MU v2 PDF extraction experiment that runs in the background and does not affect current results. Also adds MU v1 timing and success logs for comparison.

- **New Features**
  - If PDF_MU_V2_EXPERIMENT=true and PDF_MU_V2_BASE_URL is set, trigger MU v2 in the background (non-blocking).
  - Sends base64 file, filename, timeout, created_at, and optional max_pages.
  - Logs MU v2 metrics: durationMs, tokensIn/tokensOut, pages; warns on failure only.
  - Adds MU v1 telemetry: durationMs, pages, success flag.

<!-- End of auto-generated description by cubic. -->

