### PR TITLE
Fix Zod Error Handling on V0

### DIFF
--- a/apps/api/src/__tests__/snips/v0/lib.ts
+++ b/apps/api/src/__tests__/snips/v0/lib.ts
@@ -1,0 +1,32 @@
+import request from "supertest";
+import {
+  TEST_API_URL,
+  scrapeTimeout,
+  indexCooldown,
+  Identity,
+  idmux,
+} from "../lib";
+
+// Re-export shared utilities for backwards compatibility
+export { scrapeTimeout, indexCooldown, Identity, idmux };
+
+export interface V0ScrapeRequestInput {
+  url: string;
+  pageOptions?: any;
+  extractorOptions?: any;
+  crawlerOptions?: any;
+  timeout?: number;
+  origin?: string;
+  integration?: string;
+}
+
+export async function scrapeRaw(
+  body: V0ScrapeRequestInput,
+  identity: Identity,
+) {
+  return await request(TEST_API_URL)
+    .post("/v0/scrape")
+    .set("Authorization", `Bearer ${identity.apiKey}`)
+    .set("Content-Type", "application/json")
+    .send(body);
+}

--- a/apps/api/src/__tests__/snips/v0/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v0/scrape.test.ts
@@ -1,0 +1,122 @@
+import {
+  concurrentIf,
+  ALLOW_TEST_SUITE_WEBSITE,
+  TEST_SUITE_WEBSITE,
+} from "../lib";
+import { scrapeRaw, idmux, Identity } from "./lib";
+
+let identity: Identity;
+
+beforeAll(async () => {
+  identity = await idmux({
+    name: "v0-scrape",
+    concurrency: 100,
+    credits: 1000000,
+  });
+}, 10000);
+
+describe("V0 Scrape tests", () => {
+  describe("URL validation", () => {
+    it.concurrent("rejects invalid URL format", async () => {
+      const response = await scrapeRaw(
+        {
+          url: "not-a-valid-url",
+        },
+        identity,
+      );
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBeDefined();
+      expect(typeof response.body.error).toBe("string");
+      // Should contain validation error messages
+      expect(
+        response.body.error.includes("Invalid URL") ||
+          response.body.error.includes("valid top-level domain"),
+      ).toBe(true);
+    });
+
+    it.concurrent("rejects URL without protocol", async () => {
+      const response = await scrapeRaw(
+        {
+          url: "example.com",
+        },
+        identity,
+      );
+
+      // Note: The schema adds http:// prefix, so this might pass validation
+      // But if it fails, it should return 400
+      if (response.statusCode === 400) {
+        expect(response.body.success).toBe(false);
+        expect(response.body.error).toBeDefined();
+      }
+    });
+
+    it.concurrent("rejects URL with unsupported protocol", async () => {
+      const response = await scrapeRaw(
+        {
+          url: "ftp://example.com",
+        },
+        identity,
+      );
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBeDefined();
+      expect(response.body.error).toContain("unsupported protocol");
+    });
+
+    it.concurrent("rejects empty URL", async () => {
+      const response = await scrapeRaw(
+        {
+          url: "",
+        },
+        identity,
+      );
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBeDefined();
+    });
+
+    it.concurrent("rejects URL without top-level domain", async () => {
+      const response = await scrapeRaw(
+        {
+          url: "http://localhost",
+        },
+        identity,
+      );
+
+      // This might pass in self-hosted mode, but should fail in production
+      if (response.statusCode === 400) {
+        expect(response.body.success).toBe(false);
+        expect(response.body.error).toBeDefined();
+        expect(
+          response.body.error.includes("valid top-level domain") ||
+            response.body.error.includes("Invalid URL"),
+        ).toBe(true);
+      }
+    });
+
+    concurrentIf(ALLOW_TEST_SUITE_WEBSITE)(
+      "accepts valid URL without validation errors",
+      async () => {
+        const response = await scrapeRaw(
+          {
+            url: TEST_SUITE_WEBSITE,
+          },
+          identity,
+        );
+
+        // Valid URL should not return 400 for URL validation errors
+        // If it returns 400, the error should not be about URL validation
+        if (response.statusCode === 400) {
+          expect(response.body.error).not.toContain("Invalid URL");
+          expect(response.body.error).not.toContain("valid top-level domain");
+          expect(response.body.error).not.toContain("unsupported protocol");
+        }
+      },
+      60000,
+    );
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved Zod error handling in the v0 /scrape endpoint to return clear 400 responses for invalid URLs, and added tests to verify URL validation and error messages.

- **Bug Fixes**
  - Catch ZodError in v0/scrape and return a 400 with de-duplicated, readable messages (e.g., "Invalid URL", "unsupported protocol").
  - Added tests for URL validation: invalid format, missing/unsupported protocol, empty URL, localhost TLD, and a valid URL case.

<sup>Written for commit d0455b5b5f96f96026727c75d0a289fba87389cf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

