### PR TITLE
fix(api): index metrics backwards compat

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -1120,15 +1120,18 @@ export async function scrapeURL(
         meta.logger.debug("scrapeURL index metrics", {
           module: "scrapeURL/index-metrics",
           timeTaken: Date.now() - startTime,
-          changeTracking: !!hasFormatOfType(
+          changeTrackingEnabled: !!hasFormatOfType(
             meta.options.formats,
             "changeTracking",
           ),
-          summary: !!hasFormatOfType(meta.options.formats, "summary"),
-          json: !!hasFormatOfType(meta.options.formats, "json"),
-          screenshot: !!hasFormatOfType(meta.options.formats, "screenshot"),
-          images: !!hasFormatOfType(meta.options.formats, "images"),
-          branding: !!hasFormatOfType(meta.options.formats, "branding"),
+          summaryEnabled: !!hasFormatOfType(meta.options.formats, "summary"),
+          jsonEnabled: !!hasFormatOfType(meta.options.formats, "json"),
+          screenshotEnabled: !!hasFormatOfType(
+            meta.options.formats,
+            "screenshot",
+          ),
+          imagesEnabled: !!hasFormatOfType(meta.options.formats, "images"),
+          brandingEnabled: !!hasFormatOfType(meta.options.formats, "branding"),
           pdfMaxPages: getPDFMaxPages(meta.options.parsers),
           maxAge: meta.options.maxAge,
           headers: meta.options.headers
@@ -1167,15 +1170,18 @@ export async function scrapeURL(
         meta.logger.debug("scrapeURL index metrics", {
           module: "scrapeURL/index-metrics",
           timeTaken: Date.now() - startTime,
-          changeTracking: !!hasFormatOfType(
+          changeTrackingEnabled: !!hasFormatOfType(
             meta.options.formats,
             "changeTracking",
           ),
-          summary: !!hasFormatOfType(meta.options.formats, "summary"),
-          json: !!hasFormatOfType(meta.options.formats, "json"),
-          screenshot: !!hasFormatOfType(meta.options.formats, "screenshot"),
-          images: !!hasFormatOfType(meta.options.formats, "images"),
-          branding: !!hasFormatOfType(meta.options.formats, "branding"),
+          summaryEnabled: !!hasFormatOfType(meta.options.formats, "summary"),
+          jsonEnabled: !!hasFormatOfType(meta.options.formats, "json"),
+          screenshotEnabled: !!hasFormatOfType(
+            meta.options.formats,
+            "screenshot",
+          ),
+          imagesEnabled: !!hasFormatOfType(meta.options.formats, "images"),
+          brandingEnabled: !!hasFormatOfType(meta.options.formats, "branding"),
           pdfMaxPages: getPDFMaxPages(meta.options.parsers),
           maxAge: meta.options.maxAge,
           headers: meta.options.headers


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores backward-compatible index metrics by renaming boolean flags to *Enabled in scrapeURL debug logs. Keeps the metrics schema consistent with existing consumers and dashboards.

<sup>Written for commit 2d50b63ba424257271b331198da95ed130e5de56. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

