### PR TITLE
chore(js-sdk): pass `ignoreRobotsTxt` option through

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -26,6 +26,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.limit != null) data.limit = request.limit;
   if (request.crawlEntireDomain != null) data.crawlEntireDomain = request.crawlEntireDomain;
   if (request.allowExternalLinks != null) data.allowExternalLinks = request.allowExternalLinks;

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -449,6 +449,7 @@ export interface CrawlOptions {
   maxDiscoveryDepth?: number | null;
   sitemap?: 'skip' | 'include';
   ignoreQueryParameters?: boolean;
+  ignoreRobotsTxt?: boolean;
   limit?: number | null;
   crawlEntireDomain?: boolean;
   allowExternalLinks?: boolean;


### PR DESCRIPTION
Add and pass the `ignoreRobotsTxt` option from the js-sdk to the API

Related ticket: 17299

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the ignoreRobotsTxt option from the JS SDK to the API so callers can bypass robots.txt when needed. Addresses Linear 17299 by adding the option to CrawlOptions and including it in the crawl payload.

<sup>Written for commit d3767c6d41006b6ee02947007c2dc5f5b657bc52. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

