### PR TITLE
chore(api): re-route fire-1

### DIFF
--- a/apps/api/src/controllers/v1/extract.ts
+++ b/apps/api/src/controllers/v1/extract.ts
@@ -9,10 +9,7 @@ import {
 import { addExtractJobToQueue } from "../../services/queue-service";
 import { saveExtract } from "../../lib/extract/extract-redis";
 import { getTeamIdSyncB } from "../../lib/extract/team-id-sync";
-import {
-  ExtractResult,
-  performExtraction,
-} from "../../lib/extract/extraction-service";
+import { ExtractResult } from "../../lib/extract/extraction-service";
 import { performExtraction_F0 } from "../../lib/extract/fire-0/extraction-service-f0";
 import { BLOCKLISTED_URL_MESSAGE } from "../../lib/strings";
 import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
@@ -59,22 +56,12 @@ async function oldExtract(
     } as V2ExtractRequest;
 
     let result: ExtractResult;
-    const model = req.body.agent?.model;
-    if (req.body.agent && model && model.toLowerCase().includes("fire-1")) {
-      result = await performExtraction(extractId, {
-        request,
-        teamId: req.auth.team_id,
-        subId: req.acuc?.sub_id ?? undefined,
-        apiKeyId: req.acuc?.api_key_id ?? null,
-      });
-    } else {
-      result = await performExtraction_F0(extractId, {
-        request,
-        teamId: req.auth.team_id,
-        subId: req.acuc?.sub_id ?? undefined,
-        apiKeyId: req.acuc?.api_key_id ?? null,
-      });
-    }
+    result = await performExtraction_F0(extractId, {
+      request,
+      teamId: req.auth.team_id,
+      subId: req.acuc?.sub_id ?? undefined,
+      apiKeyId: req.acuc?.api_key_id ?? null,
+    });
 
     if (sender) {
       if (result.success) {

--- a/apps/api/src/lib/extract/extraction-service.ts
+++ b/apps/api/src/lib/extract/extraction-service.ts
@@ -76,7 +76,7 @@ type completions = {
   sources?: string[];
 };
 
-export async function performExtraction(
+async function performExtraction(
   extractId: string,
   options: ExtractServiceOptions,
 ): Promise<ExtractResult> {

--- a/apps/api/src/services/extract-worker.ts
+++ b/apps/api/src/services/extract-worker.ts
@@ -5,10 +5,7 @@ import { setSentryServiceTag } from "./sentry";
 import * as Sentry from "@sentry/node";
 import { logger as _logger } from "../lib/logger";
 import { configDotenv } from "dotenv";
-import {
-  ExtractResult,
-  performExtraction,
-} from "../lib/extract/extraction-service";
+import { ExtractResult } from "../lib/extract/extraction-service";
 import { updateExtract } from "../lib/extract/extract-redis";
 import { performExtraction_F0 } from "../lib/extract/fire-0/extraction-service-f0";
 import { createWebhookSender, WebhookEvent } from "./webhook";
@@ -55,22 +52,12 @@ const processExtractJob = async (
 
     let result: ExtractResult | null = null;
 
-    const model = data.request.agent?.model;
-    if (data.request.agent && model && model.toLowerCase().includes("fire-1")) {
-      result = await performExtraction(data.extractId, {
-        request: data.request,
-        teamId: data.teamId,
-        subId: data.subId ?? undefined,
-        apiKeyId: data.apiKeyId ?? null,
-      });
-    } else {
-      result = await performExtraction_F0(data.extractId, {
-        request: data.request,
-        teamId: data.teamId,
-        subId: data.subId ?? undefined,
-        apiKeyId: data.apiKeyId ?? null,
-      });
-    }
+    result = await performExtraction_F0(data.extractId, {
+      request: data.request,
+      teamId: data.teamId,
+      subId: data.subId ?? undefined,
+      apiKeyId: data.apiKeyId ?? null,
+    });
 
     if (result && result.success) {
       await updateExtract(data.extractId, {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Route all extract requests to fire-0 and remove the fire-1 path. This simplifies the API and ensures consistent behavior regardless of agent.model.

- **Refactors**
  - Removed fire-1 branching in v1/extract controller and extract worker; always call performExtraction_F0.
  - Made performExtraction in extraction-service internal (no longer exported).

<sup>Written for commit b46fa476eb09427ce6715f78bb4080dbedcad580. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

