### PR TITLE
fix: Add webhook support to startExtract method in Node.js SDK

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
@@ -1,4 +1,4 @@
-import { type ExtractResponse, type ScrapeOptions, type AgentOptions } from "../types";
+import { type ExtractResponse, type ScrapeOptions, type AgentOptions, type WebhookConfig } from "../types";
 import { HttpClient } from "../utils/httpClient";
 import { ensureValidScrapeOptions } from "../utils/validation";
 import { normalizeAxiosError, throwForBadResponse } from "../utils/errorHandler";
@@ -17,6 +17,7 @@ function prepareExtractPayload(args: {
   ignoreInvalidURLs?: boolean;
   integration?: string;
   agent?: AgentOptions;
+  webhook?: string | WebhookConfig | null;
 }): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (args.urls) body.urls = args.urls;
@@ -33,6 +34,7 @@ function prepareExtractPayload(args: {
   if (args.ignoreInvalidURLs != null) body.ignoreInvalidURLs = args.ignoreInvalidURLs;
   if (args.integration && args.integration.trim()) body.integration = args.integration.trim();
   if (args.agent) body.agent = args.agent;
+  if (args.webhook != null) body.webhook = args.webhook;
   if (args.scrapeOptions) {
     ensureValidScrapeOptions(args.scrapeOptions);
     body.scrapeOptions = args.scrapeOptions;


### PR DESCRIPTION
Fixes #2582

- Added WebhookConfig type import
- Added webhook parameter to prepareExtractPayload function
- Added logic to include webhook in the API request body

This makes startExtract consistent with other async job methods (crawl, batchScrape) that already support webhooks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds webhook support to startExtract in the Node.js SDK so clients can receive callbacks for extract jobs, consistent with crawl and batchScrape.

- **New Features**
  - Accepts webhook as string | WebhookConfig | null in prepareExtractPayload.
  - Includes webhook in the API request body when provided.
  - Imports WebhookConfig type.

<sup>Written for commit f31ac1658000fff509c25bcf4b964d9129243303. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

