### PR TITLE
API Requests Endpoint

### DIFF
--- a/apps/api/requests/v2/apirequest.requests.http
+++ b/apps/api/requests/v2/apirequest.requests.http
@@ -1,0 +1,121 @@
+### GET request
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/get",
+  "method": "GET"
+}
+
+### GET request with query params
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/get",
+  "method": "GET",
+  "params": {
+    "foo": "bar",
+    "baz": "qux"
+  }
+}
+
+### GET request with custom headers
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/headers",
+  "method": "GET",
+  "headers": {
+    "X-Custom-Header": "test-value"
+  }
+}
+
+### POST request with JSON body
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/post",
+  "method": "POST",
+  "body": {
+    "name": "test",
+    "value": 123
+  }
+}
+
+### POST request with string body
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/post",
+  "method": "POST",
+  "body": "Hello, World!",
+  "headers": {
+    "Content-Type": "text/plain"
+  }
+}
+
+### PUT request
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/put",
+  "method": "PUT",
+  "body": {
+    "updated": true
+  }
+}
+
+### DELETE request
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/delete",
+  "method": "DELETE"
+}
+
+### PATCH request
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/patch",
+  "method": "PATCH",
+  "body": {
+    "patched": true
+  }
+}
+
+### HEAD request
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/get",
+  "method": "HEAD"
+}
+
+### Request with custom timeout
+POST http://localhost:3002/v2/apirequest
+Authorization: Bearer fc-YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "url": "https://httpbin.org/delay/2",
+  "method": "GET",
+  "timeout": 5000
+}

