### PR TITLE
Increase Go Service Write Timeout

### DIFF
--- a/apps/api/src/lib/html-to-markdown-client.ts
+++ b/apps/api/src/lib/html-to-markdown-client.ts
@@ -49,7 +49,7 @@ export async function convertHTMLToMarkdownWithHttpService(
       `${url}/convert`,
       request,
       {
-        timeout: 30000, // 30 second timeout
+        timeout: 60_000,
         headers: {
           "Content-Type": "application/json",
         },

--- a/apps/go-html-to-md-service/main.go
+++ b/apps/go-html-to-md-service/main.go
@@ -16,8 +16,8 @@ import (
 const (
 	defaultPort            = "8080"
 	defaultShutdownTimeout = 30 * time.Second
-	defaultReadTimeout     = 30 * time.Second
-	defaultWriteTimeout    = 30 * time.Second
+	defaultReadTimeout     = 1 * time.Minute
+	defaultWriteTimeout    = 1 * time.Minute
 	maxUploadSize          = 50 * 1024 * 1024
 )
 


### PR DESCRIPTION








<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increased read and write timeouts for the go-html-to-md service from 30s to 60s, and set the API client's request timeout to 60s. This helps long conversions and slow connections complete without timing out.

<sup>Written for commit 198f015394d7c59ea825ce8316e8f6aae0907fdf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







