### PR TITLE
Fix Port Conflict in Harness

### DIFF
--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -72,7 +72,7 @@ const stream = createWriteStream("firecrawl.log");
 
 const PORT = process.env.PORT ?? "3002";
 const WORKER_PORT = process.env.WORKER_PORT ?? "3005";
-const EXTRACT_WORKER_PORT = process.env.EXTRACT_WORKER_PORT ?? "3015";
+const EXTRACT_WORKER_PORT = process.env.EXTRACT_WORKER_PORT ?? "3004";
 const NUQ_WORKER_START_PORT = Number(process.env.NUQ_WORKER_START_PORT ?? "3006");
 
 const logger = {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes port conflicts in the harness by making worker ports configurable. This prevents collisions across worker, extract-worker, and NUQ worker processes in local and CI runs.

- **Bug Fixes**
  - Replaced hardcoded ports with env vars: WORKER_PORT, EXTRACT_WORKER_PORT (defaults to WORKER_PORT + 10), NUQ_WORKER_START_PORT (defaults to 3006).
  - Passes the correct env vars to each service and computes NUQ worker ports as NUQ_WORKER_START_PORT + i.

<!-- End of auto-generated description by cubic. -->

