### PR TITLE
chore(sentry): set default TRACE_SAMPLE_RATE to 0

### DIFF
--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -5,7 +5,7 @@ if (process.env.SENTRY_DSN) {
   logger.info("Setting up Sentry...");
 
   const TRACE_SAMPLE_RATE = parseFloat(
-    process.env.SENTRY_TRACE_SAMPLE_RATE || "0.01",
+    process.env.SENTRY_TRACE_SAMPLE_RATE || "0",
   );
   const ERROR_SAMPLE_RATE = parseFloat(
     process.env.SENTRY_ERROR_SAMPLE_RATE || "0.05",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable Sentry tracing by default by setting the default TRACE_SAMPLE_RATE to 0. This turns off performance tracing unless SENTRY_TRACE_SAMPLE_RATE is explicitly set; error sampling remains unchanged.

<sup>Written for commit 3e4e364943360ca0630094ad1133d4db41228a3e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

