### PR TITLE
feat(api/sentry): make sampling rates configurable via environment va…

### DIFF
--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -4,6 +4,13 @@ import { logger } from "../lib/logger";
 if (process.env.SENTRY_DSN) {
   logger.info("Setting up Sentry...");
 
+  const TRACE_SAMPLE_RATE = parseFloat(
+    process.env.SENTRY_TRACE_SAMPLE_RATE || "0.01",
+  );
+  const ERROR_SAMPLE_RATE = parseFloat(
+    process.env.SENTRY_ERROR_SAMPLE_RATE || "0.05",
+  );
+
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     integrations: integrations => [
@@ -15,9 +22,9 @@ if (process.env.SENTRY_DSN) {
     ],
     tracesSampler: samplingContext => {
       // trace all AI spans, sample 1% of all others
-      return samplingContext.name?.startsWith("ai.") ? 1.0 : 0.01;
+      return samplingContext.name?.startsWith("ai.") ? 1.0 : TRACE_SAMPLE_RATE;
     },
-    sampleRate: 0.05,
+    sampleRate: ERROR_SAMPLE_RATE,
     serverName: process.env.NUQ_POD_NAME,
     environment: process.env.SENTRY_ENVIRONMENT ?? "production",
     beforeSend(event, hint) {


### PR DESCRIPTION
…riables

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Sentry trace and error sampling rates configurable via environment variables. This lets us tune telemetry without code changes while keeping ai.* spans at 100%.

- **New Features**
  - SENTRY_TRACE_SAMPLE_RATE and SENTRY_ERROR_SAMPLE_RATE (floats 0–1).
  - Defaults: trace 0.01, error 0.05.
  - Non-ai traces use TRACE_SAMPLE_RATE; ai.* spans always sample at 1.0.

<sup>Written for commit 807b1181e2e328b8b2d5abe112db1ced0b890dec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

