### PR TITLE
Update .env.example

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -7,7 +7,7 @@ REDIS_RATE_LIMIT_URL=redis://redis:6379 #for self-hosting using docker, use redi
 PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/scrape
 
 ## To turn on DB authentication, you need to set up supabase.
-USE_DB_AUTHENTICATION=true
+USE_DB_AUTHENTICATION=false
 
 # ===== Optional ENVS ======
 
@@ -47,7 +47,7 @@ RATE_LIMIT_TEST_API_KEY_CRAWL=
 # set if you'd like to use scraping Be to handle JS blocking
 SCRAPING_BEE_API_KEY=
 # add for LLM dependent features (image alt generation, etc.)
-OPENAI_API_KEY=
+OPENAI_API_KEY=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
 BULL_AUTH_KEY=@
 # set if you have a llamaparse key you'd like to use to parse pdfs
 LLAMAPARSE_API_KEY=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Turned off DB authentication by default and added a sample OpenAI API key in apps/api/.env.example to make local setup easier.

- **Migration**
  - If you use Supabase, set USE_DB_AUTHENTICATION=true.
  - Replace the sample OPENAI_API_KEY with your own key. Do not commit real secrets.

<sup>Written for commit a01800caa5225e2a25eb840e1ee58f0f4cced7b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

