### PR TITLE
CI: Remove npm audit from server tests

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -10,15 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
   self-host:
     name: Self-hosted environment tests
     strategy:
@@ -35,7 +26,6 @@ jobs:
         # search: ["searxng", "google"]
         # ai: ["openai", "no-ai"]
     runs-on: big-runner
-    needs: setup
     services:
       redis:
         image: redis


### PR DESCRIPTION
Prevent audit failures from cancelling test runs, this already runs on a separate workflow



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed npm audit from the server test workflow to prevent audit failures from canceling tests and speed up runs. Also removed the unused commented build-images block and the audit dependency from the self-host job.

- **Refactors**
  - Deleted the audit job and all audit-ci steps.
  - Removed needs: audit from self-host.
  - Dropped the commented build-images block.

<sup>Written for commit 8e5517c6abd98b8bc20c8b43b4c2374eeef2ec49. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



