### PR TITLE
feat(nuq): concurrency tracking

### DIFF
--- a/apps/nuq-postgres/nuq.sql
+++ b/apps/nuq-postgres/nuq.sql
@@ -37,6 +37,13 @@ CREATE INDEX IF NOT EXISTS nuq_queue_scrape_queued_optimal_2_idx ON nuq.queue_sc
 CREATE INDEX IF NOT EXISTS nuq_queue_scrape_failed_created_at_idx ON nuq.queue_scrape USING btree (created_at) WHERE (status = 'failed'::nuq.job_status);
 CREATE INDEX IF NOT EXISTS nuq_queue_scrape_completed_created_at_idx ON nuq.queue_scrape USING btree (created_at) WHERE (status = 'completed'::nuq.job_status);
 
+CREATE TABLE IF NOT EXISTS nuq.queue_scrape_owner_concurrency (
+    id uuid NOT NULL,
+    current_concurrency int8 NOT NULL,
+    max_concurrency int8 NOT NULL,
+    CONSTRAINT queue_scrape_owner_concurrency_pkey PRIMARY KEY (id)
+);
+
 SELECT cron.schedule('nuq_queue_scrape_clean_completed', '*/5 * * * *', $$
   DELETE FROM nuq.queue_scrape WHERE nuq.queue_scrape.status = 'completed'::nuq.job_status AND nuq.queue_scrape.created_at < now() - interval '1 hour';
 $$);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds per-owner concurrency tracking to NuQ and enables it for the scrape queue. Job activation, completion, and failure now atomically update per-owner concurrency counts to reduce race conditions.

- **New Features**
  - Added queue option concurrencyLimit: "per-owner".
  - Prefetch and single-job fetch use CTEs to select and activate jobs in one query; when enabled, they increment owner current_concurrency.
  - Completion and failure paths decrement owner current_concurrency with GREATEST(0, ...); notification behavior unchanged.
  - New table: nuq.queue_scrape_owner_concurrency (id, current_concurrency, max_concurrency); inserts default max_concurrency to 100.
  - Enabled per-owner concurrency tracking for nuq.queue_scrape.

- **Migration**
  - Apply apps/nuq-postgres/nuq.sql to create nuq.queue_scrape_owner_concurrency. No data backfill needed.

<!-- End of auto-generated description by cubic. -->

