### PR TITLE
fix(api): sitemap + robots skip markdown parsing

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -384,7 +384,10 @@ async function scrapeURLLoopIter(
     );
 
     let checkMarkdown: string;
-    if (meta.internalOptions.teamId === "sitemap") {
+    if (
+      meta.internalOptions.teamId === "sitemap" ||
+      meta.internalOptions.teamId === "robots-txt"
+    ) {
       checkMarkdown = engineResult.html?.trim() ?? "";
     } else {
       checkMarkdown = await parseMarkdown(

--- a/apps/api/src/scraper/scrapeURL/transformers/index.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/index.ts
@@ -65,6 +65,13 @@ async function deriveMarkdownFromHTML(
   meta: Meta,
   document: Document,
 ): Promise<Document> {
+  if (
+    meta.internalOptions.teamId === "sitemap" ||
+    meta.internalOptions.teamId === "robots-txt"
+  ) {
+    return document;
+  }
+
   if (document.html === undefined) {
     throw new Error(
       "html is undefined -- this transformer is being called out of order",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip markdown parsing for sitemap and robots.txt scrape flows to avoid incorrect content handling and reduce processing time.

- **Bug Fixes**
  - Bypass parseMarkdown when teamId is "sitemap" or "robots-txt" in scrapeURL loop and HTML→markdown transformer, keeping the original HTML untouched.

<sup>Written for commit d0cad31281c02050904c159b40873af18742fbd6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

