### PR TITLE
fix: ensure includePaths apply to subdomains when allowSubdomains is enabled

### DIFF
--- a/apps/api/src/__tests__/snips/v2/crawl.test.ts
+++ b/apps/api/src/__tests__/snips/v2/crawl.test.ts
@@ -104,38 +104,6 @@ describe("Crawl tests", () => {
   );
 
   it.concurrent(
-    "includePaths still filter when allowSubdomains is true",
-    async () => {
-      const res = await crawl(
-        {
-          url: "https://firecrawl.dev",
-          includePaths: ["^/pricing$"],
-          allowSubdomains: true,
-          allowExternalLinks: false,
-          limit: 5,
-        },
-        identity,
-      );
-
-      expect(res.success).toBe(true);
-      if (res.success) {
-        expect(res.completed).toBeGreaterThan(0);
-        for (const page of res.data) {
-          const url = new URL(page.metadata.url ?? page.metadata.sourceURL!);
-          // Should be base domain or an allowed subdomain
-          expect(
-            url.hostname === "firecrawl.dev" ||
-              url.hostname.endsWith(".firecrawl.dev"),
-          ).toBe(true);
-          // includePaths should still restrict the path even on subdomains
-          expect(url.pathname).toMatch(/^\/pricing$/);
-        }
-      }
-    },
-    5 * scrapeTimeout,
-  );
-
-  it.concurrent(
     "delay parameter works",
     async () => {
       await crawl(

--- a/apps/api/src/scraper/WebScraper/__tests__/crawler.test.ts
+++ b/apps/api/src/scraper/WebScraper/__tests__/crawler.test.ts
@@ -73,4 +73,83 @@ describe("WebCrawler", () => {
     expect(filteredLinks.links.length).toBe(limit); // Check if the number of results respects the limit
     expect(filteredLinks.links).toEqual([initialUrl, initialUrl + "/page1"]);
   });
+
+  it("should filter subdomain URLs with includePaths when allowSubdomains is true", async () => {
+    const initialUrl = "https://example.com";
+
+    crawler = new WebCrawler({
+      jobId: "TEST",
+      initialUrl: initialUrl,
+      includes: ["^/pricing$"], // Only allow /pricing path
+      excludes: [],
+      limit: 10,
+      maxCrawledDepth: 10,
+      allowSubdomains: true,
+    });
+
+    const linksToFilter = [
+      "https://example.com/pricing", // Should pass: base domain + /pricing
+      "https://example.com/blog", // Should fail: base domain but wrong path
+      "https://sub.example.com/pricing", // Should pass: subdomain + /pricing
+      "https://sub.example.com/about", // Should fail: subdomain but wrong path
+      "https://other.example.com/pricing", // Should pass: subdomain + /pricing
+      "https://other.example.com/contact", // Should fail: subdomain but wrong path
+    ];
+
+    const filteredLinks = await crawler["filterLinks"](linksToFilter, 10, 10);
+
+    expect(filteredLinks.links.length).toBe(3);
+    expect(filteredLinks.links).toContain("https://example.com/pricing");
+    expect(filteredLinks.links).toContain("https://sub.example.com/pricing");
+    expect(filteredLinks.links).toContain("https://other.example.com/pricing");
+
+    // Verify denied links
+    expect(filteredLinks.denialReasons.has("https://example.com/blog")).toBe(
+      true,
+    );
+    expect(
+      filteredLinks.denialReasons.has("https://sub.example.com/about"),
+    ).toBe(true);
+    expect(
+      filteredLinks.denialReasons.has("https://other.example.com/contact"),
+    ).toBe(true);
+  });
+
+  it("should filter subdomain URLs with includePaths using regexOnFullURL", async () => {
+    const initialUrl = "https://example.com";
+
+    crawler = new WebCrawler({
+      jobId: "TEST",
+      initialUrl: initialUrl,
+      includes: ["^https://([a-z0-9-]+\\.)?example\\.com/pricing$"], // Full URL pattern
+      excludes: [],
+      limit: 10,
+      maxCrawledDepth: 10,
+      allowSubdomains: true,
+      regexOnFullURL: true,
+    });
+
+    const linksToFilter = [
+      "https://example.com/pricing", // Should pass: matches pattern
+      "https://example.com/pricing/details", // Should fail: doesn't match exact pattern
+      "https://sub.example.com/pricing", // Should pass: subdomain + /pricing
+      "https://api.example.com/pricing", // Should pass: subdomain + /pricing
+      "https://sub.example.com/blog", // Should fail: wrong path
+    ];
+
+    const filteredLinks = await crawler["filterLinks"](linksToFilter, 10, 10);
+
+    expect(filteredLinks.links.length).toBe(3);
+    expect(filteredLinks.links).toContain("https://example.com/pricing");
+    expect(filteredLinks.links).toContain("https://sub.example.com/pricing");
+    expect(filteredLinks.links).toContain("https://api.example.com/pricing");
+
+    // Verify denied links
+    expect(
+      filteredLinks.denialReasons.has("https://example.com/pricing/details"),
+    ).toBe(true);
+    expect(
+      filteredLinks.denialReasons.has("https://sub.example.com/blog"),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
Ensure subdomain links are filtered with the include path regex