### PR TITLE
(js-sdk): Fix types

### DIFF
--- a/.github/workflows/test-js-sdk.yml
+++ b/.github/workflows/test-js-sdk.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm install
         working-directory: ./apps/js-sdk/firecrawl
+      - name: Build
+        run: npm run build
+        working-directory: ./apps/js-sdk/firecrawl
       - name: Run tests
         run: npm run test
         working-directory: ./apps/js-sdk/firecrawl

--- a/apps/js-sdk/firecrawl/src/v2/watcher.ts
+++ b/apps/js-sdk/firecrawl/src/v2/watcher.ts
@@ -114,6 +114,7 @@ export class Watcher extends EventEmitter {
     const data = (payload.data || []) as Document[];
     const snap: Snapshot = this.kind === "crawl"
       ? {
+          id: this.jobId,
           status,
           completed: payload.completed ?? 0,
           total: payload.total ?? 0,
@@ -123,6 +124,7 @@ export class Watcher extends EventEmitter {
           data,
         }
       : {
+          id: this.jobId,
           status,
           completed: payload.completed ?? 0,
           total: payload.total ?? 0,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed Snapshot typing in the JS SDK by adding id: this.jobId in v2 Watcher so snapshots include the required id. Updated the GitHub Actions workflow to build the SDK before running tests to catch type and build issues early.

<sup>Written for commit 375717413b3a7313821bba367b4e2e434193f053. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

