### PR TITLE
(feat/partners) Allow email to be optional for partners API

### DIFF
--- a/apps/api/src/controllers/v0/admin/create-user.ts
+++ b/apps/api/src/controllers/v0/admin/create-user.ts
@@ -32,7 +32,7 @@ async function addCoupon(teamId: string, integration: any) {
 
 /**
  * Generates a synthetic email for partner integrations that don't provide real emails.
- * Format: <externalUserId>@<integration-slug>.firecrawl.dev
+ * Format: <externalUserId>@<integration-slug>.partner.firecrawl.dev
  */
 function generateSyntheticEmail(
   externalUserId: string,
@@ -40,7 +40,7 @@ function generateSyntheticEmail(
 ): string {
   // Sanitize the externalUserId to be email-safe (alphanumeric, dots, hyphens, underscores)
   const sanitizedId = externalUserId.replace(/[^a-zA-Z0-9._-]/g, "_");
-  return `${sanitizedId}@${integrationSlug}.firecrawl.dev`;
+  return `${sanitizedId}@${integrationSlug}.partner.firecrawl.dev`;
 }
 
 export async function integCreateUserController(req: Request, res: Response) {

--- a/apps/api/src/controllers/v0/admin/validate-api-key.ts
+++ b/apps/api/src/controllers/v0/admin/validate-api-key.ts
@@ -14,7 +14,7 @@ function extractExternalUserId(
   email: string,
   integrationSlug: string,
 ): string | null {
-  const syntheticDomain = `@${integrationSlug}.firecrawl.dev`;
+  const syntheticDomain = `@${integrationSlug}.partner.firecrawl.dev`;
   if (email.endsWith(syntheticDomain)) {
     return email.slice(0, -syntheticDomain.length);
   }


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make email optional in the partners API by accepting externalUserId and generating a synthetic email when needed. This lets partner integrations create users without real emails and surfaces externalUserId in API key validation.

- **New Features**
  - Accept either email or externalUserId in create-user; generate a sanitized synthetic email: <externalUserId>@<integration-slug>.partner.firecrawl.dev.
  - Save external_user_id in user metadata and return it from validate-api-key when using a synthetic email.

<sup>Written for commit 5bcb04ad7152826435f7015148beabcda4b34f4a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



