### PR TITLE
feat(billing): merge credits and tokens

### DIFF
--- a/apps/api/src/__tests__/snips/v1/billing.test.ts
+++ b/apps/api/src/__tests__/snips/v1/billing.test.ts
@@ -382,7 +382,7 @@ describeIf(TEST_PRODUCTION)("Billing tests", () => {
 
       const rc2 = (await tokenUsage(identity)).remaining_tokens;
 
-      expect(rc1 - rc2).toBe(305);
+      expect(rc1 - rc2).toBe(315); // rounded to closest 15 due to internal logic
     },
     300000,
   );

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -190,7 +190,7 @@ export async function getACUC(
       const client =
         Math.random() > 2 / 3 ? supabase_rr_service : supabase_service;
       ({ data, error } = await client.rpc(
-        "auth_credit_usage_chunk_35",
+        "auth_credit_usage_chunk_36",
         {
           input_key: api_key,
           i_is_extract: isExtract,
@@ -317,7 +317,7 @@ export async function getACUCTeam(
       const client =
         Math.random() > 2 / 3 ? supabase_rr_service : supabase_service;
       ({ data, error } = await client.rpc(
-        "auth_credit_usage_chunk_35_from_team",
+        "auth_credit_usage_chunk_36_from_team",
         {
           input_team: team_id,
           i_is_extract: isExtract,

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -304,7 +304,7 @@ async function supaBillTeam(
   _logger.info(`Batch billing team ${team_id} for ${credits} credits`);
 
   // Perform the actual database operation
-  const { data, error } = await supabase_service.rpc("bill_team_5", {
+  const { data, error } = await supabase_service.rpc("bill_team_6", {
     _team_id: team_id,
     sub_id: subscription_id ?? null,
     fetch_subscription: subscription_id === undefined,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Merged credits and tokens into a single billing flow. Usage is rounded to the nearest 15-unit step, and API calls now use the latest billing/usage RPCs.

- **New Features**
  - Unified credit/token accounting across usage and batch billing.
  - Usage deltas rounded to 15 units; tests updated (e.g., 305 → 315).
  - Switched to auth_credit_usage_chunk_36(_from_team) and bill_team_6.

- **Migration**
  - Deploy DB changes that add auth_credit_usage_chunk_36, auth_credit_usage_chunk_36_from_team, and bill_team_6 before deploying the API.

<sup>Written for commit 19c5659dce98e8662593961b3ae6ee078048798d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

