### PR TITLE
fix: error truncation

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
@@ -215,7 +215,10 @@ export async function fireEngineCheckStatus(
       (status.error.includes("Element") ||
         status.error.includes("Javascript execution failed"))
     ) {
-      throw new ActionError(status.error.split("Error: ")[1]);
+      const errorMessage = status.error.startsWith("Error: ")
+        ? status.error.substring(7)
+        : status.error;
+      throw new ActionError(errorMessage);
     } else {
       throw new EngineError("Scrape job failed", {
         cause: {

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -262,7 +262,10 @@ export async function fireEngineScrape<
       (status.error.includes("Element") ||
         status.error.includes("Javascript execution failed"))
     ) {
-      throw new ActionError(status.error.split("Error: ")[1]);
+      const errorMessage = status.error.startsWith("Error: ")
+        ? status.error.substring(7)
+        : status.error;
+      throw new ActionError(errorMessage);
     } else if (
       typeof status.error === "string" &&
       status.error.includes("proxies available for")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes truncated ActionError messages in Fire Engine by only removing the "Error:" prefix when it starts the message, preserving the full error text. Addresses ENG-3838 so element lookup and JavaScript execution failures show complete, useful errors.

<sup>Written for commit 446677a6f8a730efebba684f53e7b6923624fcee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

