### PR TITLE
feat(api): ab/bsrch

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1623,6 +1623,13 @@ export const searchRequestSchema = z
           }, "You may only specify one screenshot format"),
       })
       .optional(),
+    __agentInterop: z
+      .object({
+        auth: z.string(),
+        requestId: z.string(),
+        shouldBill: z.boolean(),
+      })
+      .optional(),
   })
   .refine(x => waitForRefine(x.scrapeOptions), waitForRefineOpts)
   .transform(x => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds agent interop to the v2 search API so trusted agents can authenticate, attach an external requestId, and control billing. Updates schema, validation, logging, and billing to honor these fields.

- **New Features**
  - Add __agentInterop to searchRequestSchema: { auth, requestId, shouldBill }.
  - Validate auth against AGENT_INTEROP_SECRET; return 403 if invalid or not enabled.
  - Use requestId for job submission and logSearch; skip initial logRequest when provided.
  - Respect shouldBill: bypass billing when false and log credits_cost as 0.

<sup>Written for commit ae462b3b8c20ad272e158520e2ba79cea72c11df. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

