### PR TITLE
Rust client: use `tracing` instead of print

### DIFF
--- a/apps/rust-sdk/Cargo.lock
+++ b/apps/rust-sdk/Cargo.lock
@@ -703,6 +703,7 @@ dependencies = [
  "serde_with",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -2676,7 +2677,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/apps/rust-sdk/Cargo.toml
+++ b/apps/rust-sdk/Cargo.toml
@@ -25,6 +25,7 @@ uuid = { version = "^1.10", features = ["v4"] }
 tokio = { version = "^1", features = ["full"] }
 futures = "0.3.31"
 schemars = "0.8.22"
+tracing = ">=0.1.0,<0.2.0"
 
 [dev-dependencies]
 clippy = "^0.0.302"

--- a/apps/rust-sdk/src/lib.rs
+++ b/apps/rust-sdk/src/lib.rs
@@ -84,8 +84,7 @@ impl FirecrawlApp {
                 serde_json::from_str::<Value>(&response_json)
                     .map_err(|e| FirecrawlError::ResponseParseError(e))
                     .inspect(|data| {
-                        #[cfg(debug_assertions)]
-                        println!("Response JSON: {:#?}", data);
+                        tracing::debug!("Response JSON: {:#?}", data);
                     })
             })
             .and_then(|response_value| {


### PR DESCRIPTION
Polling the status of a crawl quickly fills up my terminal with unnecessarily verbose output.

Using the standard `tracing` crate allows users to configure their desired log level and ship logs somewhere else if they wish.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched the Rust SDK from println! to tracing for debug logs. This cuts terminal noise and lets users control log levels and route logs.

- **Refactors**
  - Replaced conditional println with tracing::debug in FirecrawlApp response parsing.

- **Dependencies**
  - Added tracing 0.1 to rust-sdk.

<!-- End of auto-generated description by cubic. -->

