### PR TITLE
feat(api): total wait time in request metrics

### DIFF
--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -210,6 +210,7 @@ export async function scrapeController(
     middlewareTime,
     controllerTime,
     totalRequestTime,
+    totalWait,
   });
 
   return res.status(200).json({

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -281,6 +281,7 @@ export async function scrapeController(
         "scrape.status_code": 200,
         "scrape.total_request_time_ms": totalRequestTime,
         "scrape.controller_time_ms": controllerTime,
+        "scrape.total_wait_time_ms": totalWait,
         "scrape.document.status_code": doc?.metadata?.statusCode,
         "scrape.document.content_type": doc?.metadata?.contentType,
         "scrape.document.error": doc?.metadata?.error,
@@ -295,6 +296,7 @@ export async function scrapeController(
         middlewareTime,
         controllerTime,
         totalRequestTime,
+        totalWait,
       });
 
       return res.status(200).json({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds total wait time to scrape request metrics to improve observability of request delays. This exposes a new metric and includes it in the emitted metrics for both v1 and v2 controllers.

- **New Features**
  - Emit scrape.total_wait_time_ms in v2 telemetry.
  - Include totalWait in the metrics payload for v1 and v2 scrape controllers.

<sup>Written for commit 1295c481ef30a357354969a289d26e50edaca493. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

