### PR TITLE
Add Request ID to Markdown Service Logger

### DIFF
--- a/apps/api/src/lib/html-to-markdown-client.ts
+++ b/apps/api/src/lib/html-to-markdown-client.ts
@@ -52,14 +52,21 @@ export async function convertHTMLToMarkdownWithHttpService(
   try {
     const request: ConvertRequest = { html };
 
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    // Add request ID header if available
+    if (requestId) {
+      headers["X-Request-ID"] = requestId;
+    }
+
     const response = await axios.post<ConvertResponse>(
       `${url}/convert`,
       request,
       {
         timeout: 60_000,
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers,
       },
     );
 
@@ -73,6 +80,7 @@ export async function convertHTMLToMarkdownWithHttpService(
       duration_ms: duration,
       input_size: html.length,
       output_size: response.data.markdown.length,
+      ...(requestId ? { request_id: requestId } : {}),
     });
 
     return response.data.markdown;

--- a/apps/go-html-to-md-service/handler.go
+++ b/apps/go-html-to-md-service/handler.go
@@ -100,26 +100,34 @@ type ErrorResponse struct {
 func (h *Handler) ConvertHTML(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
 
+	// Extract request ID from header for logging
+	requestID := r.Header.Get("X-Request-ID")
+	logger := log.Logger
+	if requestID != "" {
+		logger = log.With().Str("request_id", requestID).Logger()
+	}
+
 	// Limit request body size
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 
 	// Read and decode request body
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to read request body")
+		logger.Error().Err(err).Msg("Failed to read request body")
 		h.sendError(w, "Failed to read request body", err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	var req ConvertRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		log.Error().Err(err).Msg("Failed to parse request body")
+		logger.Error().Err(err).Msg("Failed to parse request body")
 		h.sendError(w, "Invalid JSON in request body", err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	// Validate input
 	if req.HTML == "" {
+		logger.Warn().Msg("Empty HTML field in request")
 		h.sendError(w, "HTML field is required", "The 'html' field cannot be empty", http.StatusBadRequest)
 		return
 	}
@@ -127,14 +135,14 @@ func (h *Handler) ConvertHTML(w http.ResponseWriter, r *http.Request) {
 	// Convert HTML to Markdown
 	markdown, err := h.converter.ConvertHTMLToMarkdown(req.HTML)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to convert HTML to Markdown")
+		logger.Error().Err(err).Msg("Failed to convert HTML to Markdown")
 		h.sendError(w, "Failed to convert HTML to Markdown", err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// Log metrics
 	duration := time.Since(startTime)
-	log.Info().
+	logger.Info().
 		Dur("duration_ms", duration).
 		Int("input_size", len(req.HTML)).
 		Int("output_size", len(markdown)).


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add request ID propagation to the HTML-to-Markdown pipeline for better request tracing and debugging. The API client sends X-Request-ID when available, and the Go service attaches request_id to structured logs and warns on empty HTML.

<sup>Written for commit 25545787aeea4a55d23be9341be5cd94618c035a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

