### PR TITLE
Implement retry logic for PDF and document scraping

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -954,7 +954,7 @@ export async function scrapeURL(
     }
 
     try {
-      let result: ScrapeUrlResponse
+      let result: ScrapeUrlResponse;
       let pdfRetries = 0;
       let documentRetries = 0;
       const MAX_RETRIES = parseInt(process.env.SCRAPE_MAX_RETRIES || "3", 10);


### PR DESCRIPTION
Added retry logic for PDF and document scraping, fixes https://github.com/firecrawl/firecrawl/issues/2350



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add retry logic to PDF and document scraping to handle anti-bot blocks and reduce flaky failures. Retries stop after the configured limit and return clear errors when blocking persists.

- **New Features**
  - Retries on PDFAntibotError and DocumentAntibotError, capped by SCRAPE_MAX_RETRIES env (default 3).
  - Logs attempts; when the limit is hit or prefetched content is still blocked, throws PDFPrefetchFailed or DocumentPrefetchFailed.

<sup>Written for commit 02ce20b6b9f8173456841dd2ccdc577c57bdc2d1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



