### PR TITLE
fix: implement post-filtering for larger: image size operator

### DIFF
--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -349,14 +349,17 @@ export async function searchController(
     // so we post-filter results to ensure they meet the minimum size criteria
     if (searchResponse.images && searchResponse.images.length > 0) {
       const originalCount = searchResponse.images.length;
-      searchResponse.images = applyLargerOperatorFilter(
+      const filterResult = applyLargerOperatorFilter(
         req.body.query,
         searchResponse.images,
       );
-      if (searchResponse.images.length !== originalCount) {
+      searchResponse.images = filterResult.images;
+      if (filterResult.applied) {
         logger.info("Applied larger: image size filter", {
           originalCount,
-          filteredCount: searchResponse.images.length,
+          filteredCount: filterResult.images.length,
+          minWidth: filterResult.minWidth,
+          minHeight: filterResult.minHeight,
         });
       }
     }

--- a/apps/api/src/controllers/v2/x402-search.ts
+++ b/apps/api/src/controllers/v2/x402-search.ts
@@ -309,14 +309,17 @@ export async function x402SearchController(
     // so we post-filter results to ensure they meet the minimum size criteria
     if (searchResponse.images && searchResponse.images.length > 0) {
       const originalCount = searchResponse.images.length;
-      searchResponse.images = applyLargerOperatorFilter(
+      const filterResult = applyLargerOperatorFilter(
         req.body.query,
         searchResponse.images,
       );
-      if (searchResponse.images.length !== originalCount) {
+      searchResponse.images = filterResult.images;
+      if (filterResult.applied) {
         logger.info("Applied larger: image size filter [x402]", {
           originalCount,
-          filteredCount: searchResponse.images.length,
+          filteredCount: filterResult.images.length,
+          minWidth: filterResult.minWidth,
+          minHeight: filterResult.minHeight,
         });
       }
     }

--- a/apps/api/src/lib/search-query-builder.ts
+++ b/apps/api/src/lib/search-query-builder.ts
@@ -167,6 +167,16 @@ interface ImageResultWithDimensions {
 }
 
 /**
+ * Result of applying the larger: operator filter
+ */
+interface LargerOperatorFilterResult<T> {
+  images: T[];
+  applied: boolean;
+  minWidth?: number;
+  minHeight?: number;
+}
+
+/**
  * Applies the larger: operator filter to image search results.
  *
  * The larger: operator is a Google image search operator that should filter images
@@ -176,7 +186,7 @@ interface ImageResultWithDimensions {
  *
  * @param query The search query that may contain larger:WxH
  * @param images Array of image search results to filter
- * @returns Filtered array of images (unchanged if no larger: operator in query)
+ * @returns Object with filtered images and metadata about the filter applied
  *
  * @example
  * const images = [
@@ -185,30 +195,30 @@ interface ImageResultWithDimensions {
  *   { title: "Exact", imageWidth: 1920, imageHeight: 1080 }
  * ];
  * applyLargerOperatorFilter("wallpaper larger:1920x1080", images)
- * // Returns: [{ title: "Large", ... }, { title: "Exact", ... }]
+ * // Returns: { images: [...], applied: true, minWidth: 1920, minHeight: 1080 }
  *
  * applyLargerOperatorFilter("wallpaper", images)
- * // Returns: all 3 images unchanged (no larger: operator)
+ * // Returns: { images: [...], applied: false }
  */
 export function applyLargerOperatorFilter<T extends ImageResultWithDimensions>(
   query: string,
   images: T[],
-): T[] {
+): LargerOperatorFilterResult<T> {
   // Match larger:WIDTHxHEIGHT pattern (case-insensitive)
   const largerMatch = query.match(/larger:(\d+)x(\d+)/i);
 
   if (!largerMatch) {
-    return images;
+    return { images, applied: false };
   }
 
   const minWidth = parseInt(largerMatch[1], 10);
   const minHeight = parseInt(largerMatch[2], 10);
 
   if (isNaN(minWidth) || isNaN(minHeight) || minWidth <= 0 || minHeight <= 0) {
-    return images;
+    return { images, applied: false };
   }
 
-  return images.filter(image => {
+  const filtered = images.filter(image => {
     // If dimensions are missing, we can't verify size - exclude the image
     if (image.imageWidth === undefined || image.imageHeight === undefined) {
       return false;
@@ -217,4 +227,6 @@ export function applyLargerOperatorFilter<T extends ImageResultWithDimensions>(
     // Image must be at least as large as the minimum in BOTH dimensions
     return image.imageWidth >= minWidth && image.imageHeight >= minHeight;
   });
+
+  return { images: filtered, applied: true, minWidth, minHeight };
 }


### PR DESCRIPTION
## Problem

The `larger:` operator in image search queries (e.g., `larger:1920x1080`) was not being honored by the upstream search provider (Google via Fire Engine). While the operator was correctly passed through, the returned results often included images smaller than the specified minimum dimensions.

**Test results before fix:**
```
Query: 'mountain wallpaper larger:1920x1080'
Results:
- 3000x2000 ✅
- 736x414 ❌
- 1920x1080 ✅
- 500x333 ❌
- 1920x1080 ✅

Only 3/5 results met the criteria.
```

## Solution

Implemented post-filtering on the Firecrawl side to ensure that only images meeting the minimum size criteria are returned to users.

### Changes:
- Added `parseImageSizeFilter()` to extract min dimensions from `larger:WxH` queries
- Added `filterImagesBySize()` to filter image results by minimum dimensions  
- Integrated filtering into `v2/search.ts` and `v2/x402-search.ts` controllers
- Added logging for visibility into filtering behavior

## Expected behavior after fix

All returned images will have:
- `imageWidth >= minWidth` AND
- `imageHeight >= minHeight`

Images with missing dimensions are excluded. 





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the larger: image size operator works by post-filtering results so only images that meet the minimum dimensions are returned. Fixes cases where upstream providers returned smaller images.

- **Bug Fixes**
  - Added applyLargerOperatorFilter() to parse larger:WxH and filter images, excluding those without dimensions.
  - Applied filtering in v2/search.ts and v2/x402-search.ts with logging of original and filtered counts.

<sup>Written for commit 531e2cff14a702966da94efbd2b754ef777f1a76. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





