### PR TITLE
fix(api): tally system rework

### DIFF
--- a/apps/api/src/controllers/v0/admin/metrics.ts
+++ b/apps/api/src/controllers/v0/admin/metrics.ts
@@ -38,6 +38,11 @@ ${Object.entries(metrics)
       `concurrency_limit_queue_job_count{team_id="${key}"} ${value}`,
   )
   .join("\n")}
+
+# HELP billed_teams_count The number of teams that have been billed but not yet tallied
+# TYPE billed_teams_count gauge
+billed_teams_count ${await getRedisConnection().scard("billed_teams")}
+
 ${nuqGetLocalMetrics()}
 ${semaphoreMetrics}`);
 }

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -319,6 +319,8 @@ async function supaBillTeam(
     return { success: false, error };
   }
 
+  await getRedisConnection().sadd("billed_teams", team_id);
+
   // Update cached ACUC to reflect the new credit usage
   (async () => {
     for (const apiKey of (data ?? []).map(x => x.api_key)) {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reworked the billing tally flow to decouple billing from tally updates using a Redis-backed queue and a periodic worker. This reduces DB load and adds clear visibility into pending tallies.

- **New Features**
  - After successful billing, teams are added to a Redis set billed_teams.
  - The index worker runs every 5 minutes, processes up to 100 team IDs from the set, and calls update_tally_5_team for each.
  - Added Prometheus gauge billed_teams_count to track the backlog of billed but not yet tallied teams.

<sup>Written for commit 6393468186177bdd699106e063a80383c30ec878. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



