### PR TITLE
Attempt fix infinite loop

### DIFF
--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -4,25 +4,26 @@ import { config } from "../config";
 import { configDotenv } from "dotenv";
 configDotenv();
 
-const logFormat = winston.format.printf(info => {
-  const metadataStr =
-    Object.keys(info.metadata || {}).length > 0
-      ? JSON.stringify(info.metadata, (_, value) => {
-          if (value instanceof Error) {
-            return {
-              ...value,
-              name: value.name,
-              message: value.message,
-              stack: value.stack,
-              cause: value.cause,
-            };
-          } else {
-            return value;
-          }
-        })
-      : "";
-  return `${info.timestamp} ${info.level} [${info.metadata.module ?? ""}:${info.metadata.method ?? ""}]: ${info.message}${metadataStr ? " " + metadataStr : ""}`;
-});
+const logFormat = winston.format.printf(
+  info =>
+    `${info.timestamp} ${info.level} [${info.metadata.module ?? ""}:${info.metadata.method ?? ""}]: ${info.message} ${
+      info.level.includes("error") || info.level.includes("warn")
+        ? JSON.stringify(info.metadata, (_, value) => {
+            if (value instanceof Error) {
+              return {
+                ...value,
+                name: value.name,
+                message: value.message,
+                stack: value.stack,
+                cause: value.cause,
+              };
+            } else {
+              return value;
+            }
+          })
+        : ""
+    }`,
+);
 
 // Filter function to prevent logging when zeroDataRetention is true
 const zeroDataRetentionFilter = winston.format(info => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes an infinite retry loop in scrapeURL by rethrowing the error when a PDF or document is blocked by anti-bot after an attempted fetch. This stops repeated attempts and lets the caller handle the failure cleanly.

<sup>Written for commit 89772e6c8b5f04c430c033cfc0eee2d0eb82cac2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

