### PR TITLE
feat: add configurable harness startup timeout

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -97,6 +97,9 @@ const configSchema = z.object({
   EXTRACT_WORKER_PORT: z.coerce.number().default(3004),
   NUQ_WAIT_MODE: z.string().optional(),
 
+  // Harness Configuration
+  HARNESS_STARTUP_TIMEOUT_MS: z.coerce.number().default(60000),
+
   // Job & Lock Management
   JOB_LOCK_EXTEND_INTERVAL: z.coerce.number().default(10000),
   JOB_LOCK_EXTENSION_TIME: z.coerce.number().default(60000),

--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -161,7 +161,7 @@ function waitForPort(
   options: { signal?: AbortSignal; timeoutMs?: number } = {},
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const { signal, timeoutMs = 30000 } = options;
+    const { signal, timeoutMs = config.HARNESS_STARTUP_TIMEOUT_MS } = options;
 
     let settled = false;
     let retryTimer: NodeJS.Timeout | null = null;
@@ -455,7 +455,7 @@ async function startNuqPostgresContainer(
 async function waitForPostgres(
   host: string,
   port: number,
-  timeoutMs: number = 30000,
+  timeoutMs: number = config.HARNESS_STARTUP_TIMEOUT_MS,
 ): Promise<void> {
   logger.info("Waiting for PostgreSQL to be ready...");
   const start = Date.now();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the harness startup timeout configurable via HARNESS_STARTUP_TIMEOUT_MS. Default is now 60s (up from 30s) so slower environments have more time for Postgres and port readiness.

- **New Features**
  - Added HARNESS_STARTUP_TIMEOUT_MS to config (default: 60000 ms).
  - waitForPort and waitForPostgres now use this value.

- **Migration**
  - Optional: set HARNESS_STARTUP_TIMEOUT_MS to tune startup time.
  - No other changes required.

<sup>Written for commit 111e00af0bcc8c1708ea8ca1c922cd2615bae77c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

