### PR TITLE
(feat/search) Pdf search category

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1413,6 +1413,12 @@ const researchCategoryOptions = z
   })
   .strict();
 
+const pdfCategoryOptions = z
+  .object({
+    type: z.literal("pdf"),
+  })
+  .strict();
+
 export const searchRequestSchema = z
   .object({
     query: z.string(),
@@ -1445,9 +1451,9 @@ export const searchRequestSchema = z
     categories: z
       .union([
         // Array of strings (simple format)
-        z.array(z.enum(["github", "research"])),
+        z.array(z.enum(["github", "research", "pdf"])),
         // Array of objects (advanced format)
-        z.array(z.union([githubCategoryOptions, researchCategoryOptions])),
+        z.array(z.union([githubCategoryOptions, researchCategoryOptions, pdfCategoryOptions])),
       ])
       .optional(),
     lang: z.string().optional().default("en"),
@@ -1551,6 +1557,10 @@ export const searchRequestSchema = z
             case "research":
               return {
                 type: "research" as const,
+              };
+            case "pdf":
+              return {
+                type: "pdf" as const,
               };
             default:
               return { type: c as any };

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.3.8",
+  "version": "4.4.0",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -286,7 +286,7 @@ export interface SearchData {
 }
 
 export interface CategoryOption {
-  type: 'github' | 'research';
+  type: 'github' | 'research' | 'pdf';
 }
 
 export interface SearchRequest {
@@ -294,7 +294,7 @@ export interface SearchRequest {
   sources?: Array<
     'web' | 'news' | 'images' | { type: 'web' | 'news' | 'images' }
   >;
-  categories?: Array<'github' | 'research' | CategoryOption>;
+  categories?: Array<'github' | 'research' | 'pdf' | CategoryOption>;
   limit?: number;
   tbs?: string;
   location?: string;

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.3.7"
+__version__ = "4.4.0"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/v2/methods/search.py
+++ b/apps/python-sdk/firecrawl/v2/methods/search.py
@@ -123,7 +123,7 @@ def _validate_search_request(request: SearchRequest) -> SearchRequest:
     
     # Validate categories (if provided)
     if request.categories is not None:
-        valid_categories = {"github", "research"}
+        valid_categories = {"github", "research", "pdf"}
         for category in request.categories:
             if isinstance(category, str):
                 if category not in valid_categories:

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -186,7 +186,13 @@ class Source(BaseModel):
 SourceOption = Union[str, Source]
 
 class Category(BaseModel):
-    """Configuration for a search category."""
+    """Configuration for a search category.
+    
+    Supported categories:
+    - "github": Filter results to GitHub repositories
+    - "research": Filter results to research papers and academic sites
+    - "pdf": Filter results to PDF files (adds filetype:pdf to search)
+    """
     type: str
 
 CategoryOption = Union[str, Category]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a new "pdf" search category to filter results to PDF files. Updates API schema, query building, and SDK types; JS and Python SDKs bumped to 4.4.0.

- **New Features**
  - API: searchRequestSchema accepts "pdf" in categories; handles both string and object forms.
  - Query: adds filetype:pdf when "pdf" is selected; classifies .pdf URLs as "pdf".
  - SDKs: JS and Python types/validation support "pdf"; versions updated to 4.4.0.

<!-- End of auto-generated description by cubic. -->

