### PR TITLE
fix: extract race condition

### DIFF
--- a/apps/api/src/controllers/v1/extract-status.ts
+++ b/apps/api/src/controllers/v1/extract-status.ts
@@ -10,7 +10,7 @@ import { logger as _logger } from "../../lib/logger";
 
 type DBExtract = {
   id: string;
-  success: boolean;
+  is_successful: boolean;
   options: any;
   created_at: any;
   error: string | null;
@@ -47,7 +47,7 @@ async function getExtractJob(
   const job: ExtractPseudoJob<any> = {
     id,
     getState: dbExtract
-      ? () => (dbExtract.success ? "completed" : "failed")
+      ? () => (dbExtract.is_successful ? "completed" : "failed")
       : () => bullJob!.getState(),
     returnvalue: data,
     data: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race that caused /v1/extract-status to report “processing” indefinitely. Addresses ENG-4149 by enforcing a single, ordered source of truth for job state updates.

- **Bug Fixes**
  - Update extract status in the worker before moving the BullMQ job to completed/failed, preventing stale “processing”.
  - Await logExtract calls to ensure writes happen before state transitions.
  - Remove “completed” status updates from extraction services; the worker now owns all status transitions.
  - Persist tokensBilled and creditsBilled via the worker alongside status.
  - Align extract-status controller with DB schema by using is_successful to derive job state.

<sup>Written for commit e684ce31650be00128ff0390a3e7946d9a66f301. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

