### PR TITLE
(feat/monitoring) Add endpoint for change tracking monitoring

### DIFF
--- a/apps/api/src/controllers/v0/admin/check-change-tracking.ts
+++ b/apps/api/src/controllers/v0/admin/check-change-tracking.ts
@@ -1,0 +1,110 @@
+import { Request, Response } from "express";
+import { logger } from "../../../lib/logger";
+import { getACUC } from "../../auth";
+import { parseApi } from "../../../lib/parseApi";
+import { processJobInternal } from "../../../services/worker/scrape-worker";
+import { ScrapeJobData } from "../../../types";
+import { v7 as uuidv7 } from "uuid";
+import { NuQJob } from "../../../services/worker/nuq";
+import { fromV1ScrapeOptions } from "../../v2/types";
+
+export async function checkChangeTrackingController(
+  req: Request,
+  res: Response,
+) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    return res.status(401).json({
+      success: false,
+      error: "Authorization header required",
+    });
+  }
+
+  const apiKey = authHeader.slice(7);
+
+  try {
+    // Authenticate
+    const normalizedApi = parseApi(apiKey);
+    const acuc = await getACUC(normalizedApi);
+
+    if (!acuc) {
+      return res.status(401).json({
+        success: false,
+        error: "Invalid API key",
+      });
+    }
+
+    const jobId = uuidv7();
+    const testUrl = req.body.url || "https://example.com";
+
+    logger.info("Change tracking health check starting", {
+      jobId,
+      teamId: acuc.team_id,
+      testUrl,
+    });
+
+    const { scrapeOptions, internalOptions } = fromV1ScrapeOptions(
+      {
+        formats: ["markdown", "changeTracking"],
+      } as any,
+      30000,
+      acuc.team_id,
+    );
+
+    const job: NuQJob<ScrapeJobData> = {
+      id: jobId,
+      status: "active",
+      createdAt: new Date(),
+      priority: 10,
+      data: {
+        url: testUrl,
+        mode: "single_urls",
+        team_id: acuc.team_id,
+        scrapeOptions,
+        internalOptions: {
+          ...internalOptions,
+          saveScrapeResultToGCS: false,
+          bypassBilling: true,
+        },
+        skipNuq: true,
+        origin: "health-check",
+        startTime: Date.now(),
+        zeroDataRetention: false,
+        apiKeyId: acuc.api_key_id ?? null,
+        concurrencyLimited: false,
+      },
+    };
+
+    const doc = await processJobInternal(job);
+
+    if (!doc) {
+      return res.status(500).json({
+        success: false,
+        error: "Scrape returned no document",
+      });
+    }
+
+    const hasChangeTracking = !!doc.changeTracking;
+
+    logger.info("Change tracking health check completed", {
+      jobId,
+      teamId: acuc.team_id,
+      hasChangeTracking,
+      changeStatus: doc.changeTracking?.changeStatus,
+    });
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        changeTracking: doc.changeTracking,
+        warning: doc.warning,
+      },
+    });
+  } catch (error: any) {
+    logger.error("Change tracking health check failed", { error });
+    return res.status(500).json({
+      success: false,
+      error: error.message,
+    });
+  }
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -19,6 +19,7 @@ import { integValidateApiKeyController } from "../controllers/v0/admin/validate-
 import { integRotateApiKeyController } from "../controllers/v0/admin/rotate-api-key";
 import { crawlMonitorController } from "../controllers/v0/admin/crawl-monitor";
 import { RateLimiterMode } from "../types";
+import { checkChangeTrackingController } from "../controllers/v0/admin/check-change-tracking";
 
 export const adminRouter = express.Router();
 
@@ -94,4 +95,9 @@ adminRouter.post(
 adminRouter.post(
   `/admin/integration/rotate-api-key`,
   wrap(integRotateApiKeyController),
+);
+
+adminRouter.post(
+  `/admin/${config.BULL_AUTH_KEY}/change-tracking-health`,
+  wrap(checkChangeTrackingController),
 );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add an admin endpoint to verify change tracking by running a lightweight scrape and returning the detected change status. This helps monitor the pipeline and quickly spot issues.

- **New Features**
  - Added POST /admin/{BULL_AUTH_KEY}/change-tracking-health.
  - Requires Bearer API key; returns 401 if missing or invalid.
  - Accepts optional body { url }; defaults to https://example.com.
  - Runs an internal scrape with markdown + changeTracking; skipNuq, bypass billing, no GCS save.
  - Returns changeTracking and warning; 500 if the scrape fails or no document is returned.
  - Logs jobId, teamId, and changeStatus for observability.

<sup>Written for commit 68024c57a069aa70a1d3fce4ec0d48c26318f43c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

