### PR TITLE
feat: provide way to omit data in GET batch scrape/crawl status

### DIFF
--- a/apps/api/src/__tests__/snips/v1/batch-scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v1/batch-scrape.test.ts
@@ -5,7 +5,15 @@ import {
   TEST_PRODUCTION,
   TEST_SUITE_WEBSITE,
 } from "../lib";
-import { batchScrape, scrapeTimeout, idmux, Identity } from "./lib";
+import {
+  batchScrape,
+  batchScrapeStart,
+  batchScrapeStatusWithParams,
+  expectBatchScrapeStartToSucceed,
+  scrapeTimeout,
+  idmux,
+  Identity,
+} from "./lib";
 
 let identity: Identity;
 
@@ -46,6 +54,33 @@ describe("Batch scrape tests", () => {
       );
 
       expect(response.data[0].metadata.sourceURL).toBe(url);
+    },
+    scrapeTimeout,
+  );
+
+  concurrentIf(ALLOW_TEST_SUITE_WEBSITE)(
+    "skip_data query parameter omits data field",
+    async () => {
+      // Start a batch scrape
+      const bss = await batchScrapeStart(
+        { urls: [TEST_SUITE_WEBSITE] },
+        identity,
+      );
+      expectBatchScrapeStartToSucceed(bss);
+
+      // Check status with skip_data=true
+      const response = await batchScrapeStatusWithParams(
+        bss.body.id,
+        identity,
+        { skip_data: "true" },
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body).not.toHaveProperty("data");
+      expect(response.body).toHaveProperty("status");
+      expect(response.body).toHaveProperty("completed");
+      expect(response.body).toHaveProperty("total");
     },
     scrapeTimeout,
   );

