### PR TITLE
Attempt Fix Search Tests

### DIFF
--- a/apps/api/src/__tests__/snips/v2/search.test.ts
+++ b/apps/api/src/__tests__/snips/v2/search.test.ts
@@ -39,7 +39,7 @@ describeIf(TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY)("Search tests", () => {
     async () => {
       const res = await search(
         {
-          query: "firecrawl",
+          query: "firecrawl.dev",
           limit: 2,
           scrapeOptions: {
             formats: ["markdown"],


### PR DESCRIPTION
The old search query came back with some heavy protected URLs, so trying this now





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the v2 search test to use "firecrawl.dev" and limit 2 to avoid heavy/protected URLs and stabilize CI results.

<sup>Written for commit d070bde25a3c20e336833d972f259506f5e5caf8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





