### PR TITLE
Don't log EngineError to Sentry

### DIFF
--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -4,6 +4,7 @@ import { config } from "../config";
 import {
   AddFeatureError,
   RemoveFeatureError,
+  EngineError,
 } from "../scraper/scrapeURL/error";
 import { AbortManagerThrownError } from "../scraper/scrapeURL/lib/abortManager";
 
@@ -61,7 +62,8 @@ if (config.SENTRY_DSN) {
         if (
           error instanceof AddFeatureError ||
           error instanceof RemoveFeatureError ||
-          error instanceof AbortManagerThrownError
+          error instanceof AbortManagerThrownError ||
+          error instanceof EngineError
         ) {
           return null;
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop logging EngineError to Sentry. This reduces noise from expected engine failures and aligns with existing filters for known scrape errors.

<sup>Written for commit a56b480a58028c47ed98440d2dc6d8f450ec7ec3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

