### PR TITLE
fix(api): dns + crawl denial errors

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -1238,6 +1238,9 @@ export async function scrapeURL(
       } else if (error instanceof ProxySelectionError) {
         errorType = "ProxySelectionError";
         meta.logger.warn("scrapeURL: Proxy selection error", { error });
+      } else if (error instanceof DNSResolutionError) {
+        errorType = "DNSResolutionError";
+        meta.logger.warn("scrapeURL: DNS resolution error", { error });
       } else if (error instanceof AbortManagerThrownError) {
         errorType = "AbortManagerThrownError";
         throw error.inner;

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -286,7 +286,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
           const reason =
             filterResult.denialReason ||
             "Redirected target URL is not allowed by crawlOptions";
-          throw new Error(reason);
+          throw new CrawlDenialError(reason);
         }
 
         // Only re-set originUrl if it's different from the current hostname
@@ -309,7 +309,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
             (await getACUCTeam(job.data.team_id))?.flags ?? null,
           )
         ) {
-          throw new Error(BLOCKLISTED_URL_MESSAGE); // TODO: make this its own error type that is ignored by error tracking
+          throw new CrawlDenialError(BLOCKLISTED_URL_MESSAGE); // TODO: make this its own error type that is ignored by error tracking
         }
 
         const p1 = generateURLPermutations(normalizeURL(doc.metadata.url, sc));
@@ -433,7 +433,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
               const reason =
                 filterResult.denialReasons.get(url) ||
                 "Source URL is not allowed by crawl configuration";
-              throw new Error(reason);
+              throw new CrawlDenialError(reason);
             }
           }
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved scraper error handling by correctly classifying DNS resolution failures and crawl denials. This makes logs clearer and reduces noisy error reporting.

- **Bug Fixes**
  - Added explicit DNSResolutionError handling with warn logging and errorType tagging in scrapeURL.
  - Replaced generic Error with CrawlDenialError for:
    - Redirected target URL denied by crawlOptions.
    - Blocklisted URL checks.
    - Source URL denied by crawl configuration.

<sup>Written for commit 03bc994b9ff429772cacb06114a0ca9b1100fb93. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

