### PR TITLE
fix: Use NUQ_DATABASE_URL to detect docker-compose in setupNuqRabbitMQ

### DIFF
--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -614,8 +614,9 @@ async function setupNuqRabbitMQ(): Promise<Services["nuqRabbitMQ"]> {
     return undefined;
   }
 
-  // Check if we're running in docker-compose (POSTGRES_HOST is set and not localhost)
-  const isDockerCompose = POSTGRES_HOST !== "localhost";
+  // Check if we're running in docker-compose (NUQ_DATABASE_URL is set, which indicates docker-compose)
+  // This is more reliable than checking POSTGRES_HOST, which defaults to "localhost"
+  const isDockerCompose = !!config.NUQ_DATABASE_URL;
 
   if (isDockerCompose) {
     // Running in docker-compose: RabbitMQ should be configured externally


### PR DESCRIPTION
## Problem

The `setupNuqRabbitMQ()` function incorrectly detects docker-compose mode by checking if `POSTGRES_HOST !== "localhost"`. However, `POSTGRES_HOST` defaults to `"localhost"` in the config schema (see `apps/api/src/config.ts`), so when running in docker-compose where `POSTGRES_HOST` is not explicitly set, it defaults to `"localhost"`, causing `isDockerCompose` to evaluate to `false`.

This causes the code to attempt creating a RabbitMQ container inside the Firecrawl container, which fails because Docker/Podman is not available inside the container.

## Root Cause

The bug was introduced in commit 1c64e68 ("Increase Markdown Service Body Limit #2629") when `harness.ts` was first created. The `setupNuqRabbitMQ()` function was written with the same pattern as `setupNuqPostgres()`, but unlike PostgreSQL (which can work with the `POSTGRES_HOST` check because it sets `NUQ_DATABASE_URL` when detected), RabbitMQ detection happens BEFORE `NUQ_DATABASE_URL` is set, making the check unreliable.

## Solution

Change the detection logic to check if `NUQ_DATABASE_URL` is set instead, which is a more reliable indicator of docker-compose mode since:
1. `NUQ_DATABASE_URL` is explicitly set in docker-compose configurations
2. It matches the pattern used in `setupNuqPostgres()`, which first checks if `NUQ_DATABASE_URL` is set before attempting container management
3. It doesn't rely on `POSTGRES_HOST`, which has a default value that can cause false negatives

## Testing

Tested with docker-compose deployment:
- ✅ Correctly detects docker-compose mode when `NUQ_DATABASE_URL` is set
- ✅ Skips RabbitMQ container management in docker-compose
- ✅ Falls back to local container management when `NUQ_DATABASE_URL` is not set

## Related

This fix mirrors the logic in `setupNuqPostgres()` which correctly checks `NUQ_DATABASE_URL` first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix docker-compose detection in setupNuqRabbitMQ by using NUQ_DATABASE_URL instead of POSTGRES_HOST. This prevents attempts to create a RabbitMQ container inside the API container when running under docker-compose.

- **Bug Fixes**
  - Detect docker-compose via NUQ_DATABASE_URL and skip RabbitMQ container management when set.
  - Align detection logic with setupNuqPostgres for consistency.

<sup>Written for commit e5f63e07d2e2d35fdb7422f1f767bf97740d75fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

