### PR TITLE
fix(security): fix audit-ci vulnerabilities and clean up allowlists

### DIFF
--- a/apps/api/audit-ci.jsonc
+++ b/apps/api/audit-ci.jsonc
@@ -2,17 +2,11 @@
     "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
     "low": true,
     "allowlist": [
-        "GHSA-33vc-wfww-vjfv|ai>jsondiffpatch", // we don't care about the HTML coming out of jsondiffpatch
         "GHSA-3gc7-fjrx-p6mg|@coinbase/x402>@coinbase/cdp-sdk>@solana/spl-token>@solana/buffer-layout-utils>bigint-buffer", // never gets called in our code paths
-        "GHSA-qj3p-xc97-xw74|@coinbase/x402>x402>wagmi>@wagmi/connectors>@metamask/sdk", // we don't use the Metamask SDK in the browser
-        "GHSA-qj3p-xc97-xw74|@coinbase/x402>x402>wagmi>@wagmi/connectors>@metamask/sdk>@metamask/sdk-communication-layer", // we don't use the Metamask SDK in the browser
-        "GHSA-ffrw-9mx8-89p8|@coinbase/x402>x402>wagmi>@wagmi/connectors>@walletconnect/ethereum-provider>@reown/appkit>@reown/appkit-utils>@walletconnect/logger>pino>fast-redact", // unused
         "GHSA-m732-5p4w-x69g|@coinbase/x402>x402>wagmi>@wagmi/connectors>porto>hono", // we don't use hono
         "GHSA-q7jf-gf43-6x6p|@coinbase/x402>x402>wagmi>@wagmi/connectors>porto>hono", // we don't use hono
-        "GHSA-rwvc-j5jr-mgvh|ai", // file upload vulnerability - not exposed in our usage
         "GHSA-5j98-mcp5-4vw2|jest>@jest/core>@jest/reporters>glob", // we do not use the glob CLI
         "GHSA-mh29-5h37-fv8m|@jest/globals>@jest/expect>jest-snapshot>@jest/transform>babel-plugin-istanbul>@istanbuljs/load-nyc-config>js-yaml", // not impacted by this
-        "GHSA-mh29-5h37-fv8m|native>@napi-rs/cli>js-yaml", // not impacted by this
         "GHSA-36hm-qxxp-pg3m|@coinbase/x402>x402>wagmi>@wagmi/connectors>@coinbase/wallet-sdk>preact" // we don't use preact in our code paths
     ]
 }

--- a/apps/test-suite/audit-ci.jsonc
+++ b/apps/test-suite/audit-ci.jsonc
@@ -2,8 +2,8 @@
     "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
     "low": true,
     "allowlist": [
-        "GHSA-5j98-mcp5-4vw2|artillery>artillery-plugin-apdex>tap>@tapjs/fixture>rimraf>glob", // not impacted by this
         "GHSA-mh29-5h37-fv8m|@jest/globals>@jest/expect>jest-snapshot>@jest/transform>babel-plugin-istanbul>@istanbuljs/load-nyc-config>js-yaml", // not impacted by this
-        "GHSA-5j98-mcp5-4vw2|jest>@jest/core>@jest/reporters>glob" // we do not use the glob CLI
+        "GHSA-5j98-mcp5-4vw2|jest>@jest/core>@jest/reporters>glob", // we do not use the glob CLI
+        "GHSA-6475-r3vj-m8vf|artillery>artillery-plugin-publish-metrics>@aws-sdk/client-cloudwatch>@smithy/config-resolver" // informational enhancement - we control region input
     ]
 }


### PR DESCRIPTION
## Summary
- Removed 6 stale allowlist entries from apps/api/audit-ci.jsonc
- Added new AWS SDK informational advisory to apps/test-suite/audit-ci.jsonc (region parameter validation enhancement)
- All audit-ci checks now pass with no unused allowlists

The changes address vulnerabilities that have been patched or are not applicable to our usage patterns.

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed six stale audit-ci allowlist entries in apps/api and added an informational AWS SDK advisory in apps/test-suite (region parameter validation). All audit-ci checks now pass with no unused allowlists.

<sup>Written for commit 1d99e3d8fc2bcb58697da399fa7e02bd1faad65e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

