### PR TITLE
Revert "fix: add Number() coercion to prevent string concatenation in credit calculations"

### DIFF
--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -176,11 +176,9 @@ export function authMiddleware(
       req.acuc = chunk ?? undefined;
       if (chunk) {
         req.account = {
-          // Use Number() to prevent string concatenation bugs
-          // (Postgres numeric columns may be returned as strings by Supabase)
           remainingCredits: chunk.price_should_be_graceful
-            ? Number(chunk.remaining_credits) + Number(chunk.price_credits)
-            : Number(chunk.remaining_credits),
+            ? chunk.remaining_credits + chunk.price_credits
+            : chunk.remaining_credits,
         };
       }
       next();

--- a/apps/api/src/services/billing/auto_charge.ts
+++ b/apps/api/src/services/billing/auto_charge.ts
@@ -354,17 +354,14 @@ async function _autoChargeScale(
             return {
               success: true,
               message: "Auto-recharge successful",
-              // Use Number() to prevent string concatenation bugs
               remainingCredits:
-                Number(
-                  updatedChunk?.remaining_credits ?? chunk.remaining_credits,
-                ) + Number(price.credits),
+                (updatedChunk?.remaining_credits ?? chunk.remaining_credits) +
+                price.credits,
               chunk: {
                 ...(updatedChunk ?? chunk),
                 remaining_credits:
-                  Number(
-                    updatedChunk?.remaining_credits ?? chunk.remaining_credits,
-                  ) + Number(price.credits),
+                  (updatedChunk?.remaining_credits ?? chunk.remaining_credits) +
+                  price.credits,
               },
             };
           }
@@ -614,13 +611,12 @@ async function _autoChargeSelfServe(
                 return {
                   success: true,
                   message: "Auto-recharge successful",
-                  // Use Number() to prevent string concatenation bugs
                   remainingCredits:
-                    Number(chunk.remaining_credits) + AUTO_RECHARGE_CREDITS,
+                    chunk.remaining_credits + AUTO_RECHARGE_CREDITS,
                   chunk: {
                     ...chunk,
                     remaining_credits:
-                      Number(chunk.remaining_credits) + AUTO_RECHARGE_CREDITS,
+                      chunk.remaining_credits + AUTO_RECHARGE_CREDITS,
                   },
                 };
               } else {

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -329,11 +329,9 @@ async function supaBillTeam(
         acuc
           ? {
               ...acuc,
-              // Use Number() to prevent string concatenation bugs
-              credits_used: Number(acuc.credits_used) + credits,
-              adjusted_credits_used:
-                Number(acuc.adjusted_credits_used) + credits,
-              remaining_credits: Number(acuc.remaining_credits) - credits,
+              credits_used: acuc.credits_used + credits,
+              adjusted_credits_used: acuc.adjusted_credits_used + credits,
+              remaining_credits: acuc.remaining_credits - credits,
             }
           : null,
       );
@@ -341,11 +339,9 @@ async function supaBillTeam(
         acuc
           ? {
               ...acuc,
-              // Use Number() to prevent string concatenation bugs
-              credits_used: Number(acuc.credits_used) + credits,
-              adjusted_credits_used:
-                Number(acuc.adjusted_credits_used) + credits,
-              remaining_credits: Number(acuc.remaining_credits) - credits,
+              credits_used: acuc.credits_used + credits,
+              adjusted_credits_used: acuc.adjusted_credits_used + credits,
+              remaining_credits: acuc.remaining_credits - credits,
             }
           : null,
       );

--- a/apps/api/src/services/billing/credit_billing.ts
+++ b/apps/api/src/services/billing/credit_billing.ts
@@ -88,26 +88,20 @@ async function supaCheckTeamCredits(
     };
   }
 
-  // Ensure numeric types to prevent string concatenation bugs
-  // (Postgres numeric columns may be returned as strings by Supabase)
-  const adjustedCreditsUsed = Number(chunk.adjusted_credits_used);
-  const totalCreditsSum = Number(chunk.total_credits_sum ?? 100000000);
-  const priceCredits = Number(chunk.price_credits);
-  const chunkRemainingCredits = Number(chunk.remaining_credits);
-
   const remainingCredits = chunk.price_should_be_graceful
-    ? chunkRemainingCredits + priceCredits
-    : chunkRemainingCredits;
+    ? chunk.remaining_credits + chunk.price_credits
+    : chunk.remaining_credits;
 
-  const creditsWillBeUsed = adjustedCreditsUsed + credits;
+  const creditsWillBeUsed = chunk.adjusted_credits_used + credits;
 
   // In case chunk.price_credits is undefined, set it to a large number to avoid mistakes
   const totalPriceCredits = chunk.price_should_be_graceful
-    ? totalCreditsSum + priceCredits
-    : totalCreditsSum;
+    ? (chunk.total_credits_sum ?? 100000000) + chunk.price_credits
+    : (chunk.total_credits_sum ?? 100000000);
 
   // Removal of + credits
-  const creditUsagePercentage = adjustedCreditsUsed / totalCreditsSum;
+  const creditUsagePercentage =
+    chunk.adjusted_credits_used / (chunk.total_credits_sum ?? 100000000);
 
   let isAutoRechargeEnabled = false,
     autoRechargeThreshold = 1000;


### PR DESCRIPTION
Reverts firecrawl/firecrawl#2635

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Number() coercion added to credit calculations and restores the previous logic across auth and billing. This returns credit math to the prior behavior in auto-recharge, batch billing, and credit checks.

- **Refactors**
  - Removed Number() casts and use raw values for remaining_credits, credits_used, adjusted_credits_used, and price_credits.
  - Restored original arithmetic in auth middleware and billing services (auto_charge, batch_billing, credit_billing).

<sup>Written for commit 46e2b8f438ebbd85712e6379585bad702400e773. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

