### PR TITLE
feat: update root endpoint to return JSON with documentation URL

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -93,7 +93,10 @@ const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
 app.use(`/admin/${config.BULL_AUTH_KEY}/queues`, serverAdapter.getRouter());
 
 app.get("/", (_, res) => {
-  res.redirect("https://docs.firecrawl.dev/api-reference/v2-introduction");
+  res.json({
+    message: "Firecrawl API",
+    documentation_url: "https://docs.firecrawl.dev",
+  });
 });
 
 app.get("/e2e-test", (_, res) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return JSON from the root (/) endpoint with a message and documentation_url instead of redirecting to docs. This makes the root machine-readable for health checks and avoids unnecessary redirects for clients and proxies.

<sup>Written for commit 3a3efcdccf66166d69c853984af9586a8557fb20. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

