### PR TITLE
Update html-to-markdown module

### DIFF
--- a/apps/api/sharedLibs/go-html-to-md/go.mod
+++ b/apps/api/sharedLibs/go-html-to-md/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3
-	github.com/firecrawl/html-to-markdown v0.0.0-20250922154302-32a7ad4a22c3
+	github.com/firecrawl/html-to-markdown v0.0.0-20251217182832-090acb7b0e2e
 	golang.org/x/net v0.41.0
 )
 
@@ -17,4 +17,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/JohannesKaufmann/html-to-markdown => github.com/firecrawl/html-to-markdown v0.0.0-20250917145228-b6d0a75dfdba
+replace github.com/JohannesKaufmann/html-to-markdown => github.com/firecrawl/html-to-markdown v0.0.0-20251217182832-090acb7b0e2e

--- a/apps/api/sharedLibs/go-html-to-md/go.sum
+++ b/apps/api/sharedLibs/go-html-to-md/go.sum
@@ -3,8 +3,8 @@ github.com/PuerkitoBio/goquery v1.10.3/go.mod h1:tMUX0zDMHXYlAQk6p35XxQMqMweEKB7
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/firecrawl/html-to-markdown v0.0.0-20250922154302-32a7ad4a22c3 h1:lzHIpN3DszdL8V2JRK03WleWIeW2ssVmiMAbg67ES/A=
-github.com/firecrawl/html-to-markdown v0.0.0-20250922154302-32a7ad4a22c3/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
+github.com/firecrawl/html-to-markdown v0.0.0-20251217182832-090acb7b0e2e h1:QZOrCLLPzfxIw2PG8KTwmzqYiBs/t60jqjYqp0pSXvM=
+github.com/firecrawl/html-to-markdown v0.0.0-20251217182832-090acb7b0e2e/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/apps/go-html-to-md-service/go.mod
+++ b/apps/go-html-to-md-service/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3
-	github.com/firecrawl/html-to-markdown v0.0.0-20250922154302-32a7ad4a22c3
+	github.com/firecrawl/html-to-markdown v0.0.0-20251217182832-090acb7b0e2e
 	github.com/gorilla/mux v1.8.1
 	github.com/rs/zerolog v1.33.0
 	golang.org/x/net v0.41.0
@@ -20,4 +20,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/JohannesKaufmann/html-to-markdown => github.com/firecrawl/html-to-markdown v0.0.0-20250917145228-b6d0a75dfdba
+replace github.com/JohannesKaufmann/html-to-markdown => github.com/firecrawl/html-to-markdown v0.0.0-20251217182832-090acb7b0e2e

--- a/apps/go-html-to-md-service/go.sum
+++ b/apps/go-html-to-md-service/go.sum
@@ -4,8 +4,8 @@ github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kk
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/firecrawl/html-to-markdown v0.0.0-20250922154302-32a7ad4a22c3 h1:lzHIpN3DszdL8V2JRK03WleWIeW2ssVmiMAbg67ES/A=
-github.com/firecrawl/html-to-markdown v0.0.0-20250922154302-32a7ad4a22c3/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
+github.com/firecrawl/html-to-markdown v0.0.0-20251217182832-090acb7b0e2e h1:QZOrCLLPzfxIw2PG8KTwmzqYiBs/t60jqjYqp0pSXvM=
+github.com/firecrawl/html-to-markdown v0.0.0-20251217182832-090acb7b0e2e/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped html-to-markdown to v0.0.0-20251217182832-090acb7b0e2e across the shared library and service to pick up upstream fixes and maintain compatibility. Updated go.mod/go.sum and the replace directive; no app code changes.

- **Dependencies**
  - Updated github.com/firecrawl/html-to-markdown in apps/api/sharedLibs/go-html-to-md and apps/go-html-to-md-service.
  - Synced replace for github.com/JohannesKaufmann/html-to-markdown to the same version.

<sup>Written for commit f5b9ae7407449431cc19fb514c65056fff673d34. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

