### PR TITLE
feat: muv2 exp apikey env

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -87,6 +87,7 @@ async function scrapePDFWithRunPodMU(
         const resp = await robustFetch({
           url: process.env.PDF_MU_V2_BASE_URL ?? "",
           method: "POST",
+          headers: process.env.PDF_MU_V2_API_KEY ? { Authorization: `Bearer ${process.env.PDF_MU_V2_API_KEY}` } : undefined,
           body: {
             input: {
               file_content: base64Content,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional Authorization header for the MU v2 PDF scraper using the PDF_MU_V2_API_KEY env var. When set, requests are authenticated; if not, behavior is unchanged.

- **Migration**
  - Set PDF_MU_V2_API_KEY in environments that require auth. No action needed otherwise.

<sup>Written for commit 3c339d3540715b09e25482c9ae1c384f382b2e8b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

