### PR TITLE
Fix: Remove Sentry trace data from API responses

### DIFF
--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -20,6 +20,7 @@ import { processJobInternal } from "../../services/worker/scrape-worker";
 import { ScrapeJobData } from "../../types";
 import { AbortManagerThrownError } from "../../scraper/scrapeURL/lib/abortManager";
 import { logRequest } from "../../services/logging/log_job";
+import { sanitizeDocumentForResponse } from "../../lib/sanitize-metadata";
 
 export async function scrapeController(
   req: RequestWithAuth<{}, ScrapeResponse, ScrapeRequest>,
@@ -253,12 +254,14 @@ export async function scrapeController(
     concurrencyQueueDurationMs: lockTime || undefined,
   });
 
+  const sanitizedDoc = sanitizeDocumentForResponse(doc!);
+
   return res.status(200).json({
     success: true,
     data: {
-      ...doc!,
+      ...sanitizedDoc,
       metadata: {
-        ...doc!.metadata,
+        ...sanitizedDoc.metadata,
         concurrencyLimited,
         concurrencyQueueDurationMs: concurrencyLimited
           ? lockTime || 0

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -28,6 +28,7 @@ import {
   applyZdrScope,
   captureExceptionWithZdrCheck,
 } from "../../services/sentry";
+import { sanitizeDocumentForResponse } from "../../lib/sanitize-metadata";
 
 interface DocumentWithCostTracking {
   document: Document;
@@ -359,7 +360,9 @@ export async function searchController(
         num_docs: docsWithCostTracking.length,
       });
 
-      const docs = docsWithCostTracking.map(item => item.document);
+      const docs = docsWithCostTracking.map(item =>
+        sanitizeDocumentForResponse(item.document),
+      );
       const filteredDocs = docs.filter(
         doc =>
           doc.serpResults || (doc.markdown && doc.markdown.trim().length > 0),

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -20,6 +20,7 @@ import { ScrapeJobData } from "../../types";
 import { teamConcurrencySemaphore } from "../../services/worker/team-semaphore";
 import { getJobPriority } from "../../lib/job-priority";
 import { logRequest } from "../../services/logging/log_job";
+import { sanitizeDocumentForResponse } from "../../lib/sanitize-metadata";
 
 export async function scrapeController(
   req: RequestWithAuth<{}, ScrapeResponse, ScrapeRequest>,
@@ -372,12 +373,13 @@ export async function scrapeController(
         concurrencyQueueDurationMs: lockTime || undefined,
       });
 
+      const sanitizedDoc = sanitizeDocumentForResponse(doc!);
       return res.status(200).json({
         success: true,
         data: {
-          ...doc!,
+          ...sanitizedDoc,
           metadata: {
-            ...doc!.metadata,
+            ...sanitizedDoc.metadata,
             concurrencyLimited,
             concurrencyQueueDurationMs: concurrencyLimited
               ? lockTime || 0

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -33,6 +33,7 @@ import {
   applyZdrScope,
   captureExceptionWithZdrCheck,
 } from "../../services/sentry";
+import { sanitizeDocumentForResponse } from "../../lib/sanitize-metadata";
 
 interface DocumentWithCostTracking {
   document: Document;
@@ -630,7 +631,7 @@ export async function searchController(
             const doc = resultsMap.get(item.url);
             return {
               ...item, // Preserve ALL original fields
-              ...doc, // Override/add scraped content
+              ...(doc ? sanitizeDocumentForResponse(doc) : undefined), // Override/add scraped content
             };
           });
         }
@@ -641,7 +642,7 @@ export async function searchController(
             const doc = item.url ? resultsMap.get(item.url) : undefined;
             return {
               ...item, // Preserve ALL original fields
-              ...doc, // Override/add scraped content
+              ...(doc ? sanitizeDocumentForResponse(doc) : undefined), // Override/add scraped content
             };
           });
         }
@@ -652,7 +653,7 @@ export async function searchController(
             const doc = item.url ? resultsMap.get(item.url) : undefined;
             return {
               ...item, // Preserve ALL original fields
-              ...doc, // Override/add scraped content
+              ...(doc ? sanitizeDocumentForResponse(doc) : undefined), // Override/add scraped content
             };
           });
         }

--- a/apps/api/src/controllers/v2/x402-search.ts
+++ b/apps/api/src/controllers/v2/x402-search.ts
@@ -32,6 +32,7 @@ import {
   applyZdrScope,
   captureExceptionWithZdrCheck,
 } from "../../services/sentry";
+import { sanitizeDocumentForResponse } from "../../lib/sanitize-metadata";
 
 interface DocumentWithCostTracking {
   document: Document;
@@ -562,7 +563,7 @@ export async function x402SearchController(
             const doc = resultsMap.get(item.url);
             return {
               ...item, // Preserve ALL original fields
-              ...doc, // Override/add scraped content
+              ...(doc ? sanitizeDocumentForResponse(doc) : undefined), // Override/add scraped content
             };
           });
         }
@@ -573,7 +574,7 @@ export async function x402SearchController(
             const doc = item.url ? resultsMap.get(item.url) : undefined;
             return {
               ...item, // Preserve ALL original fields
-              ...doc, // Override/add scraped content
+              ...(doc ? sanitizeDocumentForResponse(doc) : undefined), // Override/add scraped content
             };
           });
         }
@@ -584,7 +585,7 @@ export async function x402SearchController(
             const doc = item.url ? resultsMap.get(item.url) : undefined;
             return {
               ...item, // Preserve ALL original fields
-              ...doc, // Override/add scraped content
+              ...(doc ? sanitizeDocumentForResponse(doc) : undefined), // Override/add scraped content
             };
           });
         }

--- a/apps/api/src/lib/sanitize-metadata.ts
+++ b/apps/api/src/lib/sanitize-metadata.ts
@@ -1,0 +1,29 @@
+import { Document as V2Document } from "../controllers/v2/types";
+import { Document as V1Document } from "../controllers/v1/types";
+
+type DocumentMetadata = V1Document["metadata"] | V2Document["metadata"];
+
+function sanitizeMetadataForResponse(
+  metadata: DocumentMetadata,
+): DocumentMetadata {
+  if (!metadata) {
+    return metadata;
+  }
+  const sanitized = { ...metadata };
+  delete sanitized["sentry-trace"];
+  delete sanitized["baggage"];
+  return sanitized;
+}
+
+export function sanitizeDocumentForResponse(
+  document: V1Document | V2Document,
+): V1Document | V2Document {
+  if (!document.metadata) {
+    return document;
+  }
+
+  return {
+    ...document,
+    metadata: sanitizeMetadataForResponse(document.metadata),
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed Sentry tracing fields from API response metadata to prevent leaking trace data and reduce payload noise across search and scrape endpoints.

- **Bug Fixes**
  - Added sanitizeDocumentForResponse to strip sentry-trace and baggage from metadata.
  - Applied sanitization in v1/v2 scrape, v1/v2 search, and v2 x402-search controllers.

<sup>Written for commit 0fc6db4f3a205f932ab8a2303e4ca463d9112c73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

