### PR TITLE
fix: correct property name from 'success' to 'is_successful'

### DIFF
--- a/apps/api/src/controllers/v2/extract-status.ts
+++ b/apps/api/src/controllers/v2/extract-status.ts
@@ -10,7 +10,7 @@ import { logger as _logger } from "../../lib/logger";
 
 type DBExtract = {
   id: string;
-  success: boolean;
+  is_successful: boolean;
   options: any;
   created_at: any;
   error: string | null;
@@ -48,7 +48,7 @@ async function getExtractJob(
     id,
     getState: bullJob
       ? bullJob.getState.bind(bullJob)
-      : () => (dbExtract!.success ? "completed" : "failed"),
+      : () => (dbExtract!.is_successful ? "completed" : "failed"),
     returnvalue: data,
     data: {
       scrapeOptions: bullJob ? bullJob.data.scrapeOptions : dbExtract!.options,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the extract-status controller to use the DB field is_successful instead of success, ensuring the fallback job state returns "completed" or "failed" correctly when no Bull job exists. Addresses Linear ENG-4149 where the Extract Status API could show "processing" indefinitely due to reading the wrong field.

<sup>Written for commit aeda4583bbe39ff132d75896bc503f0df812383f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

