### PR TITLE
Make auto-recharge notifications less noisy

### DIFF
--- a/apps/api/src/services/billing/auto_charge.ts
+++ b/apps/api/src/services/billing/auto_charge.ts
@@ -307,7 +307,7 @@ async function _autoChargeScale(
 
           if (process.env.SLACK_ADMIN_WEBHOOK_URL) {
             sendSlackWebhook(
-              `💰 Auto-recharge successful on team ${chunk.team_id} for ${price.credits} credits (total auto-recharges this month: ${rechargesThisMonth.length}).`,
+              `💰 Auto-recharge successful on team ${chunk.team_id} for ${price.credits} credits (total auto-recharges this month: ${rechargesThisMonth.length + 1}).`,
               false,
               process.env.SLACK_ADMIN_WEBHOOK_URL,
             ).catch(error => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reduced auto-recharge admin Slack noise by removing the failure notification for “too many recharges this month” and adding the monthly recharge count to success messages. Keeps admins informed with less spam.

<!-- End of auto-generated description by cubic. -->

