### PR TITLE
chore(api): export gdocs as HTML instead of PDF

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/rewriteUrl.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/rewriteUrl.ts
@@ -11,7 +11,7 @@ export function rewriteUrl(url: string): string | undefined {
     }
     const id = url.match(/\/document\/d\/([-\w]+)/)?.[1];
     if (id) {
-      return `https://docs.google.com/document/d/${id}/export?format=pdf`;
+      return `https://docs.google.com/document/d/${id}/export?format=html`;
     }
   } else if (
     url.startsWith("https://docs.google.com/presentation/d/") ||
@@ -23,7 +23,7 @@ export function rewriteUrl(url: string): string | undefined {
     }
     const id = url.match(/\/presentation\/d\/([-\w]+)/)?.[1];
     if (id) {
-      return `https://docs.google.com/presentation/d/${id}/export?format=pdf`;
+      return `https://docs.google.com/presentation/d/${id}/export?format=html`;
     }
   } else if (
     url.startsWith("https://drive.google.com/file/d/") ||


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update rewriteUrl to export Google Docs and Slides as HTML instead of PDF. Fixes ENG-3963 by preserving emojis and making text extraction more reliable.

<sup>Written for commit 24d307c7605b9df592cd8059589995f1953d2220. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