--- a/apps/api/src/__tests__/snips/v2/apirequest.test.ts
+++ b/apps/api/src/__tests__/snips/v2/apirequest.test.ts
@@ -1,0 +1,493 @@
+import {
+  describeIf,
+  concurrentIf,
+  itIf,
+  TEST_PRODUCTION,
+  TEST_SELF_HOST,
+  TEST_SUITE_WEBSITE,
+  HAS_PROXY,
+  ALLOW_TEST_SUITE_WEBSITE,
+} from "../lib";
+import {
+  apiRequest,
+  apiRequestRaw,
+  apiRequestWithFailure,
+  scrapeTimeout,
+  idmux,
+  Identity,
+} from "./lib";
+
+let identity: Identity;
+
+beforeAll(async () => {
+  identity = await idmux({
+    name: "apirequest",
+    concurrency: 100,
+    credits: 1000000,
+  });
+}, 10000);
+
+describe("API Request tests", () => {
+  describe("Basic functionality", () => {
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "GET request works",
+      async () => {
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/get",
+            method: "GET",
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toBeDefined();
+        expect(response.metadata.method).toBe("GET");
+        expect(response.timing.total).toBeGreaterThan(0);
+
+        // httpbin returns JSON, parse it to verify
+        const body = JSON.parse(response.body);
+        expect(body.url).toBe("https://httpbin.org/get");
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "POST request with JSON body works",
+      async () => {
+        const testBody = { name: "test", value: 123 };
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/post",
+            method: "POST",
+            body: testBody,
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toBeDefined();
+        expect(response.metadata.method).toBe("POST");
+
+        // httpbin echoes back what we sent
+        const body = JSON.parse(response.body);
+        expect(body.json).toEqual(testBody);
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "POST request with string body works",
+      async () => {
+        const testBody = "Hello, World!";
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/post",
+            method: "POST",
+            body: testBody,
+            headers: {
+              "Content-Type": "text/plain",
+            },
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toBeDefined();
+
+        const body = JSON.parse(response.body);
+        expect(body.data).toBe(testBody);
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "PUT request works",
+      async () => {
+        const testBody = { updated: true };
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/put",
+            method: "PUT",
+            body: testBody,
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.metadata.method).toBe("PUT");
+
+        const body = JSON.parse(response.body);
+        expect(body.json).toEqual(testBody);
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "DELETE request works",
+      async () => {
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/delete",
+            method: "DELETE",
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.metadata.method).toBe("DELETE");
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "PATCH request works",
+      async () => {
+        const testBody = { patched: true };
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/patch",
+            method: "PATCH",
+            body: testBody,
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.metadata.method).toBe("PATCH");
+
+        const body = JSON.parse(response.body);
+        expect(body.json).toEqual(testBody);
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "HEAD request works",
+      async () => {
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/get",
+            method: "HEAD",
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.metadata.method).toBe("HEAD");
+        // HEAD requests should have empty body
+        expect(response.body).toBe("");
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "OPTIONS request works",
+      async () => {
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/get",
+            method: "OPTIONS",
+          },
+          identity,
+        );
+
+        // httpbin allows OPTIONS
+        expect(response.metadata.method).toBe("OPTIONS");
+      },
+      scrapeTimeout,
+    );
+  });
+
+  describe("Custom headers", () => {
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "custom headers are sent",
+      async () => {
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/headers",
+            method: "GET",
+            headers: {
+              "X-Custom-Header": "test-value",
+              "X-Another-Header": "another-value",
+            },
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        const body = JSON.parse(response.body);
+        expect(body.headers["X-Custom-Header"]).toBe("test-value");
+        expect(body.headers["X-Another-Header"]).toBe("another-value");
+      },
+      scrapeTimeout,
+    );
+  });
+
+  describe("Query parameters", () => {
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "query params are appended to URL",
+      async () => {
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/get",
+            method: "GET",
+            params: {
+              foo: "bar",
+              baz: "qux",
+            },
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        const body = JSON.parse(response.body);
+        expect(body.args.foo).toBe("bar");
+        expect(body.args.baz).toBe("qux");
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "query params are merged with existing URL params",
+      async () => {
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/get?existing=param",
+            method: "GET",
+            params: {
+              new: "param",
+            },
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        const body = JSON.parse(response.body);
+        expect(body.args.existing).toBe("param");
+        expect(body.args.new).toBe("param");
+      },
+      scrapeTimeout,
+    );
+  });
+
+  describe("Response handling", () => {
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "response headers are returned",
+      async () => {
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/response-headers?X-Test=test-value",
+            method: "GET",
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.headers).toBeDefined();
+        expect(response.headers["x-test"]).toBe("test-value");
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "handles various status codes",
+      async () => {
+        // Test 201 Created
+        const response201 = await apiRequest(
+          {
+            url: "https://httpbin.org/status/201",
+            method: "GET",
+          },
+          identity,
+        );
+        expect(response201.statusCode).toBe(201);
+
+        // Test 204 No Content
+        const response204 = await apiRequest(
+          {
+            url: "https://httpbin.org/status/204",
+            method: "GET",
+          },
+          identity,
+        );
+        expect(response204.statusCode).toBe(204);
+        expect(response204.body).toBe("");
+
+        // Test 404 Not Found
+        const response404 = await apiRequest(
+          {
+            url: "https://httpbin.org/status/404",
+            method: "GET",
+          },
+          identity,
+        );
+        expect(response404.statusCode).toBe(404);
+      },
+      scrapeTimeout,
+    );
+
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "follows redirects",
+      async () => {
+        const response = await apiRequest(
+          {
+            url: "https://httpbin.org/redirect/1",
+            method: "GET",
+          },
+          identity,
+        );
+
+        expect(response.statusCode).toBe(200);
+        // Final URL after redirect
+        expect(response.url).toContain("httpbin.org/get");
+      },
+      scrapeTimeout,
+    );
+  });
+
+  describe("Validation", () => {
+    it("rejects body for GET request", async () => {
+      const raw = await apiRequestRaw(
+        {
+          url: "https://httpbin.org/get",
+          method: "GET",
+          body: { test: "value" },
+        } as any,
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
+      expect(raw.body.error).toContain("body");
+    });
+
+    it("rejects body for DELETE request", async () => {
+      const raw = await apiRequestRaw(
+        {
+          url: "https://httpbin.org/delete",
+          method: "DELETE",
+          body: { test: "value" },
+        } as any,
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
+      expect(raw.body.error).toContain("body");
+    });
+
+    it("rejects invalid URL", async () => {
+      const raw = await apiRequestRaw(
+        {
+          url: "not-a-valid-url",
+          method: "GET",
+        },
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
+    });
+
+    it("rejects non-HTTP protocols", async () => {
+      const raw = await apiRequestRaw(
+        {
+          url: "ftp://example.com/file",
+          method: "GET",
+        },
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
+    });
+
+    it("rejects invalid HTTP method", async () => {
+      const raw = await apiRequestRaw(
+        {
+          url: "https://httpbin.org/get",
+          method: "INVALID" as any,
+        },
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
+    });
+  });
+
+  describeIf(TEST_SELF_HOST)("Security", () => {
+    it("blocks private IP addresses", async () => {
+      const raw = await apiRequestRaw(
+        {
+          url: "http://127.0.0.1:8080/test",
+          method: "GET",
+        },
+        identity,
+      );
+
+      // Should be blocked unless ALLOW_LOCAL_WEBHOOKS is true
+      if (process.env.ALLOW_LOCAL_WEBHOOKS !== "true") {
+        expect(raw.statusCode).toBe(403);
+        expect(raw.body.success).toBe(false);
+        expect(raw.body.error).toContain("private");
+      }
+    });
+
+    it("blocks localhost", async () => {
+      const raw = await apiRequestRaw(
+        {
+          url: "http://localhost:8080/test",
+          method: "GET",
+        },
+        identity,
+      );
+
+      // Should be blocked unless ALLOW_LOCAL_WEBHOOKS is true
+      if (process.env.ALLOW_LOCAL_WEBHOOKS !== "true") {
+        expect(raw.statusCode).toBe(403);
+        expect(raw.body.success).toBe(false);
+      }
+    });
+  });
+
+  describe("Timeout handling", () => {
+    concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
+      "respects timeout setting",
+      async () => {
+        const raw = await apiRequestRaw(
+          {
+            url: "https://httpbin.org/delay/10", // 10 second delay
+            method: "GET",
+            timeout: 2000, // 2 second timeout
+          },
+          identity,
+        );
+
+        expect(raw.statusCode).toBe(408);
+        expect(raw.body.success).toBe(false);
+        expect(raw.body.error).toContain("timed out");
+      },
+      scrapeTimeout,
+    );
+  });
+
+  describe("Authentication required", () => {
+    it("rejects requests without auth", async () => {
+      const request = await import("supertest");
+      const TEST_API_URL =
+        process.env.TEST_API_URL || "http://127.0.0.1:3002";
+
+      const raw = await request.default(TEST_API_URL)
+        .post("/v2/apirequest")
+        .set("Content-Type", "application/json")
+        .send({
+          url: "https://httpbin.org/get",
+          method: "GET",
+        });
+
+      expect(raw.statusCode).toBe(401);
+    });
+  });
+});

--- a/apps/api/src/__tests__/snips/v2/lib.ts
+++ b/apps/api/src/__tests__/snips/v2/lib.ts
@@ -12,6 +12,8 @@ import {
   MapRequestInput,
   BatchScrapeRequestInput,
   SearchRequestInput,
+  ApiRequestInput,
+  ApiRequestDocument,
 } from "../../../controllers/v2/types";
 import request from "supertest";
 import {
@@ -551,4 +553,80 @@ export async function zdrcleaner(teamId: string) {
 
   expect(res.statusCode).toBe(200);
   expect(res.body.ok).toBe(true);
+}
+
+// =========================================
+// API Request API
+// =========================================
+
+export async function apiRequestRaw(body: ApiRequestInput, identity: Identity) {
+  return await request(TEST_API_URL)
+    .post("/v2/apirequest")
+    .set("Authorization", `Bearer ${identity.apiKey}`)
+    .set("Content-Type", "application/json")
+    .send(body);
+}
+
+function expectApiRequestToSucceed(
+  response: Awaited<ReturnType<typeof apiRequestRaw>>,
+) {
+  if (response.statusCode !== 200) {
+    console.warn(
+      "API Request did not succeed",
+      JSON.stringify(response.body, null, 2),
+    );
+  }
+
+  expect(response.statusCode).toBe(200);
+  expect(response.body.success).toBe(true);
+  expect(typeof response.body.data).toBe("object");
+}
+
+function expectApiRequestToFail(
+  response: Awaited<ReturnType<typeof apiRequestRaw>>,
+) {
+  expect(response.statusCode).not.toBe(200);
+  expect(response.body.success).toBe(false);
+  expect(typeof response.body.error).toBe("string");
+}
+
+export async function apiRequest(
+  body: ApiRequestInput,
+  identity: Identity,
+): Promise<ApiRequestDocument> {
+  const raw = await apiRequestRaw(body, identity);
+  expectApiRequestToSucceed(raw);
+  return raw.body.data;
+}
+
+export async function apiRequestWithFailure(
+  body: ApiRequestInput,
+  identity: Identity,
+): Promise<{
+  success: false;
+  error: string;
+}> {
+  const raw = await apiRequestRaw(body, identity);
+  expectApiRequestToFail(raw);
+  return raw.body;
+}
+
+export async function apiRequestStatusRaw(jobId: string, identity: Identity) {
+  return await request(TEST_API_URL)
+    .get("/v2/apirequest/" + encodeURIComponent(jobId))
+    .set("Authorization", `Bearer ${identity.apiKey}`)
+    .send();
+}
+
+export async function apiRequestStatus(
+  jobId: string,
+  identity: Identity,
+): Promise<ApiRequestDocument> {
+  const raw = await apiRequestStatusRaw(jobId, identity);
+  expect(raw.statusCode).toBe(200);
+  expect(raw.body.success).toBe(true);
+  expect(typeof raw.body.data).toBe("object");
+  expect(raw.body.data).not.toBeNull();
+  expect(raw.body.data).toBeDefined();
+  return raw.body.data;
 }

--- a/apps/api/src/controllers/v2/apirequest-status.ts
+++ b/apps/api/src/controllers/v2/apirequest-status.ts
@@ -1,0 +1,64 @@
+import { supabaseGetJobByIdOnlyData } from "../../lib/supabase-jobs";
+import { getJob } from "./crawl-status";
+import { logger as _logger } from "../../lib/logger";
+
+export async function apiRequestStatusController(req: any, res: any) {
+  const uuidReg =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!req.params.jobId || !uuidReg.test(req.params.jobId)) {
+    return res.status(400).json({
+      success: false,
+      error: "Invalid request ID",
+    });
+  }
+
+  const logger = _logger.child({
+    module: "apirequest-status",
+    method: "apiRequestStatusController",
+    teamId: req.auth.team_id,
+    jobId: req.params.jobId,
+    requestId: req.params.jobId,
+    zeroDataRetention: req.acuc?.flags?.forceZDR,
+  });
+
+  if (req.acuc?.flags?.forceZDR) {
+    return res.status(400).json({
+      success: false,
+      error:
+        "Your team has zero data retention enabled. This is not supported on API request status. Please contact support@firecrawl.com to unblock this feature.",
+    });
+  }
+
+  const job = await supabaseGetJobByIdOnlyData(req.params.jobId, logger);
+
+  if (!job) {
+    return res.status(404).json({
+      success: false,
+      error: "Request not found.",
+    });
+  }
+
+  if (job?.team_id !== req.auth.team_id) {
+    return res.status(403).json({
+      success: false,
+      error: "You are not allowed to access this resource.",
+    });
+  }
+
+  const jobData = await getJob(req.params.jobId, logger);
+  const data = Array.isArray(jobData?.returnvalue)
+    ? jobData?.returnvalue[0]
+    : jobData?.returnvalue;
+
+  if (!data) {
+    return res.status(404).json({
+      success: false,
+      error: "Request not found.",
+    });
+  }
+
+  return res.status(200).json({
+    success: true,
+    data,
+  });
+}

--- a/apps/api/src/controllers/v2/apirequest.ts
+++ b/apps/api/src/controllers/v2/apirequest.ts
@@ -1,0 +1,343 @@
+import { Response } from "express";
+import { logger as _logger } from "../../lib/logger";
+import {
+  ApiRequest,
+  ApiRequestDocument,
+  ApiRequestInput,
+  ApiRequestResponse,
+  HttpMethod,
+  RequestWithAuth,
+  apiRequestSchema,
+} from "./types";
+import { v7 as uuidv7 } from "uuid";
+import { TransportableError } from "../../lib/error";
+import { withSpan, setSpanAttributes, SpanKind } from "../../lib/otel-tracer";
+import { teamConcurrencySemaphore } from "../../services/worker/team-semaphore";
+import * as undici from "undici";
+import { getSecureDispatcher } from "../../scraper/scrapeURL/engines/utils/safeFetch";
+
+async function executeApiRequest(
+  url: string,
+  method: HttpMethod,
+  options: {
+    body?: string | Record<string, any>;
+    headers?: Record<string, string>;
+    params?: Record<string, string>;
+    timeout: number;
+    skipTlsVerification?: boolean;
+  },
+  abort: AbortSignal,
+): Promise<ApiRequestDocument> {
+  const startTime = Date.now();
+
+  // Build URL with query parameters
+  const urlObj = new URL(url);
+  if (options.params) {
+    for (const [key, value] of Object.entries(options.params)) {
+      urlObj.searchParams.append(key, value);
+    }
+  }
+  const finalUrl = urlObj.toString();
+
+  // Prepare request body
+  let requestBody: string | undefined;
+  const requestHeaders: Record<string, string> = { ...options.headers };
+
+  if (options.body !== undefined) {
+    if (typeof options.body === "string") {
+      requestBody = options.body;
+    } else {
+      requestBody = JSON.stringify(options.body);
+      // Set content-type if not already set
+      if (
+        !Object.keys(requestHeaders).some(
+          k => k.toLowerCase() === "content-type",
+        )
+      ) {
+        requestHeaders["Content-Type"] = "application/json";
+      }
+    }
+  }
+
+  // Create abort signal with timeout
+  const timeoutSignal = AbortSignal.timeout(options.timeout);
+  const combinedSignal = AbortSignal.any([abort, timeoutSignal]);
+
+  const response = await undici.fetch(finalUrl, {
+    method,
+    headers: requestHeaders,
+    body: requestBody,
+    dispatcher: getSecureDispatcher(options.skipTlsVerification ?? false),
+    redirect: "follow",
+    signal: combinedSignal,
+  });
+
+  const responseBody = await response.text();
+  const endTime = Date.now();
+
+  // Convert headers to Record<string, string>
+  const responseHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    responseHeaders[key] = value;
+  });
+
+  return {
+    statusCode: response.status,
+    headers: responseHeaders,
+    body: responseBody,
+    url: response.url,
+    timing: {
+      total: endTime - startTime,
+    },
+    metadata: {
+      sourceURL: url,
+      method,
+      contentType: responseHeaders["content-type"],
+    },
+  };
+}
+
+export async function apiRequestController(
+  req: RequestWithAuth<{}, ApiRequestResponse, ApiRequestInput>,
+  res: Response<ApiRequestResponse>,
+) {
+  return withSpan(
+    "api.apirequest.request",
+    async span => {
+      const middlewareStartTime =
+        (req as any).requestTiming?.startTime || new Date().getTime();
+      const controllerStartTime = new Date().getTime();
+
+      const jobId = uuidv7();
+      const preNormalizedBody = { ...req.body };
+
+      setSpanAttributes(span, {
+        "apirequest.job_id": jobId,
+        "apirequest.url": String(req.body?.url ?? ""),
+        "apirequest.method": String(req.body?.method ?? "GET"),
+        "apirequest.team_id": req.auth.team_id,
+        "apirequest.api_key_id": req.acuc?.api_key_id,
+        "apirequest.middleware_time_ms": controllerStartTime - middlewareStartTime,
+      });
+
+      // Validation
+      let validatedBody: ApiRequest;
+      try {
+        validatedBody = apiRequestSchema.parse(req.body);
+      } catch (error) {
+        setSpanAttributes(span, {
+          "apirequest.error": "Validation failed",
+          "apirequest.status_code": 400,
+        });
+        return res.status(400).json({
+          success: false,
+          error:
+            error instanceof Error ? error.message : "Invalid request body",
+          details: error,
+        });
+      }
+
+      const zeroDataRetention =
+        req.acuc?.flags?.forceZDR || validatedBody.zeroDataRetention;
+
+      const logger = _logger.child({
+        method: "apiRequestController",
+        jobId,
+        noq: true,
+        requestId: jobId,
+        teamId: req.auth.team_id,
+        team_id: req.auth.team_id,
+        zeroDataRetention,
+      });
+
+      const middlewareTime = controllerStartTime - middlewareStartTime;
+
+      logger.debug("API Request " + jobId + " starting", {
+        version: "v2",
+        requestId: jobId,
+        request: validatedBody,
+        originalRequest: preNormalizedBody,
+        account: req.account,
+      });
+
+      setSpanAttributes(span, {
+        "apirequest.zero_data_retention": zeroDataRetention,
+        "apirequest.origin": validatedBody.origin,
+        "apirequest.timeout": validatedBody.timeout,
+      });
+
+      const timeout = validatedBody.timeout;
+
+      let doc: ApiRequestDocument | null = null;
+      let timeoutHandle: NodeJS.Timeout | null = null;
+
+      try {
+        const lockStart = Date.now();
+        const aborter = new AbortController();
+
+        if (timeout) {
+          timeoutHandle = setTimeout(() => {
+            aborter.abort();
+          }, timeout * 0.667);
+        }
+        req.on("close", () => aborter.abort());
+
+        doc = await teamConcurrencySemaphore.withSemaphore(
+          req.auth.team_id,
+          jobId,
+          req.acuc?.concurrency || 1,
+          aborter.signal,
+          timeout ?? 30000,
+          async limited => {
+            const lockTime = Date.now() - lockStart;
+
+            logger.debug(`Lock acquired for team: ${req.auth.team_id}`, {
+              teamId: req.auth.team_id,
+              lockTime,
+            });
+
+            const result = await withSpan(
+              "api.apirequest.execute",
+              async executeSpan => {
+                setSpanAttributes(executeSpan, {
+                  "execute.timeout": timeout,
+                  "execute.job_id": jobId,
+                  "execute.method": validatedBody.method,
+                });
+
+                const doc = await executeApiRequest(
+                  validatedBody.url,
+                  validatedBody.method,
+                  {
+                    body: validatedBody.body,
+                    headers: validatedBody.headers,
+                    params: validatedBody.params,
+                    timeout: timeout,
+                    skipTlsVerification: validatedBody.skipTlsVerification,
+                  },
+                  aborter.signal,
+                );
+
+                setSpanAttributes(executeSpan, {
+                  "execute.success": true,
+                  "execute.status_code": doc.statusCode,
+                });
+
+                return doc;
+              },
+            );
+
+            return result;
+          },
+        );
+      } catch (e) {
+        const isTimeout =
+          e instanceof Error &&
+          (e.name === "TimeoutError" || e.message.includes("timed out"));
+
+        if (!isTimeout) {
+          logger.error(`Error in apiRequestController`, {
+            version: "v2",
+            error: e,
+          });
+        }
+
+        setSpanAttributes(span, {
+          "apirequest.error": e instanceof Error ? e.message : String(e),
+          "apirequest.error_type": isTimeout ? "timeout" : "unknown",
+        });
+
+        if (isTimeout) {
+          setSpanAttributes(span, {
+            "apirequest.status_code": 408,
+          });
+          return res.status(408).json({
+            success: false,
+            error: "Request timed out",
+          });
+        }
+
+        if (e instanceof TransportableError) {
+          const statusCode = 500;
+          setSpanAttributes(span, {
+            "apirequest.status_code": statusCode,
+          });
+          return res.status(statusCode).json({
+            success: false,
+            code: e.code,
+            error: e.message,
+          });
+        }
+
+        // Check for connection security error (private IP)
+        if (
+          e instanceof TypeError &&
+          e.message.includes("fetch failed") &&
+          e.cause instanceof Error &&
+          e.cause.message.includes("security")
+        ) {
+          setSpanAttributes(span, {
+            "apirequest.status_code": 403,
+          });
+          return res.status(403).json({
+            success: false,
+            error:
+              "Request blocked: Cannot make requests to private/internal IP addresses",
+          });
+        }
+
+        setSpanAttributes(span, {
+          "apirequest.status_code": 500,
+        });
+        return res.status(500).json({
+          success: false,
+          error: `(Internal server error) - ${e && (e as Error).message ? (e as Error).message : e}`,
+        });
+      } finally {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+        }
+      }
+
+      const totalRequestTime = new Date().getTime() - middlewareStartTime;
+      const controllerTime = new Date().getTime() - controllerStartTime;
+
+      setSpanAttributes(span, {
+        "apirequest.success": true,
+        "apirequest.status_code": 200,
+        "apirequest.total_request_time_ms": totalRequestTime,
+        "apirequest.controller_time_ms": controllerTime,
+        "apirequest.response_status_code": doc?.statusCode,
+        "apirequest.response_content_type": doc?.metadata?.contentType,
+      });
+
+      logger.info("Request metrics", {
+        version: "v2",
+        requestId: jobId,
+        mode: "apirequest",
+        middlewareStartTime,
+        controllerStartTime,
+        middlewareTime,
+        controllerTime,
+        totalRequestTime,
+        method: validatedBody.method,
+        responseStatusCode: doc?.statusCode,
+      });
+
+      return res.status(200).json({
+        success: true,
+        data: doc!,
+        request_id: validatedBody.origin?.includes("website")
+          ? jobId
+          : undefined,
+      });
+    },
+    {
+      attributes: {
+        "http.method": "POST",
+        "http.route": "/v2/apirequest",
+      },
+      kind: SpanKind.SERVER,
+    },
+  );
+}

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1668,3 +1668,94 @@ const generateLLMsTextRequestSchema = z.object({
 });
 
 type GenerateLLMsTextRequest = z.infer<typeof generateLLMsTextRequestSchema>;
