### PR TITLE
feat(nuq/concurrency-tracking): fix deadlock

### DIFF
--- a/apps/api/src/services/worker/nuq-prefetch-worker.ts
+++ b/apps/api/src/services/worker/nuq-prefetch-worker.ts
@@ -1,35 +1,45 @@
 import "dotenv/config";
-import { scrapeQueue, nuqGetLocalMetrics, nuqHealthCheck, nuqShutdown } from "./nuq";
+import {
+  scrapeQueue,
+  nuqGetLocalMetrics,
+  nuqHealthCheck,
+  nuqShutdown,
+} from "./nuq";
 import Express from "express";
 import { logger } from "../../lib/logger";
 
 (async () => {
-    const app = Express();
+  const app = Express();
 
-    app.get("/metrics", (_, res) => res.contentType("text/plain").send(nuqGetLocalMetrics()));
-    app.get("/health", async (_, res) => {
-        if (await nuqHealthCheck()) {
-            res.status(200).send("OK");
-        } else {
-            res.status(500).send("Not OK");
-        }
-    });
-
-    const server = app.listen(Number(process.env.NUQ_PREFETCH_WORKER_PORT ?? process.env.PORT ?? 3011), () => {
-        logger.info("NuQ prefetch worker metrics server started");
-    });
-
-    async function shutdown() {
-        server.close();
-        await nuqShutdown();
-        process.exit(0);
+  app.get("/metrics", (_, res) =>
+    res.contentType("text/plain").send(nuqGetLocalMetrics()),
+  );
+  app.get("/health", async (_, res) => {
+    if (await nuqHealthCheck()) {
+      res.status(200).send("OK");
+    } else {
+      res.status(500).send("Not OK");
     }
+  });
 
-    process.on("SIGINT", shutdown);
-    process.on("SIGTERM", shutdown);
+  const server = app.listen(
+    Number(process.env.NUQ_PREFETCH_WORKER_PORT ?? process.env.PORT ?? 3011),
+    () => {
+      logger.info("NuQ prefetch worker metrics server started");
+    },
+  );
 
-    while (true) {
-        await scrapeQueue.prefetchJobs();
-        await new Promise(resolve => setTimeout(resolve, 250));
-    }
+  async function shutdown() {
+    server.close();
+    await nuqShutdown();
+    process.exit(0);
+  }
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  while (true) {
+    await scrapeQueue.prefetchJobs();
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
 })();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes deadlocks in NuQ per-owner concurrency tracking by using deterministic per-owner advisory locks and smaller batches. This prevents stuck workers and skipped jobs, and smooths prefetching.

- **Bug Fixes**
  - Acquire pg_advisory_xact_lock per owner in a deterministic order to avoid deadlocks between workers.
  - Upsert now increments current_concurrency and updates max_concurrency for owners.
  - Reduce batch size from 500 to 100 to lower lock contention; increase prefetch cadence from 250ms to 100ms.

<!-- End of auto-generated description by cubic. -->

