### PR TITLE
Update firecrawl/html-to-markdown

### DIFF
--- a/apps/api/sharedLibs/go-html-to-md/go.mod
+++ b/apps/api/sharedLibs/go-html-to-md/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3
-	github.com/firecrawl/html-to-markdown v0.0.0-20251230195842-d4db4da35d6b
+	github.com/firecrawl/html-to-markdown v0.0.0-20260103214238-c035ce0e6258
 	golang.org/x/net v0.41.0
 )
 
@@ -17,4 +17,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/JohannesKaufmann/html-to-markdown => github.com/firecrawl/html-to-markdown v0.0.0-20251230195842-d4db4da35d6b
+replace github.com/JohannesKaufmann/html-to-markdown => github.com/firecrawl/html-to-markdown v0.0.0-20260103214238-c035ce0e6258

--- a/apps/api/sharedLibs/go-html-to-md/go.sum
+++ b/apps/api/sharedLibs/go-html-to-md/go.sum
@@ -3,8 +3,8 @@ github.com/PuerkitoBio/goquery v1.10.3/go.mod h1:tMUX0zDMHXYlAQk6p35XxQMqMweEKB7
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/firecrawl/html-to-markdown v0.0.0-20251230195842-d4db4da35d6b h1:SitKYwFT7vUXqzatv258cf02yD5HFlH5P+bjM7ZVkTo=
-github.com/firecrawl/html-to-markdown v0.0.0-20251230195842-d4db4da35d6b/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
+github.com/firecrawl/html-to-markdown v0.0.0-20260103214238-c035ce0e6258 h1:kBxOHtR16DUg2FQHDcZy+c1HsOJlKxtNlCTyNGghuio=
+github.com/firecrawl/html-to-markdown v0.0.0-20260103214238-c035ce0e6258/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/apps/go-html-to-md-service/go.mod
+++ b/apps/go-html-to-md-service/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3
-	github.com/firecrawl/html-to-markdown v0.0.0-20251230195842-d4db4da35d6b
+	github.com/firecrawl/html-to-markdown v0.0.0-20260103214238-c035ce0e6258
 	github.com/gorilla/mux v1.8.1
 	github.com/rs/zerolog v1.33.0
 	golang.org/x/net v0.41.0
@@ -20,4 +20,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/JohannesKaufmann/html-to-markdown => github.com/firecrawl/html-to-markdown v0.0.0-20251230195842-d4db4da35d6b
+replace github.com/JohannesKaufmann/html-to-markdown => github.com/firecrawl/html-to-markdown v0.0.0-20260103214238-c035ce0e6258

--- a/apps/go-html-to-md-service/go.sum
+++ b/apps/go-html-to-md-service/go.sum
@@ -4,8 +4,8 @@ github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kk
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/firecrawl/html-to-markdown v0.0.0-20251230195842-d4db4da35d6b h1:SitKYwFT7vUXqzatv258cf02yD5HFlH5P+bjM7ZVkTo=
-github.com/firecrawl/html-to-markdown v0.0.0-20251230195842-d4db4da35d6b/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
+github.com/firecrawl/html-to-markdown v0.0.0-20260103214238-c035ce0e6258 h1:kBxOHtR16DUg2FQHDcZy+c1HsOJlKxtNlCTyNGghuio=
+github.com/firecrawl/html-to-markdown v0.0.0-20260103214238-c035ce0e6258/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped firecrawl/html-to-markdown to the latest version across the shared library and service to pull in upstream fixes and keep the replace directive in sync.

- **Dependencies**
  - Updated html-to-markdown in apps/api/sharedLibs/go-html-to-md and apps/go-html-to-md-service (go.mod/go.sum), including the replace mapping for JohannesKaufmann/html-to-markdown.

<sup>Written for commit 7a1f93720e5774fd782a485f69c0bc2fa11d83cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

