### PR TITLE
Add strictJsonSchema on Branding Format LLM Call

### DIFF
--- a/apps/api/src/lib/branding/llm.ts
+++ b/apps/api/src/lib/branding/llm.ts
@@ -57,6 +57,11 @@ export async function enhanceBrandingWithLLM(
     const result = await generateObject({
       model,
       schema: brandingEnhancementSchema,
+      providerOptions: {
+        openai: {
+          strictJsonSchema: true,
+        },
+      },
       messages: [
         {
           role: "system",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces strict JSON schema on the branding enhancement LLM call so outputs always match brandingEnhancementSchema. Prevents malformed responses and reduces downstream parsing errors.

<sup>Written for commit ebb82b81c539dbd8d83d84afd7e3cfb62b8a5c60. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

