### PR TITLE
Use invoiced billing for certain expansion packs

### DIFF
--- a/apps/api/src/services/billing/auto_charge.ts
+++ b/apps/api/src/services/billing/auto_charge.ts
@@ -115,8 +115,8 @@ async function _autoChargeScale(
                 chunk.price_associated_auto_recharge_price_id === undefined
                   ? "undefined"
                   : JSON.stringify(
-                      chunk.price_associated_auto_recharge_price_id,
-                    ),
+                    chunk.price_associated_auto_recharge_price_id,
+                  ),
             });
             return {
               success: false,
@@ -126,6 +126,11 @@ async function _autoChargeScale(
               chunk: updatedChunk ?? chunk,
             };
           }
+
+          const invoiceOnly = Boolean(
+            (price.metadata as { invoice?: boolean } | null | undefined)
+              ?.invoice,
+          );
 
           // Check for recharges this month
 
@@ -224,6 +229,7 @@ async function _autoChargeScale(
               customer.stripe_customer_id,
               chunk.price_associated_auto_recharge_price_id,
               chunk.sub_id,
+              invoiceOnly,
             );
             if (!subscription) {
               logger.error("Failed to create subscription");
@@ -263,13 +269,13 @@ async function _autoChargeScale(
                 canceled_at: null,
                 current_period_start: subscription.current_period_start
                   ? new Date(
-                      subscription.current_period_start * 1000,
-                    ).toISOString()
+                    subscription.current_period_start * 1000,
+                  ).toISOString()
                   : null,
                 current_period_end: subscription.current_period_end
                   ? new Date(
-                      subscription.current_period_end * 1000,
-                    ).toISOString()
+                    subscription.current_period_end * 1000,
+                  ).toISOString()
                   : null,
                 created: subscription.created
                   ? new Date(subscription.created * 1000).toISOString()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds invoice-based billing for expansion pack auto-recharges when the Stripe price has metadata.invoice=true. Addresses Linear ENG-4202 by invoicing selected packs (net 30) instead of charging automatically.

- **New Features**
  - Detect price.metadata.invoice and create subscriptions with collection_method=send_invoice and days_until_due=30.
  - Skip default payment method lookup for invoiced packs; keep existing charge_automatically flow for others.

<sup>Written for commit 1362fe5a8ef590103273a5fc21a812b726b2f3b0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

