### PR TITLE
Fix concurrency backfill bug

### DIFF
--- a/apps/api/src/controllers/v0/admin/concurrency-queue-backfill.ts
+++ b/apps/api/src/controllers/v0/admin/concurrency-queue-backfill.ts
@@ -38,7 +38,11 @@ export async function concurrencyQueueBackfillController(
       cursor = result[0];
       const results = result[1];
 
-      results.forEach(x => queuedJobIDs.add(JSON.parse(x).id));
+      // zscan returns [member1, score1, member2, score2, ...]
+      // Only parse members (even indices), skip scores (odd indices)
+      for (let i = 0; i < results.length; i += 2) {
+        queuedJobIDs.add(JSON.parse(results[i]).id);
+      }
     } while (cursor !== "0");
 
     const jobIDsToAdd = new Set(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the concurrency queue backfill to correctly parse Redis zscan output by reading only members and skipping scores. Prevents missing or incorrect queued job IDs during backfill.

<sup>Written for commit 72713be8b4eab2ee036db5d1d8665e8419ef4e47. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

