### PR TITLE
Return 400 when actions are requested but no engines support then

### DIFF
--- a/apps/api/src/__tests__/snips/lib.ts
+++ b/apps/api/src/__tests__/snips/lib.ts
@@ -23,6 +23,7 @@ export const TEST_PRODUCTION = !TEST_SELF_HOST;
 
 // TODO: do we want to run AI tests when users run this command locally? It may lead to increased spending for them, depending on configuration
 export const HAS_AI = !!(config.OPENAI_API_KEY || config.OLLAMA_BASE_URL);
+export const HAS_FIRE_ENGINE = !!config.FIRE_ENGINE_BETA_URL;
 export const HAS_PLAYWRIGHT = !!config.PLAYWRIGHT_MICROSERVICE_URL;
 export const HAS_PROXY = !!config.PROXY_SERVER;
 

--- a/apps/api/src/__tests__/snips/v1/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v1/scrape.test.ts
@@ -7,6 +7,7 @@ import {
   TEST_PRODUCTION,
   TEST_SELF_HOST,
   TEST_SUITE_WEBSITE,
+  HAS_FIRE_ENGINE,
   HAS_PLAYWRIGHT,
   HAS_PROXY,
   HAS_AI,
@@ -228,6 +229,31 @@ describe("Scrape tests", () => {
       );
 
       expect(response.markdown).toContain("Firecrawl");
+    },
+    scrapeTimeout,
+  );
+
+  itIf(TEST_SELF_HOST && !HAS_FIRE_ENGINE)(
+    "rejects actions when fire-engine is not configured",
+    async () => {
+      const raw = await scrapeRaw(
+        {
+          url: "https://example.com",
+          timeout: scrapeTimeout,
+          actions: [
+            {
+              type: "wait",
+              milliseconds: 1000,
+            },
+          ],
+        },
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
+      expect(raw.body.code).toBe("SCRAPE_ACTIONS_NOT_SUPPORTED");
+      expect(raw.body.error).toContain("Actions are not supported");
     },
     scrapeTimeout,
   );

--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -7,6 +7,7 @@ import {
   TEST_PRODUCTION,
   TEST_SELF_HOST,
   TEST_SUITE_WEBSITE,
+  HAS_FIRE_ENGINE,
   HAS_PLAYWRIGHT,
   HAS_PROXY,
   HAS_AI,
@@ -274,6 +275,30 @@ describe("Scrape tests", () => {
       );
 
       expect(response.markdown).toContain("Firecrawl");
+    },
+    scrapeTimeout,
+  );
+
+  itIf(TEST_SELF_HOST && !HAS_FIRE_ENGINE)(
+    "rejects actions when fire-engine is not configured",
+    async () => {
+      const raw = await scrapeRaw(
+        {
+          url: "https://example.com",
+          actions: [
+            {
+              type: "wait",
+              milliseconds: 1000,
+            },
+          ],
+        },
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
+      expect(raw.body.code).toBe("SCRAPE_ACTIONS_NOT_SUPPORTED");
+      expect(raw.body.error).toContain("Actions are not supported");
     },
     scrapeTimeout,
   );

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -193,6 +193,14 @@ export async function scrapeController(
         });
       }
 
+      if (e.code === "SCRAPE_ACTIONS_NOT_SUPPORTED") {
+        return res.status(400).json({
+          success: false,
+          code: e.code,
+          error: e.message,
+        });
+      }
+
       return res.status(e.code === "SCRAPE_TIMEOUT" ? 408 : 500).json({
         success: false,
         code: e.code,

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -296,6 +296,17 @@ export async function scrapeController(
             });
           }
 
+          if (e.code === "SCRAPE_ACTIONS_NOT_SUPPORTED") {
+            setSpanAttributes(span, {
+              "scrape.status_code": 400,
+            });
+            return res.status(400).json({
+              success: false,
+              code: e.code,
+              error: e.message,
+            });
+          }
+
           const statusCode = e.code === "SCRAPE_TIMEOUT" ? 408 : 500;
           setSpanAttributes(span, {
             "scrape.status_code": statusCode,

--- a/apps/api/src/lib/error-serde.ts
+++ b/apps/api/src/lib/error-serde.ts
@@ -1,4 +1,5 @@
 import {
+  ActionsNotSupportedError,
   CrawlDenialError,
   ErrorCodes,
   MapTimeoutError,
@@ -44,6 +45,7 @@ const errorMap: Record<ErrorCodes, any> = {
   SCRAPE_UNSUPPORTED_FILE_ERROR: UnsupportedFileError,
   SCRAPE_NO_CACHED_DATA: NoCachedDataError,
   SCRAPE_ACTION_ERROR: ActionError,
+  SCRAPE_ACTIONS_NOT_SUPPORTED: ActionsNotSupportedError,
   SCRAPE_RACED_REDIRECT_ERROR: RacedRedirectError,
   SCRAPE_SITEMAP_ERROR: SitemapError,
   CRAWL_DENIAL: CrawlDenialError,

--- a/apps/api/src/lib/error.ts
+++ b/apps/api/src/lib/error.ts
@@ -18,6 +18,7 @@ export type ErrorCodes =
   | "SCRAPE_RACED_REDIRECT_ERROR"
   | "SCRAPE_NO_CACHED_DATA"
   | "SCRAPE_SITEMAP_ERROR"
+  | "SCRAPE_ACTIONS_NOT_SUPPORTED"
   | "CRAWL_DENIAL"
   | "BAD_REQUEST_INVALID_JSON"
   | "BAD_REQUEST";
@@ -168,6 +169,25 @@ export class CrawlDenialError extends TransportableError {
     data: ReturnType<typeof this.prototype.serialize> & { reason: string },
   ) {
     const x = new CrawlDenialError(data.reason);
+    x.stack = data.stack;
+    return x;
+  }
+}
+
+export class ActionsNotSupportedError extends TransportableError {
+  constructor(message: string) {
+    super("SCRAPE_ACTIONS_NOT_SUPPORTED", message);
+  }
+
+  serialize() {
+    return super.serialize();
+  }
+
+  static deserialize(
+    _: ErrorCodes,
+    data: ReturnType<typeof this.prototype.serialize>,
+  ) {
+    const x = new ActionsNotSupportedError(data.message);
     x.stack = data.stack;
     return x;
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return 400 when actions are requested but no available engines support them (e.g., Fire Engine not configured). Adds a clear error with code SCRAPE_ACTIONS_NOT_SUPPORTED and updates tests.

- **Bug Fixes**
  - Added an actions support check in scrapeURL; throws ActionsNotSupportedError when no engines support actions.
  - v1/v2 controllers return HTTP 400 with code SCRAPE_ACTIONS_NOT_SUPPORTED and the error message; v2 sets scrape.status_code telemetry.
  - Added tests for self-hosted setups without Fire Engine to assert 400 and the new code.
  - Added ActionsNotSupportedError and error-serde mapping.
  - Test helpers now detect HAS_FIRE_ENGINE.

<sup>Written for commit 97ae210ab67c1b8a666aea0a52e15518ad8bd8ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

