### PR TITLE
fix(api): scrapeURL/index-metrics logging

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -1110,11 +1110,15 @@ export async function scrapeURL(
         meta.logger.debug("scrapeURL index metrics", {
           module: "scrapeURL/index-metrics",
           timeTaken: Date.now() - startTime,
-          changeTracking: hasFormatOfType(
+          changeTracking: !!hasFormatOfType(
             meta.options.formats,
             "changeTracking",
           ),
-          branding: hasFormatOfType(meta.options.formats, "branding"),
+          summary: !!hasFormatOfType(meta.options.formats, "summary"),
+          json: !!hasFormatOfType(meta.options.formats, "json"),
+          screenshot: !!hasFormatOfType(meta.options.formats, "screenshot"),
+          images: !!hasFormatOfType(meta.options.formats, "images"),
+          branding: !!hasFormatOfType(meta.options.formats, "branding"),
           pdfMaxPages: getPDFMaxPages(meta.options.parsers),
           maxAge: meta.options.maxAge,
           headers: meta.options.headers
@@ -1153,11 +1157,15 @@ export async function scrapeURL(
         meta.logger.debug("scrapeURL index metrics", {
           module: "scrapeURL/index-metrics",
           timeTaken: Date.now() - startTime,
-          changeTracking: hasFormatOfType(
+          changeTracking: !!hasFormatOfType(
             meta.options.formats,
             "changeTracking",
           ),
-          branding: hasFormatOfType(meta.options.formats, "branding"),
+          summary: !!hasFormatOfType(meta.options.formats, "summary"),
+          json: !!hasFormatOfType(meta.options.formats, "json"),
+          screenshot: !!hasFormatOfType(meta.options.formats, "screenshot"),
+          images: !!hasFormatOfType(meta.options.formats, "images"),
+          branding: !!hasFormatOfType(meta.options.formats, "branding"),
           pdfMaxPages: getPDFMaxPages(meta.options.parsers),
           maxAge: meta.options.maxAge,
           headers: meta.options.headers


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed scrapeURL index metrics logging to output true/false for format flags and include summary, json, screenshot, and images. This improves metric consistency and observability during scraping.

<sup>Written for commit ed49e6a7f96ddf63f95ae06bff6d2ce16743cc3c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

