### PR TITLE
Fixes #2583 add RabbitMQ health check and update API dependencies

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,9 +95,12 @@ services:
       NUQ_RABBITMQ_URL: amqp://rabbitmq:5672
       ENV: local
     depends_on:
-      - redis
-      - playwright-service
-      - rabbitmq
+      redis:
+        condition: service_started
+      playwright-service:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
     ports:
       - "${PORT:-3002}:${INTERNAL_PORT:-3002}"
     command: node dist/src/harness.js --start-docker
@@ -129,6 +132,12 @@ services:
     networks:
       - backend
     command: rabbitmq-server
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Fixes an issue with the API container on startup, due to its dependency on the RabbitMQ container.

https://github.com/firecrawl/firecrawl/issues/2583

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the API container wait for RabbitMQ to be healthy before starting. Prevents startup failures when RabbitMQ isn’t ready.

- **Bug Fixes**
  - Added a RabbitMQ health check using rabbitmq-diagnostics check_running.
  - Updated docker-compose depends_on: API waits for rabbitmq service_healthy; redis and playwright-service use service_started.

<sup>Written for commit 06c274b29138ae3fa972c842280008c18c13ac80. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

