### PR TITLE
chore: add a link to the stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Looking for our MCP? Check out the [repo here](https://github.com/firecrawl/fire
 
 _Pst. hey, you, join our stargazers :)_
 
-<a href="https://github.com/firecrawl/firecrawl">
+<a href="https://github.com/firecrawl/firecrawl/stargazers">
   <img src="https://img.shields.io/github/stars/firecrawl/firecrawl.svg?style=social&label=Star&maxAge=2592000" alt="GitHub stars">
 </a>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the README stars badge link to point directly to the repository’s stargazers page, giving users a one-click path to view and star the project.

<sup>Written for commit 9bb67412d3b9949888254a29bdbb7e956d570334. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

