### PR TITLE
chore(ci): tune runners

### DIFF
--- a/.github/workflows/deploy-image-staging.yml
+++ b/.github/workflows/deploy-image-staging.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   push-app-image:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: './apps/api'

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: blacksmith-8vcpu-ubuntu-2404
           - platform: linux/arm64
-            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            runner: blacksmith-8vcpu-ubuntu-2404-arm
     defaults:
       run:
         working-directory: './apps/api'
@@ -57,7 +57,7 @@ jobs:
           provenance: false
 
   manifest:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build
     steps:
       - name: 'Login to GitHub Container Registry'

--- a/.github/workflows/deploy-playwright.yml
+++ b/.github/workflows/deploy-playwright.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: blacksmith-8vcpu-ubuntu-2404
           - platform: linux/arm64
-            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            runner: blacksmith-8vcpu-ubuntu-2404-arm
     defaults:
       run:
         working-directory: './apps/playwright-service-ts'
@@ -57,7 +57,7 @@ jobs:
           provenance: false
 
   manifest:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build
     steps:
       - name: 'Login to GitHub Container Registry'

--- a/.github/workflows/eval-prod.yml
+++ b/.github/workflows/eval-prod.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   run-eval-benchmark-prod:
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
         steps:
           - name: Checkout repository

--- a/.github/workflows/ghcr-clean.yml
+++ b/.github/workflows/ghcr-clean.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   delete-untagged-images:
     name: Delete Untagged Images
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: bots-house/ghcr-delete-image-action@v1.1.0
         with:

--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   publish:
     name: Publish
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
       - name: Set up Node.js

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -25,7 +25,7 @@ jobs:
         # proxy: ["proxy", "no-proxy"]
         # search: ["searxng", "google"]
         # ai: ["openai", "no-ai"]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     services:
       redis:
         image: redis


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tuned GitHub Actions runners for faster heavy jobs and lower resource use on light jobs. Standardizes all workflows to blacksmith Ubuntu 24.04.

- **Refactors**
  - Image builds and Playwright builds now use 8 vCPU runners for both amd64 and arm64; manifest steps use 2 vCPU.
  - API staging deploy and server tests moved to 8 vCPU runners.
  - Eval, GHCR cleanup, and JS/Python SDK publish jobs moved to 2 vCPU.
  - Replaced ubuntu-latest with blacksmith runners for consistency.

<sup>Written for commit 166205f658f43422b6d2386b00795d98915a1cea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

