### PR TITLE
feat(api): optimize redis calls

### DIFF
--- a/apps/api/src/lib/deep-research/deep-research-redis.ts
+++ b/apps/api/src/lib/deep-research/deep-research-redis.ts
@@ -55,8 +55,9 @@ export async function saveDeepResearch(
   await redisEvictConnection.set(
     "deep-research:" + id,
     JSON.stringify(research),
+    "EX",
+    DEEP_RESEARCH_TTL,
   );
-  await redisEvictConnection.expire("deep-research:" + id, DEEP_RESEARCH_TTL);
 }
 
 export async function getDeepResearch(
@@ -97,8 +98,9 @@ export async function updateDeepResearch(
   await redisEvictConnection.set(
     "deep-research:" + id,
     JSON.stringify(updatedResearch),
+    "EX",
+    DEEP_RESEARCH_TTL,
   );
-  await redisEvictConnection.expire("deep-research:" + id, DEEP_RESEARCH_TTL);
 }
 
 export async function getDeepResearchExpiry(id: string): Promise<Date> {

--- a/apps/api/src/lib/extract/extract-redis.ts
+++ b/apps/api/src/lib/extract/extract-redis.ts
@@ -69,8 +69,9 @@ export async function saveExtract(id: string, extract: StoredExtract) {
   await redisEvictConnection.set(
     "extract:" + id,
     JSON.stringify(minimalExtract),
+    "EX",
+    EXTRACT_TTL,
   );
-  await redisEvictConnection.expire("extract:" + id, EXTRACT_TTL);
 }
 
 export async function getExtract(id: string): Promise<StoredExtract | null> {
@@ -131,8 +132,9 @@ export async function updateExtract(
   await redisEvictConnection.set(
     "extract:" + id,
     JSON.stringify(minimalExtract),
+    "EX",
+    EXTRACT_TTL,
   );
-  await redisEvictConnection.expire("extract:" + id, EXTRACT_TTL);
 }
 
 export async function getExtractExpiry(id: string): Promise<Date> {

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-redis.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-redis.ts
@@ -23,8 +23,12 @@ export async function saveGeneratedLlmsTxt(
   data: GenerationData,
 ): Promise<void> {
   _logger.debug("Saving llmstxt generation " + id + " to Redis...");
-  await redisEvictConnection.set("generation:" + id, JSON.stringify(data));
-  await redisEvictConnection.expire("generation:" + id, GENERATION_TTL);
+  await redisEvictConnection.set(
+    "generation:" + id,
+    JSON.stringify(data),
+    "EX",
+    GENERATION_TTL,
+  );
 }
 
 export async function getGeneratedLlmsTxt(
@@ -49,8 +53,9 @@ export async function updateGeneratedLlmsTxt(
   await redisEvictConnection.set(
     "generation:" + id,
     JSON.stringify(updatedGeneration),
+    "EX",
+    GENERATION_TTL,
   );
-  await redisEvictConnection.expire("generation:" + id, GENERATION_TTL);
 }
 
 export async function getGeneratedLlmsTxtExpiry(id: string): Promise<Date> {

--- a/apps/api/src/services/rate-limiter.ts
+++ b/apps/api/src/services/rate-limiter.ts
@@ -4,7 +4,9 @@ import { RateLimiterMode } from "../types";
 import Redis from "ioredis";
 import type { AuthCreditUsageChunk } from "../controllers/v1/types";
 
-export const redisRateLimitClient = new Redis(config.REDIS_RATE_LIMIT_URL!);
+export const redisRateLimitClient = new Redis(config.REDIS_RATE_LIMIT_URL!, {
+  enableAutoPipelining: true,
+});
 
 const createRateLimiter = (keyPrefix, points) =>
   new RateLimiterRedis({

--- a/apps/api/src/services/redis.ts
+++ b/apps/api/src/services/redis.ts
@@ -73,4 +73,6 @@ const deleteKey = async (key: string) => {
 export { setValue, getValue, deleteKey };
 
 const redisEvictURL = config.REDIS_EVICT_URL ?? config.REDIS_RATE_LIMIT_URL;
-export const redisEvictConnection = new IORedis(redisEvictURL!);
+export const redisEvictConnection = new IORedis(redisEvictURL!, {
+  enableAutoPipelining: true,
+});

--- a/apps/api/src/services/worker/redis.ts
+++ b/apps/api/src/services/worker/redis.ts
@@ -62,6 +62,7 @@ const redis = new IORedis(config.REDIS_URL!, {
   lazyConnect: true,
   maxRetriesPerRequest: null,
   enableReadyCheck: false,
+  enableAutoPipelining: true,
 });
 
 let initPromise: Promise<void> | null = null;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimized Redis usage to reduce round-trips and set TTLs atomically across crawl, research, extract, and generation flows. This lowers latency and improves throughput, especially during crawls and rate limiting.

- **Performance**
  - Use SET with EX TTL instead of separate EXPIRE calls.
  - Batch SADD/EXPIRE/ZADD/ZREM with ioredis pipelines in crawl jobs and URL locks.
  - Enable auto-pipelining for Redis clients (rate limiter, evict, worker).
  - Compute lock results from pipeline responses for consistency.

<sup>Written for commit e6dfd0bdfaea6fd56af86cddc9fc07f2a28c15af. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

