### PR TITLE
ci: Fix dependency audit

### DIFF
--- a/apps/api/audit-ci.jsonc
+++ b/apps/api/audit-ci.jsonc
@@ -8,6 +8,7 @@
         "GHSA-qj3p-xc97-xw74|@coinbase/x402>x402>wagmi>@wagmi/connectors>@metamask/sdk>@metamask/sdk-communication-layer", // we don't use the Metamask SDK in the browser
         "GHSA-ffrw-9mx8-89p8|@coinbase/x402>x402>wagmi>@wagmi/connectors>@walletconnect/ethereum-provider>@reown/appkit>@reown/appkit-utils>@walletconnect/logger>pino>fast-redact", // unused
         "GHSA-m732-5p4w-x69g|@coinbase/x402>x402>wagmi>@wagmi/connectors>porto>hono", // we don't use hono
-        "GHSA-q7jf-gf43-6x6p|@coinbase/x402>x402>wagmi>@wagmi/connectors>porto>hono" // we don't use hono
+        "GHSA-q7jf-gf43-6x6p|@coinbase/x402>x402>wagmi>@wagmi/connectors>porto>hono", // we don't use hono
+        "GHSA-rwvc-j5jr-mgvh|ai" // file upload vulnerability - not exposed in our usage
     ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes failing dependency audit in CI by allowing GHSA-rwvc-j5jr-mgvh (ai) in audit-ci. The advisory targets a file upload path we don’t use, so there’s no security impact and CI is unblocked.

<sup>Written for commit 8593ff39fe9012d7c62f545d2b490d25ebdd04c4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

