### PR TITLE
fix(api): handle case with no billed teams in tallyBilling function

### DIFF
--- a/apps/api/src/services/indexing/index-worker.ts
+++ b/apps/api/src/services/indexing/index-worker.ts
@@ -657,6 +657,12 @@ async function tallyBilling() {
     "billed_teams",
     100,
   );
+
+  if (!billedTeams || billedTeams.length === 0) {
+    logger.debug("No billed teams to process");
+    return;
+  }
+
   await getRedisConnection().srem("billed_teams", billedTeams);
   logger.info("Starting to update tallies", {
     billedTeams: billedTeams.length,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Handle the case where there are no billed teams in tallyBilling. Return early with a debug log to avoid unnecessary Redis calls and potential errors.

<sup>Written for commit 72f1b10d0214c187d384eb55a8dff26a97d30d96. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

