### PR TITLE
fix: Remove Redis TTL for expired crawls (status)

### DIFF
--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -71,7 +71,6 @@ export async function getCrawl(id: string): Promise<StoredCrawl | null> {
       return null;
     }
 
-    await redisEvictConnection.expire("crawl:" + id, 24 * 60 * 60);
     const crawl = JSON.parse(x);
 
     setSpanAttributes(span, {


### PR DESCRIPTION
ref: https://discord.com/channels/1226707384710332458/1426937118688546816
Ensures failed crawls expire from Redis and display correct status, while active crawls continue working normally.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the TTL reset in getCrawl so failed/expired crawls in Redis actually expire and show the correct status. Active crawls are unaffected.

- **Bug Fixes**
  - Stopped setting a 24h expire on "crawl:{id}" during reads.

<!-- End of auto-generated description by cubic. -->

