### PR TITLE
fix: Map function returns empty results for URLs with www prefix

### DIFF
--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -192,7 +192,7 @@ export async function getMapResults({
         ? `${search} ${urlWithoutWww}`
         : search
           ? `${search} site:${urlWithoutWww}`
-          : `site:${url}`;
+          : `site:${urlWithoutWww}`;
 
     const resultsPerPage = 100;
     const maxPages = Math.ceil(


### PR DESCRIPTION
Fixes #2580

The map endpoint was returning empty results when URLs contained the www. prefix because the search query used the original URL with www while results came back without it.

Changed map-utils.ts to consistently use urlWithoutWww for all site search queries, matching the behavior when search parameters are provided.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed empty map results for URLs with a www prefix by always using urlWithoutWww in site: queries, including when no search term is provided. Fixes #2580.

<sup>Written for commit b6a9fc259f22d18e1fec743f818c85c0688cf3c6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

