### PR TITLE
feat: redirect to docs when hitting main api endpoint

### DIFF
--- a/apps/api/src/__tests__/e2e_full_withAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_full_withAuth/index.test.ts
@@ -16,20 +16,12 @@ describe("E2E Tests for API Routes", () => {
   afterAll(() => {
     delete process.env.USE_DB_AUTHENTICATION;
   });
-  describe("GET /", () => {
-    it.concurrent("should return Hello, world! message", async () => {
-      const response = await request(TEST_URL).get("/");
 
+  describe("GET /e2e-test", () => {
+    it.concurrent("should return OK message", async () => {
+      const response = await request(TEST_URL).get("/e2e-test");
       expect(response.statusCode).toBe(200);
-      expect(response.text).toContain("SCRAPERS-JS: Hello, world! Fly.io");
-    });
-  });
-
-  describe("GET /test", () => {
-    it.concurrent("should return Hello, world! message", async () => {
-      const response = await request(TEST_URL).get("/test");
-      expect(response.statusCode).toBe(200);
-      expect(response.text).toContain("Hello, world!");
+      expect(response.text).toContain("OK");
     });
   });
 

--- a/apps/api/src/__tests__/e2e_noAuth/index.test.ts
+++ b/apps/api/src/__tests__/e2e_noAuth/index.test.ts
@@ -32,19 +32,11 @@ describe("E2E Tests for API Routes with No Authentication", () => {
     process.env = originalEnv;
   });
 
-  describe("GET /", () => {
-    it("should return Hello, world! message", async () => {
-      const response = await request(TEST_URL).get("/");
+  describe("GET /e2e-test", () => {
+    it.concurrent("should return OK message", async () => {
+      const response = await request(TEST_URL).get("/e2e-test");
       expect(response.statusCode).toBe(200);
-      expect(response.text).toContain("SCRAPERS-JS: Hello, world! Fly.io");
-    });
-  });
-
-  describe("GET /test", () => {
-    it("should return Hello, world! message", async () => {
-      const response = await request(TEST_URL).get("/test");
-      expect(response.statusCode).toBe(200);
-      expect(response.text).toContain("Hello, world!");
+      expect(response.text).toContain("OK");
     });
   });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -89,13 +89,12 @@ app.use(
   serverAdapter.getRouter(),
 );
 
-app.get("/", (req, res) => {
-  res.send("SCRAPERS-JS: Hello, world! K8s!");
+app.get("/", (_, res) => {
+  res.redirect("https://docs.firecrawl.dev/api-reference/v2-introduction");
 });
 
-//write a simple test function
-app.get("/test", async (req, res) => {
-  res.send("Hello, world!");
+app.get("/e2e-test", (_, res) => {
+  res.status(200).send("OK");
 });
 
 // register router


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Redirected the root API endpoint (/) to the Firecrawl docs and replaced the old /test route with a simple /e2e-test health check. This makes the entry point clearer and keeps tests stable.

- **New Features**
  - GET / now redirects to https://docs.firecrawl.dev/api-reference/v2-introduction.
  - Added GET /e2e-test returning 200 OK with "OK".
  - Updated E2E tests to hit /e2e-test; removed "Hello, world!" assertions.

<sup>Written for commit 052fe5dfcb1ab4e22e7fa66c5a2a7f27cd1d81b5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

