### PR TITLE
Fix Deps Audit

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -128,7 +128,7 @@
     "response-time": "^2.3.4",
     "robots-parser": "^3.0.1",
     "stripe": "^16.1.0",
-    "systeminformation": "^5.27.8",
+    "systeminformation": "^5.27.14",
     "tldts": "^6.1.75",
     "tough-cookie": "^4.1.4",
     "turndown": "^7.1.3",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: ^16.1.0
         version: 16.1.0
       systeminformation:
-        specifier: ^5.27.8
-        version: 5.27.8
+        specifier: ^5.27.14
+        version: 5.27.14
       tldts:
         specifier: ^6.1.75
         version: 6.1.75
@@ -5929,8 +5929,8 @@ packages:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  systeminformation@5.27.8:
-    resolution: {integrity: sha512-d3Z0gaQO1MlUxzDUKsmXz5y4TOBCMZ8IyijzaYOykV3AcNOTQ7mT+tpndUOXYNSxzLK3la8G32xiUFvZ0/s6PA==}
+  systeminformation@5.27.14:
+    resolution: {integrity: sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -13719,7 +13719,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  systeminformation@5.27.8: {}
+  systeminformation@5.27.14: {}
 
   tdigest@0.1.2:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated apps/api to use systeminformation 5.27.14 to fix dependency audit warnings. Updated pnpm-lock.yaml to match.

<sup>Written for commit 670e7312132f06df7fb8869d21703bc928333dae. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

