### PR TITLE
feat(api): concurrency limit info in scrape metadata

### DIFF
--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1054,6 +1054,8 @@ export type Document = {
     creditsUsed?: number;
     postprocessorsUsed?: string[];
     indexId?: string; // ID used to store the document in the index (GCS)
+    concurrencyLimited?: boolean;
+    concurrencyQueueDurationMs?: number;
     // [key: string]: string | string[] | number | { smartScrape: number; other: number; total: number } | undefined;
   };
   serpResults?: {

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -130,8 +130,12 @@ export async function scrapeController(
           0,
         );
 
-      let doc: Document | null = null;
+      let lockTime: number | null = null;
+      let concurrencyLimited: boolean = false;
+
       let timeoutHandle: NodeJS.Timeout | null = null;
+      let doc: Document | null = null;
+
       try {
         const lockStart = Date.now();
         const aborter = new AbortController();
@@ -155,12 +159,13 @@ export async function scrapeController(
               basePriority: 10,
             });
 
-            // TODO: send 429 on abort
-            const lockTime = Date.now() - lockStart;
+            lockTime = Date.now() - lockStart;
+            concurrencyLimited = limited;
 
             logger.debug(`Lock acquired for team: ${req.auth.team_id}`, {
               teamId: req.auth.team_id,
               lockTime,
+              limited,
             });
 
             // Wait for job completion span
@@ -339,11 +344,22 @@ export async function scrapeController(
         totalWait,
         usedLlm,
         formats,
+        concurrencyLimited,
+        concurrencyQueueDurationMs: lockTime || undefined,
       });
 
       return res.status(200).json({
         success: true,
-        data: doc!,
+        data: {
+          ...doc!,
+          metadata: {
+            ...doc!.metadata,
+            concurrencyLimited,
+            concurrencyQueueDurationMs: concurrencyLimited
+              ? lockTime || 0
+              : undefined,
+          },
+        },
         scrape_id: origin?.includes("website") ? jobId : undefined,
       });
     },

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -991,6 +991,8 @@ export type Document = {
     creditsUsed?: number;
     postprocessorsUsed?: string[];
     indexId?: string; // ID used to store the document in the index (GCS)
+    concurrencyLimited?: boolean;
+    concurrencyQueueDurationMs?: number;
     // [key: string]: string | string[] | number | { smartScrape: number; other: number; total: number } | undefined;
   };
   serpResults?: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds concurrency limit details to scrape responses so clients can see if a request was queued and how long it waited. Applies to both v1 and v2 scrape endpoints.

- New Features
  - data.metadata now includes concurrencyLimited (boolean) and concurrencyQueueDurationMs (number) when a lock wait occurred.
  - Adds the same fields to scrape analytics for observability.

<sup>Written for commit 9d554458bde109283b69623954c80c8be6418398. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

