### PR TITLE
fix(api): handle browser-rendered XML in sitemap parsing

### DIFF
--- a/apps/api/src/scraper/WebScraper/__tests__/sitemap.test.ts
+++ b/apps/api/src/scraper/WebScraper/__tests__/sitemap.test.ts
@@ -1,43 +1,4 @@
-// Test the extractXmlFromHtmlWrapper function in isolation
-// We inline the function here to avoid importing the full sitemap module
-// which has complex dependencies that Jest can't handle
-
-/**
- * Extracts raw XML from HTML-wrapped content that browsers generate when rendering XML files.
- */
-function extractXmlFromHtmlWrapper(content: string): string {
-  // Only process if content looks like HTML-wrapped XML
-  if (
-    content.includes("webkit-xml-viewer-source-xml") ||
-    (content.startsWith("<!--?xml") && content.includes("<html"))
-  ) {
-    // Try to extract from WebKit XML viewer div
-    const webkitMatch = content.match(
-      /<div[^>]*id=["']webkit-xml-viewer-source-xml["'][^>]*>([\s\S]*?)<\/div>/i,
-    );
-    if (webkitMatch && webkitMatch[1]) {
-      const extracted = webkitMatch[1].trim();
-      if (
-        extracted.includes("<urlset") ||
-        extracted.includes("<sitemapindex")
-      ) {
-        return extracted;
-      }
-    }
-
-    // Fallback: extract urlset or sitemapindex directly via regex
-    const urlsetMatch = content.match(/<urlset[\s\S]*?<\/urlset>/i);
-    if (urlsetMatch) return urlsetMatch[0];
-
-    const sitemapIndexMatch = content.match(
-      /<sitemapindex[\s\S]*?<\/sitemapindex>/i,
-    );
-    if (sitemapIndexMatch) return sitemapIndexMatch[0];
-  }
-
-  // Return original content if not HTML-wrapped
-  return content;
-}
+import { extractXmlFromHtmlWrapper } from "../utils/xml-utils";
 
 describe("extractXmlFromHtmlWrapper", () => {
   describe("when content is raw XML", () => {

--- a/apps/api/src/scraper/WebScraper/sitemap.ts
+++ b/apps/api/src/scraper/WebScraper/sitemap.ts
@@ -18,54 +18,13 @@ import { gunzip } from "node:zlib";
 import { promisify } from "node:util";
 import { fetchFileToBuffer } from "../scrapeURL/engines/utils/downloadFile";
 import { useIndex } from "../../services";
+import { extractXmlFromHtmlWrapper } from "./utils/xml-utils";
 
 const useFireEngine =
   config.FIRE_ENGINE_BETA_URL !== "" &&
   config.FIRE_ENGINE_BETA_URL !== undefined;
 
 const gunzipAsync = promisify(gunzip);
-
-/**
- * Extracts raw XML from HTML-wrapped content that browsers generate when rendering XML files.
- * When browser engines (like Chrome) fetch XML files, they render them as HTML pages with
- * the XML content wrapped in a viewer div. This function detects and extracts the raw XML.
- *
- * @param content - The content that may be HTML-wrapped XML or raw XML
- * @returns The extracted raw XML or the original content if not HTML-wrapped
- */
-export function extractXmlFromHtmlWrapper(content: string): string {
-  // Only process if content looks like HTML-wrapped XML
-  if (
-    content.includes("webkit-xml-viewer-source-xml") ||
-    (content.startsWith("<!--?xml") && content.includes("<html"))
-  ) {
-    // Try to extract from WebKit XML viewer div
-    const webkitMatch = content.match(
-      /<div[^>]*id=["']webkit-xml-viewer-source-xml["'][^>]*>([\s\S]*?)<\/div>/i,
-    );
-    if (webkitMatch && webkitMatch[1]) {
-      const extracted = webkitMatch[1].trim();
-      if (
-        extracted.includes("<urlset") ||
-        extracted.includes("<sitemapindex")
-      ) {
-        return extracted;
-      }
-    }
-
-    // Fallback: extract urlset or sitemapindex directly via regex
-    const urlsetMatch = content.match(/<urlset[\s\S]*?<\/urlset>/i);
-    if (urlsetMatch) return urlsetMatch[0];
-
-    const sitemapIndexMatch = content.match(
-      /<sitemapindex[\s\S]*?<\/sitemapindex>/i,
-    );
-    if (sitemapIndexMatch) return sitemapIndexMatch[0];
-  }
-
-  // Return original content if not HTML-wrapped
-  return content;
-}
 
 export async function getLinksFromSitemap(
   {

--- a/apps/api/src/scraper/WebScraper/utils/xml-utils.ts
+++ b/apps/api/src/scraper/WebScraper/utils/xml-utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Extracts raw XML from HTML-wrapped content that browsers generate when rendering XML files.
+ * When browser engines (like Chrome) fetch XML files, they render them as HTML pages with
+ * the XML content wrapped in a viewer div. This function detects and extracts the raw XML.
+ *
+ * @param content - The content that may be HTML-wrapped XML or raw XML
+ * @returns The extracted raw XML or the original content if not HTML-wrapped
+ */
+export function extractXmlFromHtmlWrapper(content: string): string {
+  // Only process if content looks like HTML-wrapped XML
+  if (
+    content.includes("webkit-xml-viewer-source-xml") ||
+    (content.startsWith("<!--?xml") && content.includes("<html"))
+  ) {
+    // Try to extract from WebKit XML viewer div
+    const webkitMatch = content.match(
+      /<div[^>]*id=["']webkit-xml-viewer-source-xml["'][^>]*>([\s\S]*?)<\/div>/i,
+    );
+    if (webkitMatch && webkitMatch[1]) {
+      const extracted = webkitMatch[1].trim();
+      if (
+        extracted.includes("<urlset") ||
+        extracted.includes("<sitemapindex")
+      ) {
+        return extracted;
+      }
+    }
+
+    // Fallback: extract urlset or sitemapindex directly via regex
+    const urlsetMatch = content.match(/<urlset[\s\S]*?<\/urlset>/i);
+    if (urlsetMatch) return urlsetMatch[0];
+
+    const sitemapIndexMatch = content.match(
+      /<sitemapindex[\s\S]*?<\/sitemapindex>/i,
+    );
+    if (sitemapIndexMatch) return sitemapIndexMatch[0];
+  }
+
+  // Return original content if not HTML-wrapped
+  return content;
+}

--- a/apps/api/src/scraper/crawler/sitemap.ts
+++ b/apps/api/src/scraper/crawler/sitemap.ts
@@ -14,7 +14,7 @@ import { gunzip } from "node:zlib";
 import { promisify } from "node:util";
 import { SitemapError } from "../../lib/error";
 import { useIndex } from "../../services";
-import { extractXmlFromHtmlWrapper } from "../WebScraper/sitemap";
+import { extractXmlFromHtmlWrapper } from "../WebScraper/utils/xml-utils";
 
 const useFireEngine =
   config.FIRE_ENGINE_BETA_URL !== "" &&


### PR DESCRIPTION
### Problem

When the map endpoint fetches a `sitemap.xml` file using browser-based engines (fire-engine with Chrome), the XML gets rendered as an HTML page with the content wrapped in a viewer div:

```html
<html>
  <body>
    <div id="webkit-xml-viewer-source-xml">
      <urlset>...actual sitemap content...</urlset>
    </div>
  </body>
</html>
````

The XML parsers expect raw XML but instead receive this HTML-wrapped content, causing parsing to fail silently.
This results in `sitemap: "only"` returning **0 results intermittently**, depending on which engine fetches the content.

### Solution

Added an `extractXmlFromHtmlWrapper()` helper function that detects and extracts raw XML from browser-rendered HTML before parsing:

* Detects WebKit XML viewer wrapper (`webkit-xml-viewer-source-xml`)
* Detects browser-mangled XML declaration (`<!--?xml`)
* Falls back to regex extraction of `<urlset>` or `<sitemapindex>`
* Passes through raw XML unchanged

### Testing

* Added unit tests covering all extraction scenarios
* Verified the fix with real browser-rendered content from
  `prairie-dogs-e2e.zapier-staging.com/sitemap.xml`

### Files Changed

* `apps/api/src/scraper/WebScraper/sitemap.ts`

  * Added helper function and applied fix
* `apps/api/src/scraper/crawler/sitemap.ts`

  * Applied fix
* `apps/api/src/scraper/WebScraper/__tests__/sitemap.test.ts`

  * Added unit tests



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sitemap parsing when browser engines render XML as HTML. Extracts raw XML before parsing so sitemap-only runs return the correct links instead of zero results.

- **Bug Fixes**
  - Added extractXmlFromHtmlWrapper to strip WebKit XML viewer HTML and handle mangled XML declarations.
  - Fallback extraction of urlset or sitemapindex when wrapper detection fails; raw XML passes through unchanged.
  - Applied in WebScraper and crawler code paths; added unit tests covering all scenarios.

<sup>Written for commit c119a738070da9b92504011608f5f20ad6e0e08e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



