### PR TITLE
fix(api): update URL handling of resolved redirects

### DIFF
--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -112,7 +112,15 @@ export async function getMapResults({
 }): Promise<MapResult> {
   const functionStartTime = Date.now();
 
-  url = await resolveRedirects(url, abort);
+  const resolvedUrl = await resolveRedirects(url, abort);
+
+  // If the resolved URL is on a different domain, replace the hostname
+  if (!isSameDomain(url, resolvedUrl)) {
+    const urlObj = new URL(url);
+    urlObj.hostname = new URL(resolvedUrl).hostname;
+
+    url = urlObj.toString();
+  }
 
   const id = uuidv4();
   let mapResults: MapDocument[] = [];


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update redirect handling in map-utils to use the resolved hostname while preserving the original path and query, preventing cross-domain redirects from breaking map results. For Linear ENG-4065: if a redirect goes to another domain, replace the hostname with the resolved one and keep the original path/query.

<sup>Written for commit 0f469e9e5472ebba0feea71a07b8ead2bfd0d307. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



