### PR TITLE
feat(api/scrapeURL): engpicker integ

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -552,6 +552,7 @@ const baseScrapeOptions = z.strictObject({
   __searchPreviewToken: z.string().optional(),
   __experimental_omce: z.boolean().prefault(false).optional(),
   __experimental_omceDomain: z.string().optional(),
+  __experimental_engpicker: z.boolean().prefault(false).optional(),
 });
 
 type ScrapeOptionsBase = z.infer<typeof baseScrapeOptions>;

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -465,7 +465,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
     // TODO: handle sitemap data, see WebScraper/index.ts:280
     // TODO: ScrapeEvents
 
-    const fallbackList = buildFallbackList(meta);
+    const fallbackList = await buildFallbackList(meta);
 
     setSpanAttributes(span, {
       "engine.fallback_list": fallbackList.map(f => f.engine).join(","),


### PR DESCRIPTION
under an experimental flag for now

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates Engpicker to adjust engine selection per domain behind an experimental flag, preferring tlsclient when safe. No default behavior change. Supports Linear ENG-4152.

- New Features
  - Added __experimental_engpicker option (default false).
  - Introduced queryEngpickerVerdict(hostname) using index RPC with a 250ms timeout; returns TlsClientOk/ChromeCdpRequired/Uncertain/Unknown (Unknown on errors or write-only).
  - When verdict is TlsClientOk and no forceEngine is set, boosts tlsclient engines in the fallback sort to rank above CDP; otherwise keeps current ordering.
  - buildFallbackList is now async; scrape loop updated to await it.

<sup>Written for commit 5195a5d0b8cd4216b7260bd5c3ce944d0785fec6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

