### PR TITLE
(sdks)feat/added concurrency info to metadata

### DIFF
--- a/apps/js-sdk/firecrawl/src/v1/index.ts
+++ b/apps/js-sdk/firecrawl/src/v1/index.ts
@@ -53,6 +53,9 @@ export interface FirecrawlDocumentMetadata {
   proxyUsed?: "basic" | "stealth";
   cacheState?: "miss" | "hit";
   cachedAt?: string;
+  creditsUsed?: number;
+  concurrencyLimited?: boolean;
+  concurrencyQueueDurationMs?: number;
   [key: string]: any; // Allows for additional metadata properties not explicitly defined.
 }
 

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -351,6 +351,8 @@ export interface DocumentMetadata {
   cacheState?: 'hit' | 'miss';
   cachedAt?: string;
   creditsUsed?: number;
+  concurrencyLimited?: boolean;
+  concurrencyQueueDurationMs?: number;
 
   // Error information
   error?: string;

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_metadata_extras.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_metadata_extras.py
@@ -63,6 +63,19 @@ class TestDocumentMetadataExtras:
         assert dumped["metadata"]["title"] == "Page"
         assert dumped["metadata"]["twitter:site"] == "@site"
 
+    def test_concurrency_fields_are_mapped(self):
+        raw = {
+            "markdown": "# Queue info",
+            "metadata": {
+                "concurrencyLimited": True,
+                "concurrencyQueueDurationMs": 1234,
+            },
+        }
+        doc = Document(**normalize_document_input(raw))
+        md = doc.metadata_typed
+        assert md.concurrency_limited is True
+        assert md.concurrency_queue_duration_ms == 1234
+
     def test_unknown_list_metadata_preserved(self):
         raw = {
             "markdown": "# Body",

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -120,6 +120,8 @@ class DocumentMetadata(BaseModel):
     cache_state: Optional[Literal["hit", "miss"]] = None
     cached_at: Optional[str] = None
     credits_used: Optional[int] = None
+    concurrency_limited: Optional[bool] = None
+    concurrency_queue_duration_ms: Optional[int] = None
 
     # Error information
     error: Optional[str] = None

--- a/apps/python-sdk/firecrawl/v2/utils/normalize.py
+++ b/apps/python-sdk/firecrawl/v2/utils/normalize.py
@@ -48,6 +48,8 @@ def _map_metadata_keys(md: Dict[str, Any]) -> Dict[str, Any]:
         "cacheState": "cache_state",
         "cachedAt": "cached_at",
         "creditsUsed": "credits_used",
+        "concurrencyLimited": "concurrency_limited",
+        "concurrencyQueueDurationMs": "concurrency_queue_duration_ms",
     }
 
     out: Dict[str, Any] = {}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose concurrency metadata on documents to help users see when requests were queue-limited and how long they waited. Adds two optional fields across JS and Python SDKs.

- **New Features**
  - JS SDK (v1/v2): added metadata fields concurrencyLimited and concurrencyQueueDurationMs.
  - Python SDK: added metadata fields concurrency_limited and concurrency_queue_duration_ms.
  - Normalization maps camelCase to snake_case for Python.
  - Added unit test to verify mapping and serialization.

<sup>Written for commit c06fbed408caf1acfb99ff217e9db29dbe37e9c2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

