### PR TITLE
fix(api): validate team ownership when appending to an existing crawl

### DIFF
--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -161,6 +161,15 @@ export async function batchScrapeController(
         zeroDataRetention,
       };
 
+  if (req.body.appendToId) {
+    if (!sc || sc.team_id !== req.auth.team_id) {
+      return res.status(404).json({
+        success: false,
+        error: "Job not found",
+      });
+    }
+  }
+
   if (!req.body.appendToId) {
     await crawlGroup.addGroup(
       id,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate team ownership when appending to an existing crawl in the batch-scrape API. If the job is missing or belongs to another team, return 404 to prevent cross-team appends.

<sup>Written for commit ed658bdf970c8e724785355d1650e2b3c9905781. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

