### PR TITLE
gitignore test results xml

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -13,3 +13,5 @@ dump.rdb
 .env.*
 
 firecrawl.log
+
+test-results/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add test-results/ to apps/api/.gitignore to prevent committing test report artifacts (e.g., JUnit XML) and keep the repo clean.

<sup>Written for commit 2aa09f4b63d5302b6f12de557d67f6b227eb4aa8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

