### PR TITLE
fix: additional `queue_scrape` for nuq schema

### DIFF
--- a/apps/nuq-postgres/nuq.sql
+++ b/apps/nuq-postgres/nuq.sql
@@ -53,5 +53,3 @@ $$);
 SELECT cron.schedule('nuq_queue_scrape_reindex', '0 9 * * *', $$
   REINDEX TABLE CONCURRENTLY nuq.queue_scrape;
 $$);
-
-ALTER TABLE nuq.queue_scrape ADD COLUMN listen_channel_id text;


### PR DESCRIPTION
Fixes: #2264
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Remove the stray ALTER TABLE that added listen_channel_id to nuq.queue_scrape to match the existing schema and avoid migration conflicts. Fixes #2264.

<!-- End of auto-generated description by cubic. -->

