### PR TITLE
fix: validate UUID before querying

### DIFF
--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -1462,6 +1462,10 @@ class NuQJobGroup {
         "nuq.group_id": id,
       });
 
+      if (!isUUID(id)) {
+        return null;
+      }
+
       const start = Date.now();
       try {
         const result = this.rowToGroup(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate group_id as a UUID before querying, returning null for invalid IDs. This prevents unnecessary database hits and avoids errors from malformed IDs.

<sup>Written for commit bd6bdde5dd0471fdd4a2090962e61dcb9f1bd33b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

