### PR TITLE
fix docker-compose service build instructions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,7 @@ x-common-env: &common-env
 services:
   playwright-service:
     # NOTE: If you don't want to build the service locally,
-    # uncomment the build: statement and comment out the image: statement
+    # comment out the build: statement and uncomment the image: statement
     # image: ghcr.io/firecrawl/playwright-service:latest
     build: apps/playwright-service-ts
     environment:


### PR DESCRIPTION
Updated comment for clarity on service configuration. The logic should be swapped



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the docker-compose comment so the instructions are accurate: if you don’t want to build locally, comment out build and uncomment image. This prevents misconfiguration when using the prebuilt image.

<sup>Written for commit 9a1da8577e457476136e92b82bb979ce3700bf7c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



