### PR TITLE
fix(config): add .catch to NUQ worker port defaults for error handling

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -90,10 +90,10 @@ const configSchema = z.object({
 
   // Worker Configuration
   WORKER_PORT: z.coerce.number().default(3005),
-  NUQ_WORKER_PORT: z.coerce.number().default(3000),
+  NUQ_WORKER_PORT: z.coerce.number().default(3000).catch(3000), // todo: investigate why .catch is needed
   NUQ_WORKER_START_PORT: z.coerce.number().default(3006),
   NUQ_WORKER_COUNT: z.coerce.number().default(5),
-  NUQ_PREFETCH_WORKER_PORT: z.coerce.number().default(3011),
+  NUQ_PREFETCH_WORKER_PORT: z.coerce.number().default(3011).catch(3011), // todo: investigate why .catch is needed
   EXTRACT_WORKER_PORT: z.coerce.number().default(3004),
   NUQ_WAIT_MODE: z.string().optional(),
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add .catch to NUQ_WORKER_PORT and NUQ_PREFETCH_WORKER_PORT in the config schema so invalid env values fall back to 3000 and 3011. This prevents config parsing errors and stabilizes worker startup.

<sup>Written for commit f1a48c6d19c92b4414f84a2a27399d7457faa5d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

