### PR TITLE
fix(api): throw if not using a proxy

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
@@ -22,7 +22,7 @@ function makeSecureDispatcher(skipTlsVerification: boolean) {
   const agentOpts: undici.Agent.Options = {
     maxRedirections: 5000,
   };
-  if (!process.env.PROXY_SERVER && process.env.USE_DB_AUTHENTICATION) {
+  if (!process.env.PROXY_SERVER && process.env.USE_DB_AUTHENTICATION === "true") {
     throw new Error(
       "PROXY_SERVER is not set and USE_DB_AUTHENTICATION is true",
     );


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces proxy usage when DB authentication is enabled by throwing if PROXY_SERVER is not set. This prevents unsafe direct requests and fails fast on misconfiguration.

- **Migration**
  - Set PROXY_SERVER when USE_DB_AUTHENTICATION=true.
  - Or disable USE_DB_AUTHENTICATION if a proxy is not available.

<sup>Written for commit e1e51e433299c6c09f77ae6256e8978d0db66253. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



