### PR TITLE
(js-sdk): Bump Version

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Firecrawl JS SDK version in package.json from 4.6.0 to 4.6.1 to publish a patch release. No code changes.

<sup>Written for commit f8951c7681e5d8341477ac9616a0081373a510aa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

