### PR TITLE
feat(api): extract background images

### DIFF
--- a/apps/api/native/src/html.rs
+++ b/apps/api/native/src/html.rs
@@ -871,11 +871,11 @@ fn _extract_images(
     }
   }
 
-  // <... style="background-image: url(...)">
-  if let Ok(elements) = document.select("[style*=\"background-image\"]") {
+  // <... style="background: url(...)"> or <... style="background-image: url(...)">
+  if let Ok(elements) = document.select("[style*=\"background\"]") {
     for element in elements {
       if let Some(style) = element.attributes.borrow().get("style") {
-        if let Some(cap) = URL_REGEX.captures(style) {
+        for cap in URL_REGEX.captures_iter(style) {
           if let Some(url_match) = cap.get(1) {
             let url = url_match.as_str().trim();
             if !url.is_empty() {


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for extracting background images from inline styles and returning them in the API’s images output. This addresses ENG-3871 by capturing CSS background and background-image URLs.

- **New Features**
  - Detect style attributes with background or background-image and extract all url(...) values using a regex.
  - Resolve and include valid URLs in the images set, skipping empty and javascript: URLs.

<sup>Written for commit 0162ecabd99715f4ef9c97740a65b6af3423de1b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





