### PR TITLE
feat(api): usedLlm + formats in request metrics

### DIFF
--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -201,6 +201,21 @@ export async function scrapeController(
 
   const totalRequestTime = new Date().getTime() - middlewareStartTime;
   const controllerTime = new Date().getTime() - controllerStartTime;
+
+  let usedLlm =
+    req.body.formats?.includes("json") ||
+    req.body.formats?.includes("summary") ||
+    req.body.formats?.includes("branding") ||
+    req.body.formats?.includes("extract");
+
+  if (
+    !usedLlm &&
+    req.body.formats?.includes("changeTracking") &&
+    req.body.changeTrackingOptions?.modes?.includes("json")
+  ) {
+    usedLlm = true;
+  }
+
   logger.info("Request metrics", {
     version: "v1",
     mode: "scrape",
@@ -211,6 +226,8 @@ export async function scrapeController(
     controllerTime,
     totalRequestTime,
     totalWait,
+    usedLlm,
+    formats: req.body.formats,
   });
 
   return res.status(200).json({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added usedLlm and formats to scrape request metrics to track when LLM processing is used and which formats were requested.

- **New Features**
  - usedLlm is true when formats include json, summary, branding (plus extract in v1), or changeTracking has json mode.
  - v1 logs formats directly from req.body.formats; v2 logs an array of format types derived from FormatObject.

<sup>Written for commit 1cc7b5b7f8a1557920a5ac5808070eb307e3ade0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

