### PR TITLE
fix: Strip username/password from URLs to prevent duplicate crawls

### DIFF
--- a/apps/api/src/lib/validateUrl.ts
+++ b/apps/api/src/lib/validateUrl.ts
@@ -41,6 +41,10 @@ export const checkAndUpdateURL = (url: string) => {
     typedUrlObj.username = "";
     typedUrlObj.password = "";
     url = typedUrlObj.toString();
+    // Remove trailing slash again if toString() added it back
+    if (url.endsWith("/")) {
+      url = url.slice(0, -1);
+    }
   }
 
   return { urlObj: typedUrlObj, url: url };
@@ -166,6 +170,10 @@ export const checkAndUpdateURLForMap = (
     typedUrlObj.username = "";
     typedUrlObj.password = "";
     url = typedUrlObj.toString();
+    // Remove trailing slash again if it was added by toString()
+    if (url.endsWith("/")) {
+      url = url.slice(0, -1);
+    }
   }
 
   // remove any query params


### PR DESCRIPTION
Fixes #2591

Malformed mailto links and URLs with HTTP basic auth credentials (e.g., https://email@domain.com\) were causing duplicate crawls.

Added credential stripping logic to both checkAndUpdateURL and checkAndUpdateURLForMap functions to normalize URLs by removing username and password components, matching modern browser behavior.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip username and password from URLs during validation to prevent duplicate crawls and align with modern browser behavior. Ensure trailing slashes added during re-serialization are removed for consistent normalization.

- **Bug Fixes**
  - Normalize URLs in checkAndUpdateURL and checkAndUpdateURLForMap by clearing username/password, re-serializing, and removing trailing slashes added by toString().
  - Prevent duplicate crawls from URLs with basic auth credentials (e.g., https://user@domain.com).

<sup>Written for commit b211b1335bfbea868453048ac16a4dca9b15657c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



