### PR TITLE
fix(nuq): fix prefetch row representation

### DIFF
--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -312,7 +312,7 @@ class NuQ<JobData = any, JobReturnValue = any> {
   }
 
   private async sendJobPrefetch(
-    job: NuQJob<JobData, JobReturnValue>,
+    job: any, // this is the row/db representation here!!
     _logger: Logger = logger,
   ) {
     await this.startSender();
@@ -1028,7 +1028,7 @@ class NuQ<JobData = any, JobReturnValue = any> {
             UPDATE ${this.queueName} q SET status = 'active'::nuq.job_status, lock = gen_random_uuid(), locked_at = now() FROM next WHERE q.id = next.id RETURNING ${this.jobReturning.map(x => `q.${x}`).join(", ")};
           `,
         )
-      ).rows.map(row => this.rowToJob(row)!);
+      ).rows;
 
       for (const job of jobs) {
         await this.sendJobPrefetch(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes NuQ worker prefetch to use the raw DB row representation. Prevents type mismatches when sending prefetch and stabilizes job activation.

- **Bug Fixes**
  - sendJobPrefetch now accepts a DB row; removed rowToJob conversion for prefetch.
  - Prefetch query returns rows directly before sending.

<!-- End of auto-generated description by cubic. -->

