### PR TITLE
update proxy setup engine

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -1060,7 +1060,7 @@ describe("Scrape tests", () => {
       );
     });
 
-    describe("Location API (f-e dependent)", () => {
+    describe("Location API (proxy-backed)", () => {
       it.concurrent(
         "works without specifying an explicit location",
         async () => {
@@ -1074,7 +1074,7 @@ describe("Scrape tests", () => {
         scrapeTimeout,
       );
 
-      it.concurrent(
+      concurrentIf(TEST_SELF_HOST && HAS_PROXY)(
         "works with country US",
         async () => {
           const response = await scrape(
@@ -1086,6 +1086,24 @@ describe("Scrape tests", () => {
           );
 
           expect(response.markdown).toContain("| Country | United States |");
+        },
+        scrapeTimeout,
+      );
+
+      concurrentIf(TEST_SELF_HOST && !HAS_PROXY)(
+        "warns when location cannot be applied",
+        async () => {
+          const response = await scrapeRaw(
+            {
+              url: "https://iplocation.com",
+              location: { country: "US" },
+            },
+            identity,
+          );
+
+          expect(response.statusCode).toBe(200);
+          expect(response.body.success).toBe(true);
+          expect(response.body.warning ?? "").toContain("location");
         },
         scrapeTimeout,
       );

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -341,6 +341,16 @@ describe("V2 Types Validation", () => {
       expect(result.location?.languages).toEqual(["en"]);
     });
 
+    it("should keep location undefined when empty", () => {
+      const input: ScrapeRequestInput = {
+        url: "https://example.com",
+        location: {},
+      };
+
+      const result = scrapeRequestSchema.parse(input);
+      expect(result.location).toBeUndefined();
+    });
+
     it("should reject location schema with invalid country code", () => {
       const input: ScrapeRequestInput = {
         url: "https://example.com",

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -471,12 +471,18 @@ const locationSchema = z
         "Invalid country code. Use a valid ISO 3166-1 alpha-2 country code.",
       )
       .transform(val => {
-        if (!val) return "us-generic";
+        if (!val) return undefined;
         return val.toLowerCase();
       }),
     languages: z.array(z.string()).optional(),
   })
-  .optional();
+  .optional()
+  .transform(val => {
+    if (!val) return undefined;
+    const hasCountry = !!val.country;
+    const hasLanguages = !!val.languages && val.languages.length > 0;
+    return hasCountry || hasLanguages ? val : undefined;
+  });
 
 const baseScrapeOptions = z.strictObject({
   formats: z

--- a/apps/api/src/lib/robots-txt.ts
+++ b/apps/api/src/lib/robots-txt.ts
@@ -36,21 +36,12 @@ export async function fetchRobotsTxt(
   const urlObj = new URL(url);
   const robotsTxtUrl = `${urlObj.protocol}//${urlObj.host}/robots.txt`;
 
-  const shouldPrioritizeFireEngine = location && useFireEngine;
+  const shouldPrioritizeFireEngine = false;
 
   const forceEngine: Engine[] = [
     ...(useIndex ? ["index" as const] : []),
-    ...(shouldPrioritizeFireEngine
-      ? [
-          "fire-engine;tlsclient" as const,
-          "fire-engine;tlsclient;stealth" as const,
-          // final fallback to chrome-cdp to fill the index
-          "fire-engine;chrome-cdp" as const,
-          "fire-engine;chrome-cdp;stealth" as const,
-        ]
-      : []),
     "fetch",
-    ...(!shouldPrioritizeFireEngine && useFireEngine
+    ...(useFireEngine
       ? [
           "fire-engine;tlsclient" as const,
           "fire-engine;tlsclient;stealth" as const,

--- a/apps/api/src/scraper/scrapeURL/engines/fetch/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fetch/index.ts
@@ -4,8 +4,10 @@ import { Meta } from "../..";
 import { SSLError } from "../../error";
 import { specialtyScrapeCheck } from "../utils/specialtyHandler";
 import {
+  buildProxyConfig,
   getSecureDispatcher,
   InsecureConnectionError,
+  mergeLocationHeaders,
 } from "../utils/safeFetch";
 import { MockState, saveMock } from "../../lib/mock";
 import { TextDecoder } from "util";
@@ -51,10 +53,18 @@ export async function scrapeURLWithFetch(
     };
   } else {
     try {
+      const proxyConfig = buildProxyConfig(meta.options.location);
+      const headers = mergeLocationHeaders(
+        meta.options.headers,
+        meta.options.location,
+      );
       const x = await undici.fetch(meta.rewrittenUrl ?? meta.url, {
-        dispatcher: getSecureDispatcher(meta.options.skipTlsVerification),
+        dispatcher: getSecureDispatcher(
+          meta.options.skipTlsVerification,
+          proxyConfig,
+        ),
         redirect: "follow",
-        headers: meta.options.headers,
+        headers,
         signal: meta.abort.asSignal(),
       });
 

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -20,6 +20,7 @@ import { hasFormatOfType } from "../../../lib/format-utils";
 import { getPDFMaxPages } from "../../../controllers/v2/types";
 import { PdfMetadata } from "@mendable/firecrawl-rs";
 import { BrandingProfile } from "../../../types/branding";
+import { isLocationSupportedByProxy } from "./utils/safeFetch";
 
 export type Engine =
   | "fire-engine;chrome-cdp"
@@ -575,6 +576,45 @@ export async function buildFallbackList(meta: Meta): Promise<
     selectedEngines = selectedEngines.filter(
       x => engineOptions[x.engine].quality > 0,
     );
+  }
+
+  const hasLocation = meta.featureFlags.has("location");
+  const locationSupported = isLocationSupportedByProxy(meta.options.location);
+  const locationOnlyLanguages =
+    !!meta.options.location &&
+    !meta.options.location.country &&
+    !!meta.options.location.languages?.length;
+
+  if (selectedEngines.length === 0 && hasLocation) {
+    for (const engine of currentEngines) {
+      const unsupportedFeatures = new Set(meta.featureFlags);
+      selectedEngines.push({ engine, supportScore: 0, unsupportedFeatures });
+    }
+  }
+
+  if (selectedEngines.length === 0) {
+    for (const engine of currentEngines) {
+      selectedEngines.push({
+        engine,
+        supportScore: 0,
+        unsupportedFeatures: new Set(meta.featureFlags),
+      });
+    }
+  }
+
+  if (
+    selectedEngines.length > 0 &&
+    hasLocation &&
+    !locationSupported &&
+    !locationOnlyLanguages
+  ) {
+    selectedEngines = selectedEngines.map(engine => ({
+      ...engine,
+      unsupportedFeatures: new Set([
+        ...engine.unsupportedFeatures,
+        "location",
+      ]),
+    }));
   }
 
   if (meta.internalOptions.forceEngine === undefined) {

--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -4,10 +4,20 @@ import { EngineScrapeResult } from "..";
 import { Meta } from "../..";
 import { robustFetch } from "../../lib/fetch";
 import { getInnerJson } from "@mendable/firecrawl-rs";
+import {
+  buildProxyConfig,
+  mergeLocationHeaders,
+} from "../utils/safeFetch";
 
 export async function scrapeURLWithPlaywright(
   meta: Meta,
 ): Promise<EngineScrapeResult> {
+  const proxyConfig = buildProxyConfig(meta.options.location);
+  const headers = mergeLocationHeaders(
+    meta.options.headers,
+    meta.options.location,
+  );
+
   const response = await robustFetch({
     url: config.PLAYWRIGHT_MICROSERVICE_URL!,
     headers: {
@@ -17,8 +27,10 @@ export async function scrapeURLWithPlaywright(
       url: meta.rewrittenUrl ?? meta.url,
       wait_after_load: meta.options.waitFor,
       timeout: meta.abort.scrapeTimeout(),
-      headers: meta.options.headers,
+      headers,
       skip_tls_verification: meta.options.skipTlsVerification,
+      proxy: proxyConfig ?? undefined,
+      locale: meta.options.location?.languages?.[0],
     },
     method: "POST",
     logger: meta.logger.child("scrapeURLWithPlaywright/robustFetch"),

--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
@@ -6,11 +6,70 @@ import { interceptors } from "undici";
 import { CookieJar } from "tough-cookie";
 import { cookie } from "http-cookie-agent/undici";
 import IPAddr from "ipaddr.js";
+
+export type ProxyConfig = {
+  server: string;
+  username?: string;
+  password?: string;
+};
+
 export class InsecureConnectionError extends Error {
   constructor() {
     super("Connection violated security rules.");
   }
 }
+
+const normalizeProxyServer = (server: string) =>
+  server.includes("://") ? server : "http://" + server;
+
+const normalizeLocationCountry = (country?: string) => {
+  if (!country) return undefined;
+  const lowered = country.toLowerCase();
+  if (lowered === "us-generic" || lowered === "us-whitelist") {
+    return "US";
+  }
+  return country.toUpperCase();
+};
+
+export const buildProxyConfig = (location?: {
+  country?: string;
+}): ProxyConfig | null => {
+  if (!config.PROXY_SERVER) return null;
+  const country = normalizeLocationCountry(location?.country);
+  const usernameBase = config.PROXY_USERNAME;
+  const username =
+    usernameBase && country ? `${usernameBase}-cc-${country}` : usernameBase;
+  return {
+    server: config.PROXY_SERVER,
+    username,
+    password: config.PROXY_PASSWORD,
+  };
+};
+
+export const isLocationSupportedByProxy = (location?: {
+  country?: string;
+}) => {
+  if (!location?.country) return true;
+  return !!(config.PROXY_SERVER && config.PROXY_USERNAME);
+};
+
+const hasHeader = (headers: Record<string, string> | undefined, name: string) => {
+  if (!headers) return false;
+  const target = name.toLowerCase();
+  return Object.keys(headers).some(key => key.toLowerCase() === target);
+};
+
+export const mergeLocationHeaders = (
+  headers: Record<string, string> | undefined,
+  location?: { languages?: string[] },
+) => {
+  if (!location?.languages?.length) return headers;
+  if (hasHeader(headers, "accept-language")) return headers;
+  return {
+    ...(headers ?? {}),
+    "Accept-Language": location.languages.join(","),
+  };
+};
 
 export function isIPPrivate(address: string): boolean {
   if (!IPAddr.isValid(address)) return false;
@@ -19,14 +78,21 @@ export function isIPPrivate(address: string): boolean {
   return addr.range() !== "unicast";
 }
 
-function createBaseAgent(skipTlsVerification: boolean) {
-  const baseAgent = config.PROXY_SERVER
+function createBaseAgent(
+  skipTlsVerification: boolean,
+  proxyConfig?: ProxyConfig | null,
+) {
+  const proxy = proxyConfig ?? (config.PROXY_SERVER ? {
+    server: config.PROXY_SERVER,
+    username: config.PROXY_USERNAME,
+    password: config.PROXY_PASSWORD,
+  } : null);
+
+  const baseAgent = proxy
     ? new undici.ProxyAgent({
-        uri: config.PROXY_SERVER.includes("://")
-          ? config.PROXY_SERVER
-          : "http://" + config.PROXY_SERVER,
-        token: config.PROXY_USERNAME
-          ? `Basic ${Buffer.from(config.PROXY_USERNAME + ":" + (config.PROXY_PASSWORD ?? "")).toString("base64")}`
+        uri: normalizeProxyServer(proxy.server),
+        token: proxy.username
+          ? `Basic ${Buffer.from(proxy.username + ":" + (proxy.password ?? "")).toString("base64")}`
           : undefined,
         requestTls: {
           rejectUnauthorized: !skipTlsVerification, // Only bypass SSL verification if explicitly requested
@@ -61,8 +127,11 @@ function attachSecurityCheck(agent: undici.Dispatcher) {
 }
 
 // Dispatcher WITH cookie handling (for scraping - needs cookies for auth flows)
-function makeSecureDispatcher(skipTlsVerification: boolean) {
-  const baseAgent = createBaseAgent(skipTlsVerification);
+function makeSecureDispatcher(
+  skipTlsVerification: boolean,
+  proxyConfig?: ProxyConfig | null,
+) {
+  const baseAgent = createBaseAgent(skipTlsVerification, proxyConfig);
   const cookieJar = new CookieJar();
   const agent = baseAgent.compose(cookie({ jar: cookieJar }));
   attachSecurityCheck(agent);
@@ -70,8 +139,11 @@ function makeSecureDispatcher(skipTlsVerification: boolean) {
 }
 
 // Dispatcher WITHOUT cookie handling (for webhooks - avoids empty cookie header bug)
-function makeSecureDispatcherNoCookies(skipTlsVerification: boolean) {
-  const agent = createBaseAgent(skipTlsVerification);
+function makeSecureDispatcherNoCookies(
+  skipTlsVerification: boolean,
+  proxyConfig?: ProxyConfig | null,
+) {
+  const agent = createBaseAgent(skipTlsVerification, proxyConfig);
   attachSecurityCheck(agent);
   return agent;
 }
@@ -82,13 +154,27 @@ const secureDispatcherNoCookies = makeSecureDispatcherNoCookies(false);
 const secureDispatcherNoCookiesSkipTlsVerification =
   makeSecureDispatcherNoCookies(true);
 
-export const getSecureDispatcher = (skipTlsVerification: boolean = false) =>
-  skipTlsVerification ? secureDispatcherSkipTlsVerification : secureDispatcher;
+export const getSecureDispatcher = (
+  skipTlsVerification: boolean = false,
+  proxyConfig?: ProxyConfig | null,
+) => {
+  if (!proxyConfig) {
+    return skipTlsVerification
+      ? secureDispatcherSkipTlsVerification
+      : secureDispatcher;
+  }
+  return makeSecureDispatcher(skipTlsVerification, proxyConfig);
+};
 
 // Use this for webhook delivery to avoid sending empty cookie headers
 export const getSecureDispatcherNoCookies = (
   skipTlsVerification: boolean = false,
-) =>
-  skipTlsVerification
-    ? secureDispatcherNoCookiesSkipTlsVerification
-    : secureDispatcherNoCookies;
+  proxyConfig?: ProxyConfig | null,
+) => {
+  if (!proxyConfig) {
+    return skipTlsVerification
+      ? secureDispatcherNoCookiesSkipTlsVerification
+      : secureDispatcherNoCookies;
+  }
+  return makeSecureDispatcherNoCookies(skipTlsVerification, proxyConfig);
+};

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -81,6 +81,12 @@ interface UrlModel {
   headers?: { [key: string]: string };
   check_selector?: string;
   skip_tls_verification?: boolean;
+  proxy?: {
+    server: string;
+    username?: string;
+    password?: string;
+  };
+  locale?: string;
 }
 
 let browser: Browser;
@@ -100,7 +106,14 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
+const normalizeProxyServer = (server: string) =>
+  server.includes('://') ? server : `http://${server}`;
+
+const createContext = async (
+  skipTlsVerification: boolean = false,
+  proxy?: UrlModel['proxy'],
+  locale?: string,
+) => {
   const userAgent = new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
@@ -110,16 +123,25 @@ const createContext = async (skipTlsVerification: boolean = false) => {
     ignoreHTTPSErrors: skipTlsVerification,
   };
 
-  if (PROXY_SERVER && PROXY_USERNAME && PROXY_PASSWORD) {
+  const requestProxy = proxy ??
+    (PROXY_SERVER
+      ? {
+          server: PROXY_SERVER,
+          username: PROXY_USERNAME ?? undefined,
+          password: PROXY_PASSWORD ?? undefined,
+        }
+      : undefined);
+
+  if (requestProxy?.server) {
     contextOptions.proxy = {
-      server: PROXY_SERVER,
-      username: PROXY_USERNAME,
-      password: PROXY_PASSWORD,
+      server: normalizeProxyServer(requestProxy.server),
+      ...(requestProxy.username ? { username: requestProxy.username } : {}),
+      ...(requestProxy.password ? { password: requestProxy.password } : {}),
     };
-  } else if (PROXY_SERVER) {
-    contextOptions.proxy = {
-      server: PROXY_SERVER,
-    };
+  }
+
+  if (locale) {
+    contextOptions.locale = locale;
   }
 
   const newContext = await browser.newContext(contextOptions);
@@ -220,7 +242,16 @@ app.get('/health', async (req: Request, res: Response) => {
 });
 
 app.post('/scrape', async (req: Request, res: Response) => {
-  const { url, wait_after_load = 0, timeout = 15000, headers, check_selector, skip_tls_verification = false }: UrlModel = req.body;
+  const {
+    url,
+    wait_after_load = 0,
+    timeout = 15000,
+    headers,
+    check_selector,
+    skip_tls_verification = false,
+    proxy,
+    locale,
+  }: UrlModel = req.body;
 
   console.log(`================= Scrape Request =================`);
   console.log(`URL: ${url}`);
@@ -229,6 +260,8 @@ app.post('/scrape', async (req: Request, res: Response) => {
   console.log(`Headers: ${headers ? JSON.stringify(headers) : 'None'}`);
   console.log(`Check Selector: ${check_selector ? check_selector : 'None'}`);
   console.log(`Skip TLS Verification: ${skip_tls_verification}`);
+  console.log(`Proxy: ${proxy ? JSON.stringify(proxy) : 'None'}`);
+  console.log(`Locale: ${locale ?? 'None'}`);
   console.log(`==================================================`);
 
   if (!url) {
@@ -253,7 +286,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, proxy, locale);
     page = await requestContext.newPage();
 
     if (headers) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable proxy-backed location support for fetch and Playwright so we can apply country and language preferences. If a proxy isn’t available, location is marked unsupported and a warning is returned.

- **New Features**
  - Added per-request proxy config for fetch and Playwright; country augments credentials and proxy server is normalized.
  - Merged Accept-Language from location and passed locale to Playwright.
  - Engine selection flags location as unsupported when no proxy is configured; tests cover proxy and no-proxy paths.
  - Updated schema to treat empty location as undefined (removed “us-generic” default) and simplified robots.txt engine order.

<sup>Written for commit 954f19e105a87133880b2d5644db0d3726ef8f93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

