### PR TITLE
fix(api): opaque fire engine delete + poll interval

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -92,7 +92,9 @@ async function performFireEngineScrape<
             mock,
             undefined,
             production,
-          );
+          ).catch(e => {
+            logger.error("Failed to delete job from Fire Engine", { error: e });
+          });
           throw new Error("Error limit hit. See e.cause.errors for errors.", {
             cause: { errors },
           });
@@ -132,7 +134,11 @@ async function performFireEngineScrape<
               mock,
               undefined,
               production,
-            );
+            ).catch(e => {
+              logger.error("Failed to delete job from Fire Engine", {
+                error: e,
+              });
+            });
             logger.debug("Fire-engine scrape job failed.", {
               error,
               jobId: (scrape as any).jobId,
@@ -148,7 +154,11 @@ async function performFireEngineScrape<
               mock,
               undefined,
               production,
-            );
+            ).catch(e => {
+              logger.error("Failed to delete job from Fire Engine", {
+                error: e,
+              });
+            });
             throw error;
           } else {
             errors.push(error);
@@ -159,9 +169,9 @@ async function performFireEngineScrape<
             Sentry.captureException(error);
           }
         }
-      }
 
-      await new Promise(resolve => setTimeout(resolve, 500));
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
     } else {
       status = scrape as FireEngineCheckStatusSuccess;
     }
@@ -197,7 +207,9 @@ async function performFireEngineScrape<
       mock,
       undefined,
       production,
-    );
+    ).catch(e => {
+      logger.error("Failed to delete job from Fire Engine", { error: e });
+    });
 
     setSpanAttributes(span, {
       "fire-engine.poll_count": pollCount,

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -73,6 +73,8 @@ export type FireEngineScrapeRequestTLSClient = {
 };
 
 const successSchema = z.object({
+  jobId: z.string().optional(), // only defined if we are deferring deletion
+
   timeTaken: z.number(),
   content: z.string(),
   url: z.string().optional(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make Fire Engine job deletion best-effort and non-blocking. Also apply the 500ms polling delay only while the job is still running.

- **Bug Fixes**
  - Skip deletion when jobId is missing; log at debug.
  - Catch and log delete failures without affecting scrape flow.
  - Apply 500ms sleep only between pending poll checks.
  - Allow optional jobId in success schema to support deferred deletion.

<sup>Written for commit 6e3b032e1a1a74a5136ed99436d430fbfefcecb7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

