### PR TITLE
fix(api): vue + angular router url normalization

### DIFF
--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -308,7 +308,11 @@ export function normalizeURL(url: string, sc: StoredCrawl): string {
     urlO.search = "";
   }
   // allow hash-based routes
-  if (!urlO.hash || urlO.hash.length <= 2 || !urlO.hash.startsWith("#/")) {
+  if (
+    !urlO.hash ||
+    urlO.hash.length <= 2 ||
+    (!urlO.hash.startsWith("#/") && !urlO.hash.startsWith("#!/"))
+  ) {
     urlO.hash = "";
   }
   return urlO.href;

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -209,7 +209,15 @@ export const useSearchIndex =
 
 export function normalizeURLForIndex(url: string): string {
   const urlObj = new URL(url);
-  urlObj.hash = "";
+
+  if (
+    !urlObj.hash ||
+    urlObj.hash.length <= 2 ||
+    (!urlObj.hash.startsWith("#/") && !urlObj.hash.startsWith("#!/"))
+  ) {
+    urlObj.hash = "";
+  }
+
   urlObj.protocol = "https";
 
   if (urlObj.port === "80" || urlObj.port === "443") {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves Vue and Angular hash-based routes during URL normalization so we don’t strip “#/” and “#!/” in crawl and indexing. Fixes missing or merged pages caused by hash removal.

- **Bug Fixes**
  - Keep hashes starting with “#/” or “#!/” in crawl URL normalization.
  - Apply the same rule in index URL normalization; still enforce https and remove default ports.

<sup>Written for commit 6d537b8e94484b21c36b4d28034322ca7f31fd84. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

