### PR TITLE
fix(api): /map returning less urls with sitemap include

### DIFF
--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -143,6 +143,7 @@ export class WebCrawler {
     limit: number,
     maxDepth: number,
     fromMap: boolean = false,
+    skipRobots: boolean = false,
   ): Promise<FilterLinksResult> {
     const denialReasons = new Map<string, string>();
 
@@ -173,7 +174,7 @@ export class WebCrawler {
         excludes: this.excludes,
         includes: this.includes,
         allowBackwardCrawling: this.allowBackwardCrawling,
-        ignoreRobotsTxt: this.ignoreRobotsTxt,
+        ignoreRobotsTxt: this.ignoreRobotsTxt || skipRobots,
         robotsTxt: this.robotsTxt,
         allowExternalContentLinks: this.allowExternalContentLinks,
         allowSubdomains: this.allowSubdomains,
@@ -318,11 +319,12 @@ export class WebCrawler {
           }
         }
 
-        const isAllowed = this.ignoreRobotsTxt
-          ? true
-          : ((this.robots.isAllowed(link, "FireCrawlAgent") ||
-              this.robots.isAllowed(link, "FirecrawlAgent")) ??
-            true);
+        const isAllowed =
+          this.ignoreRobotsTxt || skipRobots
+            ? true
+            : ((this.robots.isAllowed(link, "FireCrawlAgent") ||
+                this.robots.isAllowed(link, "FirecrawlAgent")) ??
+              true);
         // Check if the link is disallowed by robots.txt
         if (!isAllowed) {
           this.logger.debug(`Link disallowed by robots.txt: ${link}`, {
@@ -450,6 +452,7 @@ export class WebCrawler {
           [...new Set(urls)],
           leftOfLimit,
           this.maxCrawledDepth,
+          fromMap,
           fromMap,
         );
         let filteredLinks = filteredLinksResult.links;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes /map returning too few URLs when including the sitemap by bypassing robots.txt checks during map generation. Sitemap links are no longer dropped due to robots rules.

- **Bug Fixes**
  - Added a skipRobots flag and enable it when fromMap is true.
  - Apply skipRobots to filtering options and per-link robots checks.

<sup>Written for commit 5b95906caf969d0ed6a221c020ea9149b99bb875. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

