### PR TITLE
chore(ci): tune runners

### DIFF
--- a/.github/workflows/deploy-image-staging.yml
+++ b/.github/workflows/deploy-image-staging.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   push-app-image:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: './apps/api'

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: blacksmith-8vcpu-ubuntu-2404
+            runner: blacksmith-4vcpu-ubuntu-2404
           - platform: linux/arm64
-            runner: blacksmith-8vcpu-ubuntu-2404-arm
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
     defaults:
       run:
         working-directory: './apps/api'

--- a/.github/workflows/deploy-playwright.yml
+++ b/.github/workflows/deploy-playwright.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: blacksmith-8vcpu-ubuntu-2404
+            runner: blacksmith-4vcpu-ubuntu-2404
           - platform: linux/arm64
-            runner: blacksmith-8vcpu-ubuntu-2404-arm
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
     defaults:
       run:
         working-directory: './apps/playwright-service-ts'

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -15,17 +15,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        engine: ["playwright", "fetch"] # unsure if we need both of these
-        proxy: ["proxy", "no-proxy"] # proxy / no-proxy run different tests, keep both
-        search: ["searxng"] # disabled google for now, should be fine with just Searxng
-        ai: ["openai"] # AI only should be fine, as it simply adds tests, if non-AI fails, AI will fail.
+        engine: ['playwright', 'fetch'] # unsure if we need both of these
+        proxy: ['proxy', 'no-proxy'] # proxy / no-proxy run different tests, keep both
+        search: ['searxng'] # disabled google for now, should be fine with just Searxng
+        ai: ['openai'] # AI only should be fine, as it simply adds tests, if non-AI fails, AI will fail.
 
         # legacy matrix:
         # engine: ["playwright", "fetch"]
         # proxy: ["proxy", "no-proxy"]
         # search: ["searxng", "google"]
         # ai: ["openai", "no-ai"]
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
       redis:
         image: redis
@@ -68,7 +68,7 @@ jobs:
             apps/api/pnpm-lock.yaml
             apps/test-site/pnpm-lock.yaml
             apps/playwright-service-ts/pnpm-lock.yaml
-      
+
       - run: pnpm fetch
         working-directory: apps/api
       - run: pnpm fetch
@@ -165,12 +165,12 @@ jobs:
           docker run -d -p 3434:8080 -v "${PWD}/searxng:/etc/searxng" --name searxng searxng/searxng
           pnpx wait-on tcp:3434 -t 30s
         working-directory: ./
-        
+
       - name: Install API dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
         working-directory: apps/api
         env:
-          npm_config_ignore_scripts: "true"
+          npm_config_ignore_scripts: 'true'
 
       - name: Install test site dependencies
         run: pnpm install --frozen-lockfile
@@ -191,7 +191,7 @@ jobs:
         working-directory: ./apps/playwright-service-ts
         env:
           PORT: 3003
-        
+
       - name: Run Docker Postgres
         run: |
           docker build -t firecrawl/nuq-postgres:latest ./apps/nuq-postgres
@@ -201,7 +201,7 @@ jobs:
         run: pnpm harness pnpm test:snips
         working-directory: apps/api
         env:
-          npm_config_ignore_scripts: "true" # required currently to prevent re-building cached native lib
+          npm_config_ignore_scripts: 'true' # required currently to prevent re-building cached native lib
 
       - name: Publish test report
         if: always()
@@ -377,7 +377,7 @@ jobs:
   #       working-directory: apps/api
   #       env:
   #         npm_config_ignore_scripts: "true"
-      
+
   #     - name: Run Docker Postgres
   #       run: |
   #         docker build -t firecrawl/nuq-postgres:latest ./apps/nuq-postgres


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Right-sized GitHub Actions runners from 8 vCPU to 4 vCPU across deploy and test workflows to reduce CI resource usage and cost without changing behavior. Also cleaned up YAML quotes and minor whitespace.

- **Refactors**
  - Switched runners to blacksmith-4vcpu-ubuntu-2404 (and -arm) in deploy-image, deploy-image-staging, deploy-playwright, and test-server.
  - Standardized matrix values and env to single quotes; minor whitespace fixes.

<sup>Written for commit 78c1c389844218ed50bb54fe77dbe666ed16c1ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

