### PR TITLE
revert nuq commits

### DIFF
--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -1093,7 +1093,7 @@ class NuQ<JobData = any, JobReturnValue = any> {
       const jobs = (
         await nuqPool.query(
           `
-            WITH next AS (SELECT id FROM ${this.queueName} WHERE ${this.queueName}.status = 'queued'::nuq.job_status ORDER BY ${this.queueName}.priority ASC, ${this.queueName}.created_at ASC FOR UPDATE SKIP LOCKED LIMIT 250)
+            WITH next AS (SELECT id FROM ${this.queueName} WHERE ${this.queueName}.status = 'queued'::nuq.job_status ORDER BY ${this.queueName}.priority ASC, ${this.queueName}.created_at ASC FOR UPDATE SKIP LOCKED LIMIT 500)
             UPDATE ${this.queueName} q SET status = 'active'::nuq.job_status, lock = gen_random_uuid(), locked_at = now() FROM next WHERE q.id = next.id RETURNING ${this.jobReturning.map(x => `q.${x}`).join(", ")};
           `,
         )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverts recent NuQ throttling changes to restore higher throughput. Increases addJobs batch size from 200 to 1000 and raises prefetch activation limit from 200 to 500.

<sup>Written for commit 01fa88cc4a8eb4993ce9cbfc852ee4e42706015b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

