### PR TITLE
chore: update last scrape rpc

### DIFF
--- a/apps/api/src/scraper/scrapeURL/transformers/diff.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/diff.ts
@@ -89,7 +89,7 @@ export async function deriveDiff(
     }
 
     const start = Date.now();
-    const res = await supabase_service.rpc("diff_get_last_scrape_5", {
+    const res = await supabase_service.rpc("diff_get_last_scrape_6", {
       i_team_id: meta.internalOptions.teamId,
       i_url: document.metadata.sourceURL ?? meta.rewrittenUrl ?? meta.url,
       i_tag: changeTrackingFormat?.tag ?? null,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the Supabase RPC in deriveDiff from diff_get_last_scrape_5 to diff_get_last_scrape_6. This keeps the scraper in sync with the latest backend function and ensures accurate last-scrape data.

<!-- End of auto-generated description by cubic. -->

