### PR TITLE
Throw error when v3-beta is passed into /extract

### DIFF
--- a/apps/api/src/controllers/v2/extract.ts
+++ b/apps/api/src/controllers/v2/extract.ts
@@ -49,7 +49,10 @@ export async function extractController(
   });
 
   if (req.body.agent?.model === "v3-beta") {
-    throw new Error("Use the new /agent endpoint instead of passing agent.model=v3-beta into /extract. ");
+    return res.status(400).json({
+      success: false,
+      error: "Use the new /agent endpoint instead of passing agent.model=v3-beta into /extract.",
+    });
   }
 
   const invalidURLs: string[] =


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
The /extract endpoint now throws an explicit error when agent.model=v3-beta is used, directing clients to use the /agent endpoint. Removed the legacy v3-beta passthrough logic from /extract.

- **Migration**
  - Move v3-beta requests to POST /agent.
  - Do not set agent.model on /extract; existing extract behavior is unchanged for non-beta models.

<sup>Written for commit 49bd21fcc5b4f28a988b5b4f7b8f967fa8b14632. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



