### PR TITLE
chore: update audit runner from 4c to 2c

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   audit:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the npm-audit workflow to a 2 vCPU runner to reduce CI resource usage.
Changes runner from blacksmith-4vcpu-ubuntu-2404 to blacksmith-2vcpu-ubuntu-2404 with minimal impact on job time.

<sup>Written for commit 071fa1e9b32bf106c9de2e02765b204e10ea5265. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

