### PR TITLE
Feat/test new mu alt

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -67,6 +67,54 @@ async function scrapePDFWithRunPodMU(
     maxPages,
   });
 
+
+
+  if (
+    process.env.PDF_MU_V2_EXPERIMENT === "true" &&
+    process.env.PDF_MU_V2_BASE_URL
+  ) {
+    (async () => {
+      const startedAt = Date.now();
+      const logger = meta.logger.child({ method: "scrapePDF/MUv2Experiment" });
+      try {
+        const resp = await robustFetch({
+          url: process.env.PDF_MU_V2_BASE_URL ?? "",
+          method: "POST",
+          body: {
+            input: {
+              file_content: base64Content,
+              filename: path.basename(tempFilePath) + ".pdf",
+              timeout: meta.abort.scrapeTimeout(),
+              created_at: Date.now(),
+              ...(maxPages !== undefined && { max_pages: maxPages }),
+            },
+          },
+          logger,
+          schema: z.any(),
+          mock: meta.mock,
+          abort: meta.abort.asSignal(),
+        });
+        const body: any = resp as any;
+        const tokensIn = body?.metadata?.["total-input-tokens"];
+        const tokensOut = body?.metadata?.["total-output-tokens"];
+        const pages = body?.metadata?.["pdf-total-pages"];
+        const durationMs = Date.now() - startedAt;
+        logger.info("MU v2 experiment completed", {
+          durationMs,
+          url: meta.rewrittenUrl ?? meta.url,
+          tokensIn,
+          tokensOut,
+          pages,
+        });
+      } catch (error) {
+        const durationMs = Date.now() - startedAt;
+        logger.warn("MU v2 experiment failed", { error, durationMs });
+      }
+    })();
+  }
+
+
+  const muV1StartedAt = Date.now();
   const podStart = await robustFetch({
     url:
       "https://api.runpod.ai/v2/" + process.env.RUNPOD_MU_POD_ID + "/runsync",
@@ -133,10 +181,20 @@ async function scrapePDFWithRunPodMU(
   }
 
   if (status === "FAILED") {
+    const durationMs = Date.now() - muV1StartedAt;
+    meta.logger.child({ method: "scrapePDF/MUv1" }).warn("MU v1 failed", {
+      durationMs,
+      url: meta.rewrittenUrl ?? meta.url,
+    });
     throw new Error("RunPod MU failed to parse PDF");
   }
 
   if (!result) {
+    const durationMs = Date.now() - muV1StartedAt;
+    meta.logger.child({ method: "scrapePDF/MUv1" }).warn("MU v1 failed", {
+      durationMs,
+      url: meta.rewrittenUrl ?? meta.url,
+    });
     throw new Error("RunPod MU returned no result");
   }
 
@@ -154,6 +212,14 @@ async function scrapePDFWithRunPodMU(
         tempFilePath,
       });
     }
+  }
+
+  {
+    const durationMs = Date.now() - muV1StartedAt;
+    meta.logger.child({ method: "scrapePDF/MUv1" }).info("MU v1 completed", {
+      durationMs,
+      url: meta.rewrittenUrl ?? meta.url,
+    });
   }
 
   return processorResult;
@@ -276,51 +342,6 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     process.env.RUNPOD_MU_API_KEY &&
     process.env.RUNPOD_MU_POD_ID
   ) {
-    // Minimal experiment: fire MU v2 in background if enabled; do not await
-    if (
-      process.env.PDF_MU_V2_EXPERIMENT === "true" &&
-      process.env.PDF_MU_V2_BASE_URL
-    ) {
-      (async () => {
-        const startedAt = Date.now();
-        const logger = meta.logger.child({ method: "scrapePDF/MUv2Experiment" });
-        try {
-          const resp = await robustFetch({
-            url: process.env.PDF_MU_V2_BASE_URL ?? "",
-            method: "POST",
-            body: {
-              input: {
-                file_content: base64Content,
-                filename: path.basename(tempFilePath) + ".pdf",
-                timeout: meta.abort.scrapeTimeout(),
-                created_at: Date.now(),
-                ...(maxPages !== undefined && { max_pages: maxPages }),
-              },
-            },
-            logger,
-            schema: z.any(),
-            mock: meta.mock,
-            abort: meta.abort.asSignal(),
-          });
-          const body: any = resp as any;
-          const tokensIn = body?.metadata?.["total-input-tokens"];
-          const tokensOut = body?.metadata?.["total-output-tokens"];
-          const pages = body?.metadata?.["pdf-total-pages"];
-          const durationMs = Date.now() - startedAt;
-          logger.info("MU v2 experiment completed", {
-            durationMs,
-            url: meta.rewrittenUrl ?? meta.url,
-            tokensIn,
-            tokensOut,
-            pages,
-          });
-        } catch (error) {
-          const durationMs = Date.now() - startedAt;
-          logger.warn("MU v2 experiment failed", { error, durationMs });
-        }
-      })();
-    }
-    const muV1StartedAt = Date.now();
     try {
       result = await scrapePDFWithRunPodMU(
         {
@@ -333,15 +354,6 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         base64Content,
         maxPages,
       );
-      const muV1DurationMs = Date.now() - muV1StartedAt;
-      meta.logger
-        .child({ method: "scrapePDF/MUv1Experiment" })
-        .info("MU v1 completed", {
-          durationMs: muV1DurationMs,
-          url: meta.rewrittenUrl ?? meta.url,
-          pages: effectivePageCount,
-          success: true,
-        });
     } catch (error) {
       if (
         error instanceof RemoveFeatureError ||
@@ -354,15 +366,6 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         { error },
       );
       Sentry.captureException(error);
-      const muV1DurationMs = Date.now() - muV1StartedAt;
-      meta.logger
-        .child({ method: "scrapePDF/MUv1Experiment" })
-        .info("MU v1 failed", {
-          durationMs: muV1DurationMs,
-          url: meta.rewrittenUrl ?? meta.url,
-          pages: effectivePageCount,
-          success: false,
-        });
     }
   }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds an optional MU v2 PDF parsing experiment and improves MU v1 logging for timing and failures. No change to parsing results; MU v1 still provides the output.

- **New Features**
  - Add MU v2 experiment behind PDF_MU_V2_EXPERIMENT and PDF_MU_V2_BASE_URL; runs fire-and-forget alongside MU v1.
  - Log MU v2 metrics: duration, input/output tokens, total pages; warn on failures.
  - Add MU v1 duration logs and warn on failed/no-result cases.

- **Migration**
  - Optional: set PDF_MU_V2_EXPERIMENT=true and PDF_MU_V2_BASE_URL to enable. Default is off.

<!-- End of auto-generated description by cubic. -->

