### PR TITLE
Muv2 exp add more logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ apps/python-sdk/.venv/
 
 
 /apps/go-html-to-md-service/.gomodcache/
+target/

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -74,8 +74,15 @@ async function scrapePDFWithRunPodMU(
       Number(process.env.PDF_MU_V2_EXPERIMENT_PERCENT ?? "100")
   ) {
     (async () => {
+      const pdfParseId = crypto.randomUUID();
       const startedAt = Date.now();
       const logger = meta.logger.child({ method: "scrapePDF/MUv2Experiment" });
+      logger.info("MU v2 experiment started", {
+        scrapeId: meta.id,
+        pdfParseId,
+        url: meta.rewrittenUrl ?? meta.url,
+        maxPages,
+      });
       try {
         const resp = await robustFetch({
           url: process.env.PDF_MU_V2_BASE_URL ?? "",
@@ -86,6 +93,7 @@ async function scrapePDFWithRunPodMU(
               filename: path.basename(tempFilePath) + ".pdf",
               timeout: meta.abort.scrapeTimeout(),
               created_at: Date.now(),
+              id: pdfParseId,
               ...(maxPages !== undefined && { max_pages: maxPages }),
             },
           },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added structured logging to the MU v2 PDF scrape experiment to improve traceability, including a unique pdfParseId and a start log with scrapeId, URL, and maxPages. Also updated .gitignore to ignore the target/ directory.

<sup>Written for commit 5df764392efa59d9d55684d4d3020fdf27859cc9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

