### PR TITLE
Prevent duplicate job processing/logging

### DIFF
--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -52,8 +52,15 @@ const processDeepResearchJobInternal = async (
   });
 
   const extendLockInterval = setInterval(async () => {
-    logger.info(`🔄 Worker extending lock on job ${job.id}`);
-    await job.extendLock(token, jobLockExtensionTime);
+    try {
+      logger.info(`🔄 Worker extending lock on job ${job.id}`);
+      await job.extendLock(token, jobLockExtensionTime);
+    } catch (error) {
+      logger.error("Failed extending BullMQ job lock", {
+        error,
+        jobId: job.id,
+      });
+    }
   }, jobLockExtendInterval);
 
   try {
@@ -134,8 +141,15 @@ const processGenerateLlmsTxtJobInternal = async (
   });
 
   const extendLockInterval = setInterval(async () => {
-    logger.info(`🔄 Worker extending lock on job ${job.id}`);
-    await job.extendLock(token, jobLockExtensionTime);
+    try {
+      logger.info(`🔄 Worker extending lock on job ${job.id}`);
+      await job.extendLock(token, jobLockExtensionTime);
+    } catch (error) {
+      logger.error("Failed extending BullMQ job lock", {
+        error,
+        jobId: job.id,
+      });
+    }
   }, jobLockExtendInterval);
 
   try {
@@ -253,8 +267,8 @@ const workerFun = async (
 
   const worker = new Worker(queue.name, null, {
     connection: getRedisConnection(),
-    lockDuration: 60 * 1000, // 60 seconds
-    stalledInterval: 60 * 1000, // 60 seconds
+    lockDuration: config.WORKER_LOCK_DURATION,
+    stalledInterval: config.WORKER_STALLED_CHECK_INTERVAL,
     maxStalledCount: 10, // 10 times
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents duplicate job execution and log entries by adding Redis-based dedupe for extract jobs and idempotent DB inserts. Also hardens BullMQ lock handling and makes lock timing configurable.

- **Bug Fixes**
  - Extract worker short-circuits if Redis shows the extract is already completed; completes the job with a deduped result to avoid double billing/logging.
  - Logging is idempotent: duplicate key errors (e.g., 23505) are treated as success in robustInsert.
  - Workers wrap job.extendLock in try/catch to avoid crashes on lost locks and use config.WORKER_LOCK_DURATION and WORKER_STALLED_CHECK_INTERVAL.

<sup>Written for commit fba5c575dfcad3a76ac6b7fa661465e3f7eaab2d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

