### PR TITLE
fix: scrape viewport test

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-viewport.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-viewport.test.ts
@@ -42,7 +42,7 @@ describeIf(TEST_PRODUCTION)("V2 Scrape Screenshot Viewport", () => {
   test(
     "should reject fullPage=true with viewport",
     async () => {
-      const data = await scrapeRaw(
+      const response = await scrapeRaw(
         {
           url: "https://example.com",
           formats: [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the local variable from data to response in the V2 scrape viewport test to improve clarity and match the scrapeRaw response semantics.
No behavior change; this is a test naming fix.

<!-- End of auto-generated description by cubic. -->

