### PR TITLE
Add more Sentry filtering

### DIFF
--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -5,6 +5,7 @@ import {
   AddFeatureError,
   RemoveFeatureError,
 } from "../scraper/scrapeURL/error";
+import { AbortManagerThrownError } from "../scraper/scrapeURL/lib/abortManager";
 
 type CaptureContext = {
   tags?: Record<string, string>;
@@ -59,7 +60,8 @@ if (config.SENTRY_DSN) {
       if (error && typeof error === "object") {
         if (
           error instanceof AddFeatureError ||
-          error instanceof RemoveFeatureError
+          error instanceof RemoveFeatureError ||
+          error instanceof AbortManagerThrownError
         ) {
           return null;
         }


### PR DESCRIPTION
- **Filter more sentry errors**
- **more filter**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded Sentry filtering to drop AbortManagerThrownError and to read error codes from rethrown TransportableErrors when error.code is missing. This reduces noise by keeping expected scraper failures out of Sentry.

<sup>Written for commit 3232839d8c681f22c5cec0ca631f77d58a6e96d3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

