### PR TITLE
fix: backfill metadata title from og:title or twitter:title when missing

### DIFF
--- a/apps/api/native/src/html.rs
+++ b/apps/api/native/src/html.rs
@@ -292,6 +292,22 @@ fn _extract_metadata(
     }
   }
 
+  // Backfill title from og:title, twitter:title, or meta[name="title"] if primary extraction failed
+  if !out.contains_key("title") {
+    let fallback_title = out
+      .get("ogTitle")
+      .or_else(|| out.get("og:title"))
+      .or_else(|| out.get("twitter:title"))
+      .and_then(|v| match v {
+        Value::String(s) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+      });
+
+    if let Some(title) = fallback_title {
+      out.insert("title".to_string(), Value::String(title));
+    }
+  }
+
   Ok(out)
 }
 

--- a/apps/api/src/lib/__tests__/html-transformer.test.ts
+++ b/apps/api/src/lib/__tests__/html-transformer.test.ts
@@ -261,6 +261,51 @@ describe("HTML Transformer", () => {
       const metadata = await extractMetadata(html);
       expect(metadata).toBeDefined();
     });
+
+    it("should backfill title from og:title when title tag is missing", async () => {
+      const html = `
+        <html>
+          <head>
+            <meta property="og:title" content="OpenGraph Title">
+            <meta name="description" content="Page description">
+          </head>
+          <body></body>
+        </html>
+      `;
+      const metadata = await extractMetadata(html);
+      expect(metadata.title).toBe("OpenGraph Title");
+      expect(metadata.ogTitle).toBe("OpenGraph Title");
+    });
+
+    it("should backfill title from twitter:title when title and og:title are missing", async () => {
+      const html = `
+        <html>
+          <head>
+            <meta name="twitter:title" content="Twitter Title">
+            <meta name="description" content="Page description">
+          </head>
+          <body></body>
+        </html>
+      `;
+      const metadata = await extractMetadata(html);
+      expect(metadata.title).toBe("Twitter Title");
+    });
+
+    it("should not backfill title when title tag exists", async () => {
+      const html = `
+        <html>
+          <head>
+            <title>Primary Title</title>
+            <meta property="og:title" content="OpenGraph Title">
+            <meta name="twitter:title" content="Twitter Title">
+          </head>
+          <body></body>
+        </html>
+      `;
+      const metadata = await extractMetadata(html);
+      expect(metadata.title).toBe("Primary Title");
+      expect(metadata.ogTitle).toBe("OpenGraph Title");
+    });
   });
 
   describe("transformHtml", () => {


### PR DESCRIPTION
When the primary <title> tag extraction fails (e.g., pages with unusual HTML structure where the first <head> node doesn't contain the expected tags),

the metadata extractor now falls back to og:title, then twitter:title.

Fallback order: ogTitle → og:title → twitter:title

This is a non-breaking change - existing <title> tags still take precedence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills metadata title from Open Graph or Twitter tags when the primary <title> extraction fails. Existing <title> still takes precedence, improving resilience on pages with unusual head structures.

- **Bug Fixes**
  - Fallback order: ogTitle → og:title → twitter:title
  - Applies only when no title was extracted
  - Added tests for og:title, twitter:title, and preserving an existing title

<sup>Written for commit 182390308570ecb0fdd06cdf35a9a8b187ad30d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

