### PR TITLE
feat(api): include jobId in search response metadata

### DIFF
--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -256,6 +256,7 @@ export async function searchController(
   let responseData: SearchResponse = {
     success: true,
     data: [],
+    id: jobId,
   };
   const middlewareTime = controllerStartTime - middlewareStartTime;
   const isSearchPreview =

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1528,6 +1528,7 @@ export type SearchResponse =
       success: true;
       warning?: string;
       data: Document[];
+      id: string;
     };
 
 export type TokenUsage = {

--- a/apps/api/src/controllers/v1/x402-search.ts
+++ b/apps/api/src/controllers/v1/x402-search.ts
@@ -199,6 +199,7 @@ export async function x402SearchController(
   let responseData: SearchResponse = {
     success: true,
     data: [],
+    id: jobId,
   };
   const startTime = new Date().getTime();
   const isSearchPreview =

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -608,6 +608,7 @@ export async function searchController(
           data: searchResponse,
           scrapeIds,
           creditsUsed: credits_billed,
+          id: jobId,
         });
       } else {
         // Sync mode: process scraped documents
@@ -733,6 +734,7 @@ export async function searchController(
       success: true,
       data: searchResponse,
       creditsUsed: credits_billed,
+      id: jobId,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1732,12 +1732,14 @@ export type SearchResponse =
       warning?: string;
       data: Document[];
       creditsUsed: number;
+      id: string;
     }
   | {
       success: true;
       warning?: string;
       data: import("../../lib/entities").SearchV2Response;
       creditsUsed: number;
+      id: string;
     }
   | {
       success: true;
@@ -1749,6 +1751,7 @@ export type SearchResponse =
         images?: string[];
       };
       creditsUsed: number;
+      id: string;
     };
 
 export type TokenUsage = {

--- a/apps/api/src/controllers/v2/x402-search.ts
+++ b/apps/api/src/controllers/v2/x402-search.ts
@@ -540,6 +540,7 @@ export async function x402SearchController(
           data: searchResponse,
           scrapeIds,
           creditsUsed: credits_billed,
+          id: jobId,
         });
       } else {
         // Sync mode: process scraped documents
@@ -624,6 +625,7 @@ export async function x402SearchController(
       success: true,
       data: searchResponse,
       creditsUsed: credits_billed,
+      id: jobId,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add jobId to all successful search responses as id to help clients trace and correlate requests. Addresses ENG-4108 by returning the job ID in the search response metadata.

- **New Features**
  - v1 and v2 search (including x402, sync and async) now return id: jobId in successful responses.
  - Updated response types to include id on all success variants.

<sup>Written for commit 61a975e29331f086f33c01fe185edb0dfb9f65c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