--- a/apps/api/src/__tests__/snips/v1/lib.ts
+++ b/apps/api/src/__tests__/snips/v1/lib.ts
@@ -220,7 +220,11 @@ async function crawlErrors(
 export async function crawl(
   body: CrawlRequestInput,
   identity: Identity,
-): Promise<Exclude<CrawlStatusResponse & { id: string }, ErrorResponse>> {
+): Promise<
+  Exclude<CrawlStatusResponse & { id: string }, ErrorResponse> & {
+    data: Document[];
+  }
+> {
   const cs = await crawlStart(body, identity);
   expectCrawlStartToSucceed(cs);
 
@@ -249,7 +253,7 @@ export async function crawl(
 // Batch Scrape API
 // =========================================
 
-async function batchScrapeStart(
+export async function batchScrapeStart(
   body: BatchScrapeRequestInput,
   identity: Identity,
 ) {
@@ -267,7 +271,23 @@ async function batchScrapeStatus(id: string, identity: Identity) {
     .send();
 }
 
-function expectBatchScrapeStartToSucceed(
+export async function batchScrapeStatusWithParams(
+  id: string,
+  identity: Identity,
+  queryParams?: Record<string, string>,
+) {
+  let req = request(TEST_API_URL)
+    .get("/v1/batch/scrape/" + encodeURIComponent(id))
+    .set("Authorization", `Bearer ${identity.apiKey}`);
+
+  if (queryParams) {
+    req = req.query(queryParams);
+  }
+
+  return await req.send();
+}
+
+export function expectBatchScrapeStartToSucceed(
   response: Awaited<ReturnType<typeof batchScrapeStart>>,
 ) {
   if (response.statusCode !== 200) {
@@ -306,7 +326,9 @@ function expectBatchScrapeToSucceed(
 export async function batchScrape(
   body: BatchScrapeRequestInput,
   identity: Identity,
-): Promise<Exclude<CrawlStatusResponse, ErrorResponse> & { id: string }> {
+): Promise<
+  Exclude<CrawlStatusResponse, ErrorResponse> & { id: string; data: Document[] }
+> {
   const bss = await batchScrapeStart(body, identity);
   expectBatchScrapeStartToSucceed(bss);
 

--- a/apps/api/src/__tests__/snips/v2/lib.ts
+++ b/apps/api/src/__tests__/snips/v2/lib.ts
@@ -222,7 +222,11 @@ export async function crawl(
   body: CrawlRequestInput,
   identity: Identity,
   shouldSucceed: boolean = true,
-): Promise<Exclude<CrawlStatusResponse & { id: string }, ErrorResponse>> {
+): Promise<
+  Exclude<CrawlStatusResponse & { id: string }, ErrorResponse> & {
+    data: Document[];
+  }
+> {
   const cs = await crawlStart(body, identity);
   expectCrawlStartToSucceed(cs);
 
@@ -311,7 +315,9 @@ function expectBatchScrapeToSucceed(
 export async function batchScrape(
   body: BatchScrapeRequestInput,
   identity: Identity,
-): Promise<Exclude<CrawlStatusResponse, ErrorResponse> & { id: string }> {
+): Promise<
+  Exclude<CrawlStatusResponse, ErrorResponse> & { id: string; data: Document[] }
+> {
   const bss = await batchScrapeStart(body, identity);
   expectBatchScrapeStartToSucceed(bss);
 

--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -174,6 +174,7 @@ export async function crawlStatusController(
     typeof req.query.limit === "string"
       ? start + parseInt(req.query.limit, 10) - 1
       : undefined;
+  const skipData = req.query.skip_data === "true";
 
   const group = await crawlGroup.getGroup(req.params.jobId);
   const groupAnyJob = await scrapeQueue.getGroupAnyJob(
@@ -222,61 +223,71 @@ export async function crawlStatusController(
   };
 
   let outputBulkB: {
-    data: Document[];
+    data?: Document[];
     next: string | undefined;
   };
 
-  const doneJobs = await scrapeQueue.getCrawlJobsForListing(
-    req.params.jobId,
-    end !== undefined ? end - start + 1 : 100,
-    start,
-    logger.child({ zeroDataRetention }),
-  );
+  if (skipData) {
+    // Skip data fetching entirely when skip_data=true
+    outputBulkB = {
+      next:
+        outputBulkA.status !== "completed"
+          ? `${req.protocol}://${req.get("host")}/v1/${isBatch ? "batch/scrape" : "crawl"}/${req.params.jobId}${req.query.limit ? `?limit=${req.query.limit}` : ""}`
+          : undefined,
+    };
+  } else {
+    const doneJobs = await scrapeQueue.getCrawlJobsForListing(
+      req.params.jobId,
+      end !== undefined ? end - start + 1 : 100,
+      start,
+      logger.child({ zeroDataRetention }),
+    );
 
-  let scrapes: Document[] = [];
-  let iteratedOver = 0;
-  let bytes = 0;
-  const bytesLimit = 10485760; // 10 MiB in bytes
+    let scrapes: Document[] = [];
+    let iteratedOver = 0;
+    let bytes = 0;
+    const bytesLimit = 10485760; // 10 MiB in bytes
 
-  const scrapeBlobs = await Promise.all(
-    doneJobs.map(
-      async x =>
-        [x.id, x.returnvalue ?? (await getJobFromGCS(x.id))?.[0]] as const,
-    ),
-  );
+    const scrapeBlobs = await Promise.all(
+      doneJobs.map(
+        async x =>
+          [x.id, x.returnvalue ?? (await getJobFromGCS(x.id))?.[0]] as const,
+      ),
+    );
 
-  for (const [id, scrape] of scrapeBlobs) {
-    if (scrape) {
-      scrapes.push(scrape);
-      bytes += JSON.stringify(scrape).length;
-    } else {
-      logger.warn("Job was considered done, but returnvalue is undefined!", {
-        jobId: id,
-        returnvalue: scrape,
-        zeroDataRetention,
-      });
+    for (const [id, scrape] of scrapeBlobs) {
+      if (scrape) {
+        scrapes.push(scrape);
+        bytes += JSON.stringify(scrape).length;
+      } else {
+        logger.warn("Job was considered done, but returnvalue is undefined!", {
+          jobId: id,
+          returnvalue: scrape,
+          zeroDataRetention,
+        });
+      }
+
+      iteratedOver++;
+
+      if (bytes > bytesLimit) {
+        break;
+      }
     }
 
-    iteratedOver++;
-
-    if (bytes > bytesLimit) {
-      break;
+    if (bytes > bytesLimit && scrapes.length !== 1) {
+      scrapes.splice(scrapes.length - 1, 1);
+      iteratedOver--;
     }
-  }
 
-  if (bytes > bytesLimit && scrapes.length !== 1) {
-    scrapes.splice(scrapes.length - 1, 1);
-    iteratedOver--;
+    outputBulkB = {
+      data: scrapes,
+      next:
+        (outputBulkA.total ?? 0) > start + iteratedOver ||
+        outputBulkA.status !== "completed"
+          ? `${req.protocol}://${req.get("host")}/v1/${isBatch ? "batch/scrape" : "crawl"}/${req.params.jobId}?skip=${start + iteratedOver}${req.query.limit ? `&limit=${req.query.limit}` : ""}`
+          : undefined,
+    };
   }
-
-  outputBulkB = {
-    data: scrapes,
-    next:
-      (outputBulkA.total ?? 0) > start + iteratedOver ||
-      outputBulkA.status !== "completed"
-        ? `${req.protocol}://${req.get("host")}/v1/${isBatch ? "batch/scrape" : "crawl"}/${req.params.jobId}?skip=${start + iteratedOver}${req.query.limit ? `&limit=${req.query.limit}` : ""}`
-        : undefined,
-  };
 
   return res.status(200).json({
     success: true,
@@ -286,6 +297,6 @@ export async function crawlStatusController(
     creditsUsed: outputBulkA.creditsUsed ?? 0,
     expiresAt: (await getCrawlExpiry(req.params.jobId)).toISOString(),
     next: outputBulkB.next,
-    data: outputBulkB.data,
+    ...(skipData ? {} : { data: outputBulkB.data ?? [] }),
   });
 }

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1168,7 +1168,7 @@ export type CrawlStatusResponse =
       creditsUsed: number;
       expiresAt: string;
       next?: string;
-      data: Document[];
+      data?: Document[];
     };
 
 export type OngoingCrawlsResponse =

--- a/apps/api/src/controllers/v2/crawl-status.ts
+++ b/apps/api/src/controllers/v2/crawl-status.ts
@@ -194,6 +194,7 @@ export async function crawlStatusController(
     typeof req.query.limit === "string"
       ? start + parseInt(req.query.limit, 10) - 1
       : undefined;
+  const skipData = req.query.skip_data === "true";
 
   const group = await crawlGroup.getGroup(req.params.jobId);
   const groupAnyJob = await scrapeQueue.getGroupAnyJob(
@@ -242,61 +243,71 @@ export async function crawlStatusController(
   };
 
   let outputBulkB: {
-    data: Document[];
+    data?: Document[];
     next: string | undefined;
   };
 
-  const doneJobs = await scrapeQueue.getCrawlJobsForListing(
-    req.params.jobId,
-    end !== undefined ? end - start + 1 : 100,
-    start,
-    logger.child({ zeroDataRetention }),
-  );
+  if (skipData) {
+    // Skip data fetching entirely when skip_data=true
+    outputBulkB = {
+      next:
+        outputBulkA.status !== "completed"
+          ? `${req.protocol}://${req.get("host")}/v1/${isBatch ? "batch/scrape" : "crawl"}/${req.params.jobId}${req.query.limit ? `?limit=${req.query.limit}` : ""}`
+          : undefined,
+    };
+  } else {
+    const doneJobs = await scrapeQueue.getCrawlJobsForListing(
+      req.params.jobId,
+      end !== undefined ? end - start + 1 : 100,
+      start,
+      logger.child({ zeroDataRetention }),
+    );
 
-  let scrapes: Document[] = [];
-  let iteratedOver = 0;
-  let bytes = 0;
-  const bytesLimit = 10485760; // 10 MiB in bytes
+    let scrapes: Document[] = [];
+    let iteratedOver = 0;
+    let bytes = 0;
+    const bytesLimit = 10485760; // 10 MiB in bytes
 
-  const scrapeBlobs = await Promise.all(
-    doneJobs.map(
-      async x =>
-        [x.id, x.returnvalue ?? (await getJobFromGCS(x.id))?.[0]] as const,
-    ),
-  );
+    const scrapeBlobs = await Promise.all(
+      doneJobs.map(
+        async x =>
+          [x.id, x.returnvalue ?? (await getJobFromGCS(x.id))?.[0]] as const,
+      ),
+    );
 
-  for (const [id, scrape] of scrapeBlobs) {
-    if (scrape) {
-      scrapes.push(scrape);
-      bytes += JSON.stringify(scrape).length;
-    } else {
-      logger.warn("Job was considered done, but returnvalue is undefined!", {
-        jobId: id,
-        returnvalue: scrape,
-        zeroDataRetention,
-      });
+    for (const [id, scrape] of scrapeBlobs) {
+      if (scrape) {
+        scrapes.push(scrape);
+        bytes += JSON.stringify(scrape).length;
+      } else {
+        logger.warn("Job was considered done, but returnvalue is undefined!", {
+          jobId: id,
+          returnvalue: scrape,
+          zeroDataRetention,
+        });
+      }
+
+      iteratedOver++;
+
+      if (bytes > bytesLimit) {
+        break;
+      }
     }
 
-    iteratedOver++;
-
-    if (bytes > bytesLimit) {
-      break;
+    if (bytes > bytesLimit && scrapes.length !== 1) {
+      scrapes.splice(scrapes.length - 1, 1);
+      iteratedOver--;
     }
-  }
 
-  if (bytes > bytesLimit && scrapes.length !== 1) {
-    scrapes.splice(scrapes.length - 1, 1);
-    iteratedOver--;
+    outputBulkB = {
+      data: scrapes,
+      next:
+        (outputBulkA.total ?? 0) > start + iteratedOver ||
+        outputBulkA.status !== "completed"
+          ? `${req.protocol}://${req.get("host")}/v1/${isBatch ? "batch/scrape" : "crawl"}/${req.params.jobId}?skip=${start + iteratedOver}${req.query.limit ? `&limit=${req.query.limit}` : ""}`
+          : undefined,
+    };
   }
-
-  outputBulkB = {
-    data: scrapes,
-    next:
-      (outputBulkA.total ?? 0) > start + iteratedOver ||
-      outputBulkA.status !== "completed"
-        ? `${req.protocol}://${req.get("host")}/v1/${isBatch ? "batch/scrape" : "crawl"}/${req.params.jobId}?skip=${start + iteratedOver}${req.query.limit ? `&limit=${req.query.limit}` : ""}`
-        : undefined,
-  };
 
   // Check for robots.txt blocked URLs and add warning if found
   let warning: string | undefined;
@@ -321,7 +332,7 @@ export async function crawlStatusController(
 
   // Check if we should warn about base domain for crawl results
   const resultCount =
-    outputBulkA.completed ?? outputBulkA.total ?? outputBulkB.data.length;
+    outputBulkA.completed ?? outputBulkA.total ?? outputBulkB.data?.length ?? 0;
   const currentStatus = outputBulkA.status ?? "scraping";
   if (!warning && currentStatus !== "scraping" && resultCount <= 1) {
     // Get the original crawl URL and options from stored crawl data
@@ -347,7 +358,7 @@ export async function crawlStatusController(
     creditsUsed: outputBulkA.creditsUsed ?? 0,
     expiresAt: (await getCrawlExpiry(req.params.jobId)).toISOString(),
     next: outputBulkB.next,
-    data: outputBulkB.data,
+    ...(skipData ? {} : { data: outputBulkB.data ?? [] }),
     ...(warning && { warning }),
   });
 }

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1188,7 +1188,7 @@ export type CrawlStatusResponse =
       creditsUsed: number;
       expiresAt: string;
       next?: string;
-      data: Document[];
+      data?: Document[];
       warning?: string;
     };
 


### PR DESCRIPTION
## Motivation

When polling batch scrape/crawl status, the API returns the full data array even when status is not "completed".
This causes unnecessary bandwidth overhead for clients that only need status information until the job completes.

## Modification
Add optional `skip_data` query parameter to status endpoints:
  - GET /v1/batch/scrape/:jobId
  - GET /v1/crawl/:jobId
  - GET /v2/batch/scrape/:jobId
  - GET /v2/crawl/:jobId

When `skip_data=true`, skip data fetching entirely and omit data field from response. This avoids expensive GCS lookups and reduces response payload size for status polling use cases.

## Result
Resolves https://github.com/firecrawl/firecrawl/issues/2599

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a skip_data query parameter to GET crawl and batch scrape status endpoints to omit the data array during polling. This reduces payload size and avoids unnecessary GCS lookups until jobs complete.

- **New Features**
  - Supports skip_data=true on GET /v1/batch/scrape/:jobId, /v1/crawl/:jobId, /v2/batch/scrape/:jobId, and /v2/crawl/:jobId.
  - When set, the response omits data and still returns status, completed, total, next, creditsUsed, and expiresAt; types updated so data is optional.
  - Added tests to verify data omission behavior for batch scrape status.

<sup>Written for commit 8e66a2b64e7a03acec629a3d22d6e78f19aae6a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

