### PR TITLE
[self-host] fix: Add fallback for `sitemap` discovery due to Fire-engine limited access 

### DIFF
--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -22,6 +22,7 @@ import { performCosineSimilarityV2 } from "./map-cosine";
 import { Logger } from "winston";
 import { logger } from "./logger";
 
+// Max Links that "Smart /map" can return
 const MAX_FIRE_ENGINE_RESULTS = 500;
 const MAX_MAP_LIMIT = 1000;
 


### PR DESCRIPTION
ref: https://github.com/firecrawl/firecrawl/issues/1397#issuecomment-3396040607

tested OK:
<img width="838" height="400" alt="image" src="https://github.com/user-attachments/assets/84b78309-54f8-4a0c-8b40-c8926a5597e5" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add sitemap fallback in /map for self-hosted setups when Fire Engine isn’t available, preventing empty results. If search finds nothing and sitemap=skip, we now try sitemap discovery and log the outcome.

- **Bug Fixes**
  - Detect Fire Engine availability via FIRE_ENGINE_BETA_URL.
  - On empty search results with sitemap=skip, call crawler.tryGetSitemap with timeout/abort support.
  - Add debug logs for fallback start, success count, and failure.

<!-- End of auto-generated description by cubic. -->

