### PR TITLE
fix(go-html-to-md): request body max 60MB

### DIFF
--- a/apps/go-html-to-md-service/handler.go
+++ b/apps/go-html-to-md-service/handler.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	maxRequestSize = 10 * 1024 * 1024 // 10MB max request size
+	maxRequestSize = 60 * 1024 * 1024 // 60MB max request size
 )
 
 // Handler manages HTTP request handling


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase request body limit in go-html-to-md service from 10MB to 60MB to support larger HTML documents and prevent 413 errors.

<sup>Written for commit b5505dddb32cfd1dd8eb7dbaf6190209af2ebf8a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