+
+// =========================================
+// API Request Schema and Types
+// =========================================
+
+const httpMethodSchema = z.enum([
+  "GET",
+  "POST",
+  "PUT",
+  "DELETE",
+  "PATCH",
+  "HEAD",
+  "OPTIONS",
+]);
+
+export type HttpMethod = z.infer<typeof httpMethodSchema>;
+
+export const apiRequestSchema = z
+  .object({
+    url: URL.describe("The URL to make the request to"),
+    method: httpMethodSchema.default("GET").describe("HTTP method to use"),
+    body: z
+      .union([z.string(), z.record(z.any())])
+      .optional()
+      .describe("Request body (string or JSON object, for POST/PUT/PATCH)"),
+    headers: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe("Custom request headers"),
+    params: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe("Query parameters to append to URL"),
+    timeout: z
+      .number()
+      .int()
+      .positive()
+      .finite()
+      .safe()
+      .default(30000)
+      .describe("Request timeout in milliseconds"),
+    skipTlsVerification: z
+      .boolean()
+      .optional()
+      .describe("Skip TLS certificate verification"),
+    origin: z.string().optional().default("api"),
+    zeroDataRetention: z.boolean().optional(),
+  })
+  .strict(strictMessage)
+  .refine(
+    data => {
+      // Body is only allowed for methods that typically have a body
+      if (
+        data.body !== undefined &&
+        !["POST", "PUT", "PATCH"].includes(data.method)
+      ) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message: "Request body is only allowed for POST, PUT, and PATCH methods",
+      path: ["body"],
+    },
+  );
+
+export type ApiRequest = z.infer<typeof apiRequestSchema>;
+export type ApiRequestInput = z.input<typeof apiRequestSchema>;
+
+export type ApiRequestDocument = {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  url: string;
+  timing: {
+    total: number;
+  };
+  metadata: {
+    sourceURL: string;
+    method: HttpMethod;
+    contentType?: string;
+  };
+};
+
+export type ApiRequestResponse =
+  | ErrorResponse
+  | {
+      success: true;
+      data: ApiRequestDocument;
+      request_id?: string;
+    };

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -12,6 +12,8 @@ import { mapController } from "../controllers/v2/map";
 import { crawlErrorsController } from "../controllers/v2/crawl-errors";
 import { ongoingCrawlsController } from "../controllers/v2/crawl-ongoing";
 import { scrapeStatusController } from "../controllers/v2/scrape-status";
