### PR TITLE
feat(api/admin/crawl-monitor): add endpoint for monitoring crawl system

### DIFF
--- a/apps/api/src/controllers/v0/admin/crawl-monitor.ts
+++ b/apps/api/src/controllers/v0/admin/crawl-monitor.ts
@@ -1,0 +1,127 @@
+import { Response } from "express";
+import { logger as _logger } from "../../../lib/logger";
+import {
+  crawlerOptions,
+  RequestWithAuth,
+  scrapeOptions,
+  toV0CrawlerOptions,
+} from "../../v2/types";
+import { v7 as uuidv7 } from "uuid";
+import { logRequest } from "../../../services/logging/log_job";
+import {
+  crawlToCrawler,
+  markCrawlActive,
+  saveCrawl,
+  StoredCrawl,
+} from "../../../lib/crawl-redis";
+import { config } from "../../../config";
+import { crawlGroup } from "../../../services/worker/nuq";
+import { _addScrapeJobToBullMQ } from "../../../services/queue-jobs";
+
+type ResponseType = {
+  ok: boolean;
+  crawlId: string;
+};
+
+export async function crawlMonitorController(
+  req: RequestWithAuth<{}, undefined, ResponseType>,
+  res: Response<ResponseType>,
+) {
+  const id = uuidv7();
+
+  const logger = _logger.child({
+    module: "crawl-monitor",
+    method: "crawlMonitorController",
+    crawlId: id,
+  });
+
+  logger.debug("Crawl monitor " + id + " starting", {
+    account: req.account,
+  });
+
+  await logRequest({
+    id,
+    kind: "crawl",
+    api_version: "v2",
+    team_id: req.auth.team_id,
+    origin: "api",
+    integration: null,
+    target_hint: "https://firecrawl.dev",
+    zeroDataRetention: false,
+  });
+
+  const sc: StoredCrawl = {
+    originUrl: "https://firecrawl.dev",
+    crawlerOptions: toV0CrawlerOptions(crawlerOptions.parse({ limit: 2 })),
+    scrapeOptions: scrapeOptions.parse({}),
+    internalOptions: {
+      disableSmartWaitCache: true,
+      teamId: req.auth.team_id,
+      saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME ? true : false,
+      zeroDataRetention: false,
+    },
+    team_id: req.auth.team_id,
+    createdAt: Date.now(),
+    maxConcurrency: undefined,
+    zeroDataRetention: false,
+  };
+
+  const crawler = crawlToCrawler(id, sc, req.acuc?.flags ?? null);
+
+  try {
+    sc.robots = await crawler.getRobotsTxt(false);
+  } catch (e) {
+    logger.debug("Failed to get robots.txt (this is probably fine!)", {
+      error: e,
+    });
+  }
+
+  await crawlGroup.addGroup(
+    id,
+    sc.team_id,
+    (req.acuc?.flags?.crawlTtlHours ?? 24) * 60 * 60 * 1000,
+  );
+
+  await saveCrawl(id, sc);
+
+  await markCrawlActive(id);
+
+  await _addScrapeJobToBullMQ(
+    {
+      url: "https://firecrawl.dev",
+      mode: "kickoff" as const,
+      team_id: req.auth.team_id,
+      crawlerOptions: crawlerOptions.parse({ limit: 2 }),
+      scrapeOptions: sc.scrapeOptions,
+      internalOptions: sc.internalOptions,
+      origin: "api",
+      integration: null,
+      crawl_id: id,
+      webhook: undefined,
+      v1: true,
+      zeroDataRetention: false,
+      apiKeyId: req.acuc?.api_key_id ?? null,
+    },
+    uuidv7(),
+  );
+
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < 60000) {
+    const group = await crawlGroup.getGroup(id);
+    if (group?.status === "completed") {
+      logger.debug("Crawl completed");
+      return res.status(200).json({
+        ok: true,
+        crawlId: id,
+      });
+    }
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+
+  logger.warn("Crawl timed out");
+  return res.status(500).json({
+    ok: false,
+    crawlId: id,
+  });
+}

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -794,7 +794,7 @@ export type BatchScrapeRequestInput = Omit<
   zeroDataRetention?: boolean;
 };
 
-const crawlerOptions = z.strictObject({
+export const crawlerOptions = z.strictObject({
   includePaths: z.string().array().prefault([]),
   excludePaths: z.string().array().prefault([]),
   maxDiscoveryDepth: z.number().optional(),

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { config } from "../config";
 import { redisHealthController } from "../controllers/v0/admin/redis-health";
-import { wrap } from "./shared";
+import { authMiddleware, checkCreditsMiddleware, wrap } from "./shared";
 import { acucCacheClearController } from "../controllers/v0/admin/acuc-cache-clear";
 import { checkFireEngine } from "../controllers/v0/admin/check-fire-engine";
 import { cclogController } from "../controllers/v0/admin/cclog";
@@ -16,6 +16,8 @@ import { realtimeSearchController } from "../controllers/v2/f-search";
 import { concurrencyQueueBackfillController } from "../controllers/v0/admin/concurrency-queue-backfill";
 import { integCreateUserController } from "../controllers/v0/admin/create-user";
 import { integValidateApiKeyController } from "../controllers/v0/admin/validate-api-key";
+import { crawlMonitorController } from "../controllers/v0/admin/crawl-monitor";
+import { RateLimiterMode } from "../types";
 
 export const adminRouter = express.Router();
 
@@ -69,6 +71,13 @@ adminRouter.post(
 adminRouter.post(
   `/admin/${config.BULL_AUTH_KEY}/concurrency-queue-backfill`,
   wrap(concurrencyQueueBackfillController),
+);
+
+adminRouter.post(
+  `/admin/${config.BULL_AUTH_KEY}/crawl-monitor`,
+  authMiddleware(RateLimiterMode.Crawl),
+  checkCreditsMiddleware(2),
+  wrap(crawlMonitorController),
 );
 
 adminRouter.post(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an admin-only endpoint to run a tiny crawl and report if it finishes, so we can monitor crawl/prefetch workers end-to-end. Supports Linear ENG-4143 by providing a simple E2E health check.

- **New Features**
  - POST /admin/{BULL_AUTH_KEY}/crawl-monitor with auth, Crawl rate limit, and 2-credit check.
  - Starts a crawl for https://firecrawl.dev with limit=2; logs request; saves state; marks active; enqueues kickoff job to BullMQ; registers crawl group.
  - Polls for up to 60s. Returns 200 { ok: true, crawlId } on completion, else 500 { ok: false, crawlId }.
  - Exports crawlerOptions from v2/types for reuse.
  - Attempts robots.txt fetch; ignores failures.

<sup>Written for commit 413729882f6743196a03e0cd886ee79c6e101897. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

