### PR TITLE
fix: export URL schema for external usage

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -24,7 +24,7 @@ import { webhookSchema } from "../../services/webhook/schema";
 import { BrandingProfile } from "../../types/branding";
 
 // Base URL schema with common validation logic
-const URL = z.preprocess(
+export const URL = z.preprocess(
   x => {
     if (!protocolIncluded(x as string)) {
       x = `http://${x}`;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exported the URL validation schema so other modules can import and reuse consistent URL checks. Supports ENG-4231 by making the shared schema available to crawlers and avoiding duplicate validation logic.

<sup>Written for commit 072a8c209f7c4ecb2fa4123ca68f2e364164e09b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

