### PR TITLE
feat: allow disabling webhook delivery

### DIFF
--- a/apps/api/src/services/webhook/delivery.ts
+++ b/apps/api/src/services/webhook/delivery.ts
@@ -62,7 +62,14 @@ export class WebhookSender {
   }
 
   private shouldSendEvent(event: WebhookEvent): boolean {
-    if (!this.config.events?.length) return true;
+    if (process.env.DISABLE_WEBHOOK_DELIVERY === "true") {
+      return false;
+    }
+
+    if (!this.config.events?.length) {
+      return true;
+    }
+
     const subType = event.split(".")[1];
     return this.config.events.includes(subType as any);
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add an environment flag to turn off webhook delivery. When DISABLE_WEBHOOK_DELIVERY=true, we skip sending all events; default behavior is unchanged.

<sup>Written for commit 8954945bc12d8e094e51c9c6143db2086c2886c7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

