### PR TITLE
chore: update geoip database

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -107,7 +107,7 @@
     "escape-html": "^1.0.3",
     "express": "^4.21.2",
     "express-ws": "^5.0.2",
-    "geoip-country": "^5.0.202508192342",
+    "geoip-country": "^5.0.202510312342",
     "git-diff": "^2.0.6",
     "http-cookie-agent": "^7.0.1",
     "ioredis": "^5.6.1",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2(bufferutil@4.0.9)(express@4.21.2)(utf-8-validate@5.0.10)
       geoip-country:
-        specifier: ^5.0.202508192342
-        version: 5.0.202508192342
+        specifier: ^5.0.202510312342
+        version: 5.0.202510312342
       git-diff:
         specifier: ^2.0.6
         version: 2.0.6
@@ -4555,8 +4555,8 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  geoip-country@5.0.202508192342:
-    resolution: {integrity: sha512-aezJJvZEACWX9tbB4jo5wNzh/HtSNM5YdRjc3RjBFdLdmBd9UO25CqCfbNaKU4uk3L9Wct6Ra8mqsbfGOUM0UQ==}
+  geoip-country@5.0.202510312342:
+    resolution: {integrity: sha512-I9PZFp8AkfVQSe0RjLSUwttm/xfhDnIJJ5jaZkMMSsKvC6lqNkVUKBBISOZnMfcwA3H2GvgyyjXTMWtrIBweMg==}
     engines: {node: '>=10.20.0'}
 
   get-caller-file@2.0.5:
@@ -12824,7 +12824,7 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  geoip-country@5.0.202508192342:
+  geoip-country@5.0.202510312342:
     dependencies:
       async: 2.6.4
       countries-list: 3.1.1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated geoip-country to 5.0.202510312342 to use the latest GeoIP data and improve IP-to-country accuracy in the API. No runtime code changes.

<sup>Written for commit c541af117e180ae767880de97d9e6f9ea4bac039. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

