### PR TITLE
fix(crawl): surface robots.txt warning reliably

### DIFF
--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -49,6 +49,20 @@ export async function saveCrawl(id: string, crawl: StoredCrawl) {
   });
 }
 
+export async function recordRobotsBlocked(
+  crawlId: string,
+  url: string,
+) {
+  await redisEvictConnection.sadd(
+    "crawl:" + crawlId + ":robots_blocked",
+    url,
+  );
+  await redisEvictConnection.expire(
+    "crawl:" + crawlId + ":robots_blocked",
+    24 * 60 * 60,
+  );
+}
+
 export async function markCrawlActive(id: string) {
   await redisEvictConnection.sadd("active_crawls", id);
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Show a clear robots.txt warning in crawl results by reliably recording blocked URLs and only surfacing the message after scraping completes. Prevents missing or premature warnings and covers both link-level and top-level robots rejections.

- **Bug Fixes**
  - Added recordRobotsBlocked helper to store blocked URLs in Redis with 24h expiration.
  - Scrape worker records robots blocks from denial reasons and from top-level "URL blocked by robots.txt" errors.
  - Crawl status warns only when status is not "scraping" and respects result count checks for base-domain warnings.

<!-- End of auto-generated description by cubic. -->

