### PR TITLE
fix(playwright-service-ts): wasn't starting up due to the lack of chromium under /tmp/.cache

### DIFF
--- a/apps/playwright-service-ts/Dockerfile
+++ b/apps/playwright-service-ts/Dockerfile
@@ -6,7 +6,7 @@ RUN npm install
 
 COPY . .
 
-ENV PLAYWRIGHT_BROWSERS_PATH=/tmp/.cache
+ENV PLAYWRIGHT_BROWSERS_PATH=/usr/local/share/playwright
 
 # Install Playwright dependencies
 RUN npx playwright install chromium --with-deps


### PR DESCRIPTION
If anyone run `docker compose build && docker compose up` according to self-host instructions it doesn't work locally at least with modern docker (I have 4.46). That's because the playwright service Dockerfile suggests installing chromium under `/tmp/.cache` directory which supposed to be used for ephemeral things, not to keep binaries after docker build is complete. So this PR fixes the bug by changing chromium installation path to persistent directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Playwright service startup in Docker by moving the Chromium install to a persistent path. Set PLAYWRIGHT_BROWSERS_PATH to /usr/local/share/playwright so Chromium is available at runtime.

<sup>Written for commit b5ae77ba3dd438b3c6a4bfff7436450e4eac61dd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

