### PR TITLE
fix(api): don't bill where stealth proxy was unsupported

### DIFF
--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -8,6 +8,7 @@ import {
 import { CostTracking } from "./cost-tracking";
 import { hasFormatOfType } from "./format-utils";
 import { TransportableError } from "./error";
+import { FeatureFlag } from "../scraper/scrapeURL/engines";
 
 const creditsPerPDFPage = 1;
 const stealthProxyCostBonus = 4;
@@ -19,6 +20,7 @@ export async function calculateCreditsToBeBilled(
   costTracking: CostTracking | ReturnType<typeof CostTracking.prototype.toJSON>,
   flags: TeamFlags,
   error?: Error | null,
+  unsupportedFeatures?: Set<FeatureFlag>,
 ) {
   const costTrackingJSON: ReturnType<typeof CostTracking.prototype.toJSON> =
     costTracking instanceof CostTracking ? costTracking.toJSON() : costTracking;
@@ -77,7 +79,10 @@ export async function calculateCreditsToBeBilled(
     creditsToBeBilled += creditsPerPDFPage * (document.metadata.numPages - 1);
   }
 
-  if (document?.metadata?.proxyUsed === "stealth") {
+  if (
+    document?.metadata?.proxyUsed === "stealth" &&
+    !unsupportedFeatures?.has("stealthProxy") // if stealth proxy was unsupported, don't bill for it
+  ) {
     creditsToBeBilled += stealthProxyCostBonus;
   }
 

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -78,6 +78,7 @@ export type ScrapeUrlResponse =
   | {
       success: true;
       document: Document;
+      unsupportedFeatures?: Set<FeatureFlag>;
     }
   | {
       success: false;
@@ -838,6 +839,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
     return {
       success: true,
       document,
+      unsupportedFeatures: result.unsupportedFeatures,
     };
   });
 }

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -73,6 +73,7 @@ import {
 } from "../../lib/otel-tracer";
 import { ScrapeUrlResponse } from "../../scraper/scrapeURL";
 import { logScrape } from "../logging/log_job";
+import { FeatureFlag } from "../../scraper/scrapeURL/engines";
 
 configDotenv();
 
@@ -93,6 +94,7 @@ async function billScrapeJob(
   costTracking: CostTracking,
   flags: TeamFlags,
   error?: Error | null,
+  unsupportedFeatures?: Set<FeatureFlag>,
 ) {
   let creditsToBeBilled: number | null = null;
 
@@ -104,6 +106,7 @@ async function billScrapeJob(
       costTracking,
       flags,
       error,
+      unsupportedFeatures,
     );
 
     if (
@@ -452,6 +455,8 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
         logger,
         costTracking,
         (await getACUCTeam(job.data.team_id))?.flags ?? null,
+        undefined,
+        pipeline.unsupportedFeatures,
       );
 
       doc.metadata.creditsUsed = credits_billed ?? undefined;
@@ -521,6 +526,8 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
         logger,
         costTracking,
         (await getACUCTeam(job.data.team_id))?.flags ?? null,
+        undefined,
+        pipeline.unsupportedFeatures,
       );
 
       doc.metadata.creditsUsed = credits_billed ?? undefined;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop charging the stealth proxy fee when a site doesn’t support stealth mode. This fixes incorrect billing and aligns with Linear ENG-4090.

- **Bug Fixes**
  - Track unsupportedFeatures in the scrape pipeline and return it with the document.
  - Skip the stealthProxy surcharge in calculateCreditsToBeBilled when stealthProxy is unsupported, even if proxyUsed is "stealth".
  - Pass unsupportedFeatures from scrapeURL to the worker so billing has the full context.

<sup>Written for commit b61a4680c86dbd94493179392fb52855abfd9ced. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

