### PR TITLE
fix(api): logJob for noq requests

### DIFF
--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -18,6 +18,7 @@ export async function logJob(
   job: FirecrawlJob,
   force: boolean = false,
   bypassLogging: boolean = false,
+  requiresBlob = false,
 ) {
   const useDbAuthentication = process.env.USE_DB_AUTHENTICATION === "true";
   if (!useDbAuthentication) {
@@ -38,7 +39,7 @@ export async function logJob(
 
   try {
     // Save to GCS if configured
-    if (process.env.GCS_BUCKET_NAME) {
+    if (process.env.GCS_BUCKET_NAME && (!zeroDataRetention || requiresBlob)) {
       await withSpan("firecrawl-log-job-save-to-gcs", async span => {
         setSpanAttributes(span, {
           "log_job.operation": "save_to_gcs",

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -531,7 +531,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
 
       doc.metadata.creditsUsed = credits_billed ?? undefined;
 
-      await logJob(
+      const logPromise = logJob(
         {
           job_id: job.id,
           success: true,
@@ -556,7 +556,18 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
         },
         false,
         job.data.internalOptions?.bypassBilling ?? false,
+        !job.data.skipNuq,
       );
+
+      if (!job.data.skipNuq) {
+        await logPromise;
+      } else {
+        logPromise.catch(error => {
+          logger.error(
+            `Failed to log job for team ${job.data.team_id}: ${error}`,
+          );
+        });
+      }
     }
 
     logger.info(`🐂 Job done ${job.id}`);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes job logging for NoQ requests by making logging non-blocking when skipNuq is true and ensuring GCS blob writes only happen when required.

- **Bug Fixes**
  - Added requiresBlob to logJob; save to GCS only if a bucket is set and either data retention allows it or a blob is required.
  - In scrape-worker, pass requiresBlob as !skipNuq; await logging for NuQ jobs, fire-and-forget for NoQ, and log errors if logging fails.

<sup>Written for commit 0573252cca4f906d5d5348c2e0277d05bb0c3a81. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

