### PR TITLE
Dont log Feature Flog Errors to Sentry

### DIFF
--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -1,6 +1,10 @@
 import * as Sentry from "@sentry/node";
 import { logger } from "../lib/logger";
 import { config } from "../config";
+import {
+  AddFeatureError,
+  RemoveFeatureError,
+} from "../scraper/scrapeURL/error";
 
 type CaptureContext = {
   tags?: Record<string, string>;
@@ -53,6 +57,14 @@ if (config.SENTRY_DSN) {
       const error = hint?.originalException;
 
       if (error && typeof error === "object") {
+        // Filter out AddFeatureError and RemoveFeatureError
+        if (
+          error instanceof AddFeatureError ||
+          error instanceof RemoveFeatureError
+        ) {
+          return null;
+        }
+
         const errorCode = "code" in error ? String(error.code) : "";
 
         const transportableErrorCodes = [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Filter AddFeatureError and RemoveFeatureError from Sentry to reduce noise and focus on actionable issues. The error processor now returns null for these known scraper errors, preventing them from being reported.

<sup>Written for commit d6d953f7caed7778b6963127e32728ea78b8b27f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