+import { apiRequestController } from "../controllers/v2/apirequest";
+import { apiRequestStatusController } from "../controllers/v2/apirequest-status";
 import { creditUsageController } from "../controllers/v2/credit-usage";
 import { tokenUsageController } from "../controllers/v2/token-usage";
 import { crawlCancelController } from "../controllers/v2/crawl-cancel";
@@ -178,6 +180,21 @@ v2Router.get(
   "/scrape/:jobId",
   authMiddleware(RateLimiterMode.CrawlStatus),
   wrap(scrapeStatusController),
+);
+
+v2Router.post(
+  "/apirequest",
+  authMiddleware(RateLimiterMode.Scrape),
+  countryCheck,
+  checkCreditsMiddleware(1),
+  blocklistMiddleware,
+  wrap(apiRequestController),
+);
+
+v2Router.get(
+  "/apirequest/:jobId",
+  authMiddleware(RateLimiterMode.CrawlStatus),
+  wrap(apiRequestStatusController),
 );
 
 v2Router.post(


### PR DESCRIPTION
Implementation of a new endpoint: API Requests

Similar to the Scrape endpoint, but for API Requests. With this endpoint it's possible to add custom body and headers options to the API endpoint itself. This was created quite quickly, so there's a likelihood of security vulnerabilities and errors.

Read apirequest.requests.http

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new /v2/apirequest endpoint to perform HTTP requests with custom methods, headers, params, and bodies when supported. This enables API calls that weren’t possible via the Scrape endpoint, with validation, security checks, and status retrieval.

- **New Features**
  - POST /v2/apirequest to send HTTP requests (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS); body allowed only for POST/PUT/PATCH.
  - Returns statusCode, headers, body, final URL, timing, and metadata; supports redirects and a timeout option.
  - Security and validation: blocks private/localhost targets, validates URL/method, enforces body rules, optional skipTlsVerification; auth, credits, rate limiting, and blocklist applied.
  - GET /v2/apirequest/:jobId to fetch request status (disabled for zero data retention teams).
  - Added ApiRequestInput/ApiRequestDocument types, route wiring, extensive tests, and requests.http examples.

<sup>Written for commit 0a4c6ed3802c7d39e68d0e3a4977eb2b01c2a5d4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

