### PR TITLE
(sdk)fix/same timeout as api now

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/utils/httpClient.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/httpClient.ts
@@ -23,7 +23,7 @@ export class HttpClient {
     this.backoffFactor = options.backoffFactor ?? 0.5;
     this.instance = axios.create({
       baseURL: this.apiUrl,
-      timeout: options.timeoutMs ?? 60000,
+      timeout: options.timeoutMs ?? 300000,
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.apiKey}`,

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -198,7 +198,7 @@ class FirecrawlClient:
             limit: Maximum number of results to return (default: 5)
             tbs: Time-based search filter
             location: Location string for search
-            timeout: Request timeout in milliseconds (default: 60000)
+            timeout: Request timeout in milliseconds (default: 300000)
             page_options: Options for scraping individual pages
             
         Returns:

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -948,7 +948,7 @@ class SearchRequest(BaseModel):
     tbs: Optional[str] = None
     location: Optional[str] = None
     ignore_invalid_urls: Optional[bool] = None
-    timeout: Optional[int] = 60000
+    timeout: Optional[int] = 300000
     scrape_options: Optional[ScrapeOptions] = None
     integration: Optional[str] = None
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align default request timeout in the JS and Python SDKs to 300,000 ms (5 minutes) to match the API and reduce premature timeouts on longer operations.

- **Bug Fixes**
  - JS SDK: axios client default timeout updated to 300,000 ms.
  - Python SDK: SearchRequest default and search() docstring updated to 300,000 ms.

<sup>Written for commit b2fa569a491c0bca940c177fc895cec752c323a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

