### PR TITLE
chore(api): update A/B test to use FIRE_ENGINE_AB_URL instead of FIRE…

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -71,7 +71,7 @@ const configSchema = z.object({
   // Fire Engine
   FIRE_ENGINE_BETA_URL: z.string().optional(),
   FIRE_ENGINE_STAGING_URL: z.string().optional(),
-  FIRE_ENGINE_AB_HOST: z.string().optional(),
+  FIRE_ENGINE_AB_URL: z.string().optional(),
   FIRE_ENGINE_AB_RATE: z.coerce.number().optional(),
 
   // ScrapeURL

--- a/apps/api/src/services/ab-test.ts
+++ b/apps/api/src/services/ab-test.ts
@@ -83,14 +83,14 @@ export function abTestFireEngine(
   const abLogger = _logger.child({ method: "ABTestToStaging" });
   try {
     const abRateEnv = config.FIRE_ENGINE_AB_RATE;
-    const abHostEnv = config.FIRE_ENGINE_AB_HOST;
+    const abUrlEnv = config.FIRE_ENGINE_AB_URL;
     const abRate =
       abRateEnv !== undefined ? Math.max(0, Math.min(1, Number(abRateEnv))) : 0;
     const shouldABTest =
       !feRequest.zeroDataRetention &&
       abRate > 0 &&
       Math.random() <= abRate &&
-      abHostEnv;
+      abUrlEnv;
     if (shouldABTest) {
       let timeout = Math.min(60000, (feRequest.timeout ?? 30000) + 10000);
 
@@ -105,7 +105,7 @@ export function abTestFireEngine(
         try {
           abLogger.info("A/B-testing scrapeURL to staging");
           await robustFetch({
-            url: `http://${abHostEnv}/scrape`,
+            url: `${abUrlEnv}/scrape`,
             method: "POST",
             body: feRequest,
             logger: abLogger,


### PR DESCRIPTION
…_ENGINE_AB_HOST

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch A/B test config from FIRE_ENGINE_AB_HOST to FIRE_ENGINE_AB_URL to allow full URLs and HTTPS. Requests now use the provided base URL instead of hardcoding http://.

- **Migration**
  - Rename env var: FIRE_ENGINE_AB_HOST → FIRE_ENGINE_AB_URL.
  - Set to a full base URL with scheme (e.g., https://fe.example.com), no trailing slash.
  - FIRE_ENGINE_AB_RATE is unchanged.

<sup>Written for commit f163aff0e994ee4086613d5566a12d5dadf216c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

