### PR TITLE
fix(api): sitemap max age for map requests

### DIFF
--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -494,10 +494,7 @@ export class WebCrawler {
       );
     });
 
-    // Allow sitemaps to be cached for 48 hours if they are requested from /map
-    // - mogery
-    const maxAge = fromMap && !onlySitemap ? 48 * 60 * 60 * 1000 : 0;
-
+    const maxAge = 48 * 60 * 60 * 1000;
     try {
       const robotsSitemaps = this.robots.getSitemaps();
       this.logger.debug("Attempting to fetch sitemap links", {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set sitemap caching to 48 hours so /map requests consistently use cached sitemaps. This reduces unnecessary fetches and improves performance.

- **Bug Fixes**
  - Removed conditional logic and always set maxAge to 48 hours in the crawler.

<sup>Written for commit ac3997a797621ded57f413fa69518aafcc7cb3dc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

