### PR TITLE
fix: prevent empty cookie header in webhook callbacks

### DIFF
--- a/apps/api/src/services/webhook/delivery.ts
+++ b/apps/api/src/services/webhook/delivery.ts
@@ -2,7 +2,7 @@ import undici from "undici";
 import { createHmac } from "crypto";
 import { logger as _logger, logger } from "../../lib/logger";
 import {
-  getSecureDispatcher,
+  getSecureDispatcherNoCookies,
   isIPPrivate,
 } from "../../scraper/scrapeURL/engines/utils/safeFetch";
 import { WebhookConfig, WebhookEvent, WebhookEventDataMap } from "./types";
@@ -113,7 +113,7 @@ export class WebhookSender {
         method: "POST",
         headers,
         body: payloadString,
-        dispatcher: getSecureDispatcher(),
+        dispatcher: getSecureDispatcherNoCookies(),
         signal: abortController.signal,
       });
 


### PR DESCRIPTION
### Problem

When Firecrawl sends webhook callbacks, the `http-cookie-agent` library sends an empty `cookie: ""` header even when the cookie jar is empty. This causes strict HTTP parsers like Laminas to crash, viewing the empty cookie header as malformed.

**Affected users:** Anyone using webhook callbacks with strict HTTP libraries (e.g., Expose, Laminas).

### Root Cause

The webhook delivery code (`delivery.ts`) uses `getSecureDispatcher()` which includes cookie handling via `http-cookie-agent`. Even with an empty cookie jar, this sends: cookie: ""


### Solution

Introduced a separate dispatcher (`getSecureDispatcherNoCookies`) for webhook delivery that doesn't include cookie handling, since webhooks don't need to maintain cookie state.

### Changes

- **`safeFetch.ts`**: Added `getSecureDispatcherNoCookies()` - a dispatcher without cookie agent
- **`delivery.ts`**: Updated to use the new cookie-free dispatcher

### Testing

Verified locally that:
1. `getSecureDispatcher()` sends empty cookie header (expected for scraping)
2. `getSecureDispatcherNoCookies()` does NOT send cookie header (fix confirmed)

Also tested via webhook.site - the `cookie` header no longer appears in webhook callbacks.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents empty Cookie headers in webhook callbacks by switching webhook delivery to a cookie-free dispatcher, avoiding crashes in strict HTTP parsers.

- **Bug Fixes**
  - Use getSecureDispatcherNoCookies() for webhook delivery to stop sending `cookie: ""`.

<sup>Written for commit 4190ce68ec4305d826271a9858068738f988d1b3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



