### PR TITLE
fix: off-by-one bug in batch scrape pagination

### DIFF
--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -232,7 +232,7 @@ export async function crawlStatusController(
 
   const doneJobs = await scrapeQueue.getCrawlJobsForListing(
     req.params.jobId,
-    end !== undefined ? end - start : 100,
+    end !== undefined ? end - start + 1 : 100,
     start,
     logger.child({ zeroDataRetention }),
   );

--- a/apps/api/src/controllers/v2/crawl-status.ts
+++ b/apps/api/src/controllers/v2/crawl-status.ts
@@ -252,7 +252,7 @@ export async function crawlStatusController(
 
   const doneJobs = await scrapeQueue.getCrawlJobsForListing(
     req.params.jobId,
-    end !== undefined ? end - start : 100,
+    end !== undefined ? end - start + 1 : 100,
     start,
     logger.child({ zeroDataRetention }),
   );


### PR DESCRIPTION
### Problem
When calling /v2/batch/scrape/{id}?skip=0&limit=10, the API returns 9 results instead of 10. Without query parameters, pagination works correctly (returns up to 100 results).

### Root Cause
The end variable is calculated as an inclusive end index (`start + limit - 1`), but when passing the limit to `getCrawlJobsForListing`, the code does `end - start` which yields `limit - 1` instead of `limit`.

### Fix
Changed end - start to end - start + 1 in both v1 and v2 crawl-status controllers.

### Files Changed
- apps/api/src/controllers/v1/crawl-status.ts
- apps/api/src/controllers/v2/crawl-status.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed an off-by-one bug in batch scrape pagination so skip/limit returns the correct number of results. Adjusts limit calculation in v1 and v2 crawl-status controllers to ensure ?skip=0&limit=10 returns 10 results.

<sup>Written for commit 170b4d11890532bd558baa1d2623d7310883a40b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

