### PR TITLE
fix typo in llm dependent features comment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ SUPABASE_SERVICE_TOKEN=
 
 # Other Optionals
 TEST_API_KEY= # use if you've set up authentication and want to test with a real API key
-OPENAI_API_KEY= # add for LLM dependednt features (image alt generation, etc.)
+OPENAI_API_KEY= # add for LLM dependent features (image alt generation, etc.)
 BULL_AUTH_KEY= @
 PLAYWRIGHT_MICROSERVICE_URL=  # set if you'd like to run a playwright fallback
 LLAMAPARSE_API_KEY= #Set if you have a llamaparse key you'd like to use to parse pdfs

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -30,7 +30,7 @@ RATE_LIMIT_TEST_API_KEY_SCRAPE=
 RATE_LIMIT_TEST_API_KEY_CRAWL=
 # set if you'd like to use scraping Be to handle JS blocking
 SCRAPING_BEE_API_KEY=
-# add for LLM dependednt features (image alt generation, etc.)
+# add for LLM dependent features (image alt generation, etc.)
 OPENAI_API_KEY=
 BULL_AUTH_KEY=@
 # set if you have a llamaparse key you'd like to use to parse pdfs


### PR DESCRIPTION
Fix a minor typo ("dependednt" to "dependent") 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a typo in LLM-related comments (“dependednt” → “dependent”) in CONTRIBUTING.md and apps/api/.env.example to improve clarity.

<sup>Written for commit f0f057c1e2172c78039a6299c874dd087d9e8178. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

