### PR TITLE
fix: make srcset URLs absolute in HTML transformation

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/removeUnwantedElements.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/removeUnwantedElements.ts
@@ -209,26 +209,30 @@ export const htmlTransform = async (
     } catch (_) {}
   });
 
-  // Make srcset URLs absolute
+  // Helper function to convert srcset URLs to absolute
+  const makeSrcsetAbsolute = (srcset: string): string => {
+    return srcset
+      .split(",")
+      .map(entry => {
+        const parts = entry.trim().split(/\s+/);
+        if (parts.length === 0) return entry;
+        const imgUrl = parts[0];
+        const descriptor = parts.slice(1).join(" ");
+        try {
+          const absoluteUrl = new URL(imgUrl, url).href;
+          return descriptor ? `${absoluteUrl} ${descriptor}` : absoluteUrl;
+        } catch (_) {
+          return entry.trim();
+        }
+      })
+      .join(", ");
+  };
+
+  // Make srcset URLs absolute for img elements
   soup("img[srcset]").each((_, el) => {
     try {
       const srcset = el.attribs.srcset;
-      const absoluteSrcset = srcset
-        .split(",")
-        .map(entry => {
-          const parts = entry.trim().split(/\s+/);
-          if (parts.length === 0) return entry;
-          const imgUrl = parts[0];
-          const descriptor = parts.slice(1).join(" ");
-          try {
-            const absoluteUrl = new URL(imgUrl, url).href;
-            return descriptor ? `${absoluteUrl} ${descriptor}` : absoluteUrl;
-          } catch (_) {
-            return entry.trim();
-          }
-        })
-        .join(", ");
-      el.attribs.srcset = absoluteSrcset;
+      el.attribs.srcset = makeSrcsetAbsolute(srcset);
     } catch (_) {}
   });
 
@@ -236,22 +240,7 @@ export const htmlTransform = async (
   soup("source[srcset]").each((_, el) => {
     try {
       const srcset = el.attribs.srcset;
-      const absoluteSrcset = srcset
-        .split(",")
-        .map(entry => {
-          const parts = entry.trim().split(/\s+/);
-          if (parts.length === 0) return entry;
-          const imgUrl = parts[0];
-          const descriptor = parts.slice(1).join(" ");
-          try {
-            const absoluteUrl = new URL(imgUrl, url).href;
-            return descriptor ? `${absoluteUrl} ${descriptor}` : absoluteUrl;
-          } catch (_) {
-            return entry.trim();
-          }
-        })
-        .join(", ");
-      el.attribs.srcset = absoluteSrcset;
+      el.attribs.srcset = makeSrcsetAbsolute(srcset);
     } catch (_) {}
   });
 


### PR DESCRIPTION
This fixes issue #2397 where srcset attributes in img and source elements were not being converted to absolute URLs during HTML transformation.

Tested OK with:
`curl -X POST http://localhost:3002/v2/crawl \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer fc-YOUR_API_KEY" \
  -d '{
    "url": "https://docs.imgix.com/en-US/getting-started/tutorials/responsive-design/responsive-images-with-srcset",
    "limit": 1,
    "scrapeOptions": {
      "formats": ["html"]
    }
  }'`

<img width="1012" height="377" alt="image" src="https://github.com/user-attachments/assets/5ab6edfb-2078-4079-8fc0-5f913ba0261d" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make all srcset URLs absolute during HTML transform so responsive images resolve correctly. Fixes broken images caused by relative srcset entries in crawled pages.

- **Bug Fixes**
  - Convert img[srcset] and source[srcset] entries to absolute using the page URL; preserve descriptors (1x/2x, 480w).
  - Support relative, root-relative, absolute, and mixed srcset entries.
  - Implemented in Rust transformer and the JS fallback.

<sup>Written for commit 614c5748408a5e7f32691553e147e7890faca1fe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



