### PR TITLE
Add per-team 300k job limit to concurrency queue

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -156,6 +156,9 @@ const configSchema = z.object({
   RATE_LIMIT_TEST_API_KEY_SCRAPE: z.coerce.number().optional(),
   RATE_LIMIT_TEST_API_KEY_CRAWL: z.coerce.number().optional(),
 
+  // Concurrency Queue Limits
+  GLOBAL_CONCURRENCY_QUEUE_LIMIT: z.coerce.number().default(300000),
+
   // Testing
   TEST_API_KEY: z.string().optional(),
   TEST_API_URL: z.string().default("http://127.0.0.1:3002"),

--- a/apps/api/src/lib/error-serde.ts
+++ b/apps/api/src/lib/error-serde.ts
@@ -1,6 +1,7 @@
 import {
   CrawlDenialError,
   ErrorCodes,
+  GlobalQueueLimitExceededError,
   MapTimeoutError,
   RacedRedirectError,
   ScrapeJobTimeoutError,
@@ -47,6 +48,7 @@ const errorMap: Record<ErrorCodes, any> = {
   SCRAPE_RACED_REDIRECT_ERROR: RacedRedirectError,
   SCRAPE_SITEMAP_ERROR: SitemapError,
   CRAWL_DENIAL: CrawlDenialError,
+  GLOBAL_QUEUE_LIMIT_EXCEEDED: GlobalQueueLimitExceededError,
 
   // Zod errors
   BAD_REQUEST: null,


### PR DESCRIPTION
## Summary
Add a configurable per-team limit (default 300k jobs) to the Redis concurrency queue. When a team's queue reaches this limit, further job additions throw a serializable `GlobalQueueLimitExceededError`. Uses atomic Lua script to prevent race conditions between limit check and job insertion. Self-hosted deployments bypass the limit check.

## Implementation
- Added `GLOBAL_CONCURRENCY_QUEUE_LIMIT` config (default 300000) to `config.ts`
- Added `GlobalQueueLimitExceededError` class with serialization support to `error.ts`
- Registered error in serialization map in `error-serde.ts`
- Modified `pushConcurrencyLimitedJob` in `concurrency-limit.ts` to atomically check team's queue size before adding jobs using Lua script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-team limit to the Redis concurrency queue (default 300k jobs) to prevent unbounded growth. When a team hits the limit, job pushes fail with GlobalQueueLimitExceededError; self-hosted installs skip the limit.

- **New Features**
  - Config: GLOBAL_CONCURRENCY_QUEUE_LIMIT (default 300000).
  - Atomic limit check + enqueue via Lua script in pushConcurrencyLimitedJob.
  - New error: GlobalQueueLimitExceededError with serialization; registered in error-serde.
  - Self-hosted deployments bypass the limit check.

- **Migration**
  - No action required. Optionally set GLOBAL_CONCURRENCY_QUEUE_LIMIT.
  - Clients should handle error code GLOBAL_QUEUE_LIMIT_EXCEEDED.

<sup>Written for commit db594c93cfed4b611dd1d2723e435ea72e07b457. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

