### PR TITLE
chore(api): disable vercel input/output tracing

### DIFF
--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -16,8 +16,8 @@ if (process.env.SENTRY_DSN) {
     integrations: integrations => [
       ...integrations,
       Sentry.vercelAIIntegration({
-        recordInputs: true,
-        recordOutputs: true,
+        recordInputs: false,
+        recordOutputs: false,
       }),
     ],
     tracesSampler: samplingContext => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled Vercel AI input/output recording in Sentry for the API. This stops capturing prompts and responses and reduces log/ingest volume.

<sup>Written for commit 6a03555ec1329e8a406968b68d76843564db1d7a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

