### PR TITLE
feat(api): update gpt-4o usage to gpt-4.1

### DIFF
--- a/apps/api/src/lib/extract/completions/analyzeSchemaAndPrompt.ts
+++ b/apps/api/src/lib/extract/completions/analyzeSchemaAndPrompt.ts
@@ -48,7 +48,7 @@ export async function analyzeSchemaAndPrompt(
 
   const schemaString = JSON.stringify(schema);
 
-  const model = getModel("gpt-4o", "openai");
+  const model = getModel("gpt-4.1", "openai");
 
   const checkSchema = z
     .object({

--- a/apps/api/src/lib/extract/completions/batchExtract.ts
+++ b/apps/api/src/lib/extract/completions/batchExtract.ts
@@ -85,7 +85,7 @@ export async function batchExtractPromise(
     markdown: buildDocument(doc),
     isExtractEndpoint: true,
     model: getModel("gpt-4o-mini", "openai"),
-    retryModel: getModel("gpt-4o", "openai"),
+    retryModel: getModel("gpt-4.1", "openai"),
     costTrackingOptions: {
       costTracking: options.costTracking,
       metadata: {

--- a/apps/api/src/lib/extract/completions/singleAnswer.ts
+++ b/apps/api/src/lib/extract/completions/singleAnswer.ts
@@ -58,7 +58,7 @@ export async function singleAnswerCompletion({
     markdown: `${singleAnswerDocs.map((x, i) => `[START_PAGE (ID: ${i})]` + buildDocument(x)).join("\n")} [END_PAGE]\n`,
     isExtractEndpoint: true,
     model: getModel("gpt-4o-mini", "openai"),
-    retryModel: getModel("gpt-4o", "openai"),
+    retryModel: getModel("gpt-4.1", "openai"),
     costTrackingOptions: {
       costTracking,
       metadata: {

--- a/apps/api/src/lib/extract/fire-0/completions/analyzeSchemaAndPrompt-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/completions/analyzeSchemaAndPrompt-f0.ts
@@ -29,7 +29,7 @@ export async function analyzeSchemaAndPrompt_F0(
 
   const schemaString = JSON.stringify(schema);
 
-  const model = getModel("gpt-4o");
+  const model = getModel("gpt-4.1");
 
   const checkSchema = z
     .object({

--- a/apps/api/src/lib/extract/url-processor.ts
+++ b/apps/api/src/lib/extract/url-processor.ts
@@ -18,7 +18,7 @@ export async function generateBasicCompletion(
 ): Promise<{ text: string } | null> {
   try {
     const result = await generateText({
-      model: getModel("gpt-4o", "openai"),
+      model: getModel("gpt-4.1", "openai"),
       prompt: prompt,
       providerOptions: {
         anthropic: {

--- a/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
@@ -453,7 +453,7 @@ export async function extractData({
             ...extractOptions,
             markdown: markdown,
             model: getModel("gpt-4o-mini", "openai"),
-            retryModel: getModel("gpt-4o", "openai"),
+            retryModel: getModel("gpt-4.1", "openai"),
             costTrackingOptions: {
               costTracking: extractOptions.costTrackingOptions.costTracking,
               metadata: {

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -303,7 +303,7 @@ export async function generateCompletions({
   model = getModel("gpt-4o-mini", "openai"),
   mode = "object",
   providerOptions,
-  retryModel = getModel("gpt-4o", "openai"),
+  retryModel = getModel("gpt-4.1", "openai"),
   costTrackingOptions,
   metadata,
 }: GenerateCompletionsOptions): Promise<{
@@ -976,7 +976,7 @@ export async function performLLMExtract(
       markdown: document.markdown,
       previousWarning: document.warning,
       model: getModel(modelSelection.modelName, "openai"),
-      retryModel: getModel("gpt-4o", "openai"),
+      retryModel: getModel("gpt-4.1", "openai"),
       costTrackingOptions: {
         costTracking: meta.costTracking,
         metadata: {
@@ -1176,7 +1176,7 @@ export async function performSummary(
         const selection = selectModelForSchema(inlineSchema);
         return getModel(selection.modelName, "openai");
       })(),
-      retryModel: getModel("gpt-4o", "openai"),
+      retryModel: getModel("gpt-4.1", "openai"),
       costTrackingOptions: {
         costTracking: meta.costTracking,
         metadata: {
@@ -1275,7 +1275,7 @@ export async function generateSchemaFromPrompt(
   },
 ): Promise<{ extract: any }> {
   const model = getModel("gpt-4o-mini", "openai");
-  const retryModel = getModel("gpt-4o", "openai");
+  const retryModel = getModel("gpt-4.1", "openai");
   const temperatures = [0, 0.1, 0.3]; // Different temperatures to try
   let lastError: Error | null = null;
 
@@ -1353,7 +1353,7 @@ export async function generateCrawlerOptionsFromPrompt(
   metadata: { teamId: string; crawlId?: string },
 ): Promise<{ extract: any }> {
   const model = getModel("gpt-4o-mini", "openai");
-  const retryModel = getModel("gpt-4o", "openai");
+  const retryModel = getModel("gpt-4.1", "openai");
   const temperatures = [0, 0.1, 0.3];
   let lastError: Error | null = null;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch model usage from gpt-4o to gpt-4.1 across extraction and URL processing. Primary calls still use gpt-4o-mini; gpt-4.1 is now the retry/fallback.

- **Refactors**
  - Updated analyzeSchemaAndPrompt (including fire-0) and generateBasicCompletion to use gpt-4.1.
  - Set gpt-4.1 as the retry model in batchExtract, singleAnswer, extractSmartScrape, and llmExtract.

<sup>Written for commit 1214caba21d40e2efc76d59ac688ab077b6cd81f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

