### PR TITLE
Handle Zod v4 schemas using toJSONSchema() fallback

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/agent.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/agent.ts
@@ -17,8 +17,14 @@ function prepareAgentPayload(args: {
   body.prompt = args.prompt;
   if (args.schema != null) {
     const s: any = args.schema;
-    const isZod = s && (typeof s.safeParse === "function" || typeof s.parse === "function") && s._def;
-    body.schema = isZod ? zodToJsonSchema(s) : args.schema;
+    const isZodV4 = typeof s.toJSONSchema === "function";
+
+    if (isZodV4) {
+      body.schema = s.toJSONSchema();
+    } else {
+      const isZod = s && (typeof s.safeParse === "function" || typeof s.parse === "function") && s._def;
+      body.schema = isZod ? zodToJsonSchema(s) : args.schema;
+    }
   }
   if (args.integration && args.integration.trim()) body.integration = args.integration.trim();
   if (args.maxCredits !== null && args.maxCredits !== undefined) body.maxCredits = args.maxCredits;

--- a/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
@@ -23,8 +23,14 @@ function prepareExtractPayload(args: {
   if (args.prompt != null) body.prompt = args.prompt;
   if (args.schema != null) {
     const s: any = args.schema;
-    const isZod = s && (typeof s.safeParse === "function" || typeof s.parse === "function") && s._def;
-    body.schema = isZod ? zodToJsonSchema(s) : args.schema;
+    const isZodV4 = typeof s.toJSONSchema === "function";
+
+    if (isZodV4) {
+      body.schema = s.toJSONSchema();
+    } else {
+      const isZod = s && (typeof s.safeParse === "function" || typeof s.parse === "function") && s._def;
+      body.schema = isZod ? zodToJsonSchema(s) : args.schema;
+    }
   }
   if (args.systemPrompt != null) body.systemPrompt = args.systemPrompt;
   if (args.allowExternalLinks != null) body.allowExternalLinks = args.allowExternalLinks;

--- a/apps/js-sdk/firecrawl/src/v2/utils/validation.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/validation.ts
@@ -17,12 +17,17 @@ export function ensureValidFormats(formats?: FormatOption[]): void {
       }
       // Flexibility: allow passing a Zod schema. Convert to JSON schema internally.
       const maybeSchema: any = j.schema as any;
-      const isZod = !!maybeSchema && (typeof maybeSchema.safeParse === "function" || typeof maybeSchema.parse === "function") && !!maybeSchema._def;
-      if (isZod) {
-        try {
-          (j as any).schema = zodToJsonSchema(maybeSchema);
-        } catch {
-          // If conversion fails, leave as-is; server-side may still handle, or request will fail explicitly
+      const isZodV4 = typeof maybeSchema.toJSONSchema === "function";
+      if (isZodV4) {
+        (j as any).schema = maybeSchema.toJSONSchema();
+      } else {
+        const isZod = !!maybeSchema && (typeof maybeSchema.safeParse === "function" || typeof maybeSchema.parse === "function") && !!maybeSchema._def;
+        if (isZod) {
+          try {
+            (j as any).schema = zodToJsonSchema(maybeSchema);
+          } catch {
+            // If conversion fails, leave as-is; server-side may still handle, or request will fail explicitly
+          }
         }
       }
       continue;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for Zod v4 schemas by using schema.toJSONSchema() when available, so agent/extract requests and format validation work reliably. Falls back to zodToJsonSchema for older Zod versions.

- **Bug Fixes**
  - Detect Zod v4 via schema.toJSONSchema and use it directly.
  - Preserve existing zodToJsonSchema conversion for Zod v3.
  - Applied in agent payloads, extract payloads, and ensureValidFormats.

<sup>Written for commit 0e028ffa1155f3d9b4e14cbf54ceef2a548bc6c7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

