### PR TITLE
(feat/dns) DNS Resolution errors should be a 200

### DIFF
--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -136,6 +136,15 @@ export async function scrapeController(
     }
 
     if (e instanceof TransportableError) {
+      // DNS resolution errors should return 200 with success: false
+      if (e.code === "SCRAPE_DNS_RESOLUTION_ERROR") {
+        return res.status(200).json({
+          success: false,
+          code: e.code,
+          error: e.message,
+        });
+      }
+
       return res.status(e.code === "SCRAPE_TIMEOUT" ? 408 : 500).json({
         success: false,
         code: e.code,

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -206,6 +206,18 @@ export async function scrapeController(
         }
 
         if (e instanceof TransportableError) {
+          // DNS resolution errors should return 200 with success: false
+          if (e.code === "SCRAPE_DNS_RESOLUTION_ERROR") {
+            setSpanAttributes(span, {
+              "scrape.status_code": 200,
+            });
+            return res.status(200).json({
+              success: false,
+              code: e.code,
+              error: e.message,
+            });
+          }
+
           const statusCode = e.code === "SCRAPE_TIMEOUT" ? 408 : 500;
           setSpanAttributes(span, {
             "scrape.status_code": statusCode,

--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -7,6 +7,7 @@ import {
 } from "../controllers/v2/types";
 import { CostTracking } from "./cost-tracking";
 import { hasFormatOfType } from "./format-utils";
+import { TransportableError } from "./error";
 
 const creditsPerPDFPage = 1;
 const stealthProxyCostBonus = 4;
@@ -17,6 +18,7 @@ export async function calculateCreditsToBeBilled(
   document: Document | null,
   costTracking: CostTracking | ReturnType<typeof CostTracking.prototype.toJSON>,
   flags: TeamFlags,
+  error?: Error | null,
 ) {
   const costTrackingJSON: ReturnType<typeof CostTracking.prototype.toJSON> =
     costTracking instanceof CostTracking ? costTracking.toJSON() : costTracking;
@@ -30,6 +32,14 @@ export async function calculateCreditsToBeBilled(
       internalOptions.v1JSONAgent?.model?.toLowerCase() === "fire-1"
     ) {
       creditsToBeBilled = Math.ceil((costTrackingJSON.totalCost ?? 1) * 1800);
+    }
+
+    // Bill for DNS resolution errors
+    if (
+      error instanceof TransportableError &&
+      error.code === "SCRAPE_DNS_RESOLUTION_ERROR"
+    ) {
+      creditsToBeBilled = 1;
     }
 
     return creditsToBeBilled;

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -90,6 +90,7 @@ async function billScrapeJob(
   logger: Logger,
   costTracking: CostTracking,
   flags: TeamFlags,
+  error?: Error | null,
 ) {
   let creditsToBeBilled: number | null = null;
 
@@ -100,6 +101,7 @@ async function billScrapeJob(
       document,
       costTracking,
       flags,
+      error,
     );
 
     if (
@@ -658,6 +660,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
       logger,
       costTracking,
       (await getACUCTeam(job.data.team_id))?.flags ?? null,
+      error instanceof Error ? error : null,
     );
 
     logger.debug("Logging job to DB...");


### PR DESCRIPTION
DNS Resolution errors should be a 200 with a success flag = false.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
DNS resolution errors in the v1/v2 scrape endpoints now return 200 with success: false. We also bill 1 credit for these cases and set tracing status_code to 200.

- **New Features**
  - v1/v2 scrape controllers return 200 with success:false, code, and error for SCRAPE_DNS_RESOLUTION_ERROR; spans record scrape.status_code=200.
  - Billing charges 1 credit on DNS resolution errors; worker forwards the error to billing.

<sup>Written for commit 9f6daa166206c26c4dabd0d1aa754153d30601ad. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

