### PR TITLE
Fix autoCharge return, add top level guard

### DIFF
--- a/apps/api/src/services/billing/credit_billing.ts
+++ b/apps/api/src/services/billing/credit_billing.ts
@@ -131,8 +131,10 @@ async function supaCheckTeamCredits(
       autoRechargeThreshold,
       remainingCredits: chunk.remaining_credits,
     });
+
     const autoChargeResult = await autoCharge(chunk, autoRechargeThreshold);
-    if (autoChargeResult.success) {
+
+    if (autoChargeResult && autoChargeResult.success) {
       return {
         success: true,
         message: autoChargeResult.message,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes undefined errors in supaCheckTeamCredits by making autoCharge always return a typed result and adding a call-site guard. Addresses ENG-3863 and makes auto-recharge safer during cooldowns.

- **Bug Fixes**
  - autoCharge now returns AutoChargeResponse in all paths, including cooldown.
  - supaCheckTeamCredits guards against a falsy autoChargeResult before reading fields.

- **Refactors**
  - Introduced AutoChargeResponse type and updated function signatures.
  - Typed redlock.using callbacks for clearer, safer returns.

<!-- End of auto-generated description by cubic. -->

