### PR TITLE
feat(api): fire-engine action metadata

### DIFF
--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -368,6 +368,12 @@ const actionSchema = z.union([
 
 export type Action = z.infer<typeof actionSchema>;
 
+export type InternalAction = Action & {
+  metadata?: {
+    [key: string]: unknown;
+  };
+};
+
 const actionsSchema = z
   .array(actionSchema)
   .refine(actions => actions.length <= MAX_ACTIONS, {

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -2,7 +2,7 @@ import { Logger } from "winston";
 import * as Sentry from "@sentry/node";
 import { z } from "zod";
 
-import { Action } from "../../../../controllers/v1/types";
+import { InternalAction } from "../../../../controllers/v1/types";
 import { robustFetch } from "../../lib/fetch";
 import { MockState } from "../../lib/mock";
 import { getDocFromGCS } from "../../../../lib/gcs-jobs";
@@ -50,7 +50,7 @@ export type FireEngineScrapeRequestCommon = {
 export type FireEngineScrapeRequestChromeCDP = {
   engine: "chrome-cdp";
   skipTlsVerification?: boolean;
-  actions?: Action[];
+  actions?: InternalAction[];
   blockMedia?: boolean;
   mobile?: boolean;
   disableSmartWaitCache?: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for action metadata in the Fire Engine (chrome-cdp) and mark internal actions with a metadata flag. The public Action schema stays the same; user-provided actions are forwarded without metadata.

- **New Features**
  - Added InternalAction (Action + optional metadata) for engine internals.
  - chrome-cdp now accepts InternalAction[]; strips metadata from user actions; branding executeJavascript is tagged with metadata { __firecrawl_internal: true }.
  - Updated scrape request types to use InternalAction[].

<sup>Written for commit 6f4b3f48b4c138eb6439e8b4a977bac06058cfd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

