### PR TITLE
chore: remove DB webhook logic

### DIFF
--- a/apps/api/src/services/ab-test-comparison.ts
+++ b/apps/api/src/services/ab-test-comparison.ts
@@ -135,11 +135,13 @@ async function runComparison(
       `${AB_LOG_PREFIX} Content mismatch detected (${diffMessage})`,
       diffLogData,
     );
-  } else {
+  } else if (contentDiff.diffPercentage! > 0) {
     abLogger.info(
       `${AB_LOG_PREFIX} Minor content differences (${diffMessage})`,
       diffLogData,
     );
+  } else {
+    abLogger.info(`${AB_LOG_PREFIX} Content identical`, baseLogData);
   }
 }
 

--- a/apps/api/src/services/webhook/config.ts
+++ b/apps/api/src/services/webhook/config.ts
@@ -1,4 +1,3 @@
-import { logger as _logger } from "../../lib/logger";
 import { supabase_rr_service } from "../supabase";
 import { WebhookConfig } from "./types";
 
@@ -11,7 +10,6 @@ export async function getWebhookConfig(
   // priority:
   // - webhook
   // - self-hosted environment variable
-  // - db webhook (if enabled)
   if (webhook) {
     return { config: webhook, secret: await getHmacSecret(teamId) };
   }
@@ -32,31 +30,7 @@ export async function getWebhookConfig(
     };
   }
 
-  if (config.USE_DB_AUTHENTICATION) {
-    const dbConfig = await fetchWebhookFromDb(teamId);
-    if (dbConfig) {
-      return { config: dbConfig, secret: await getHmacSecret(teamId) };
-    }
-  }
-
   return null;
-}
-
-async function fetchWebhookFromDb(
-  teamId: string,
-): Promise<WebhookConfig | null> {
-  try {
-    const { data, error } = await supabase_rr_service
-      .from("webhooks")
-      .select("url, headers, metadata, events")
-      .eq("team_id", teamId)
-      .limit(1)
-      .single();
-
-    return error || !data ? null : data;
-  } catch {
-    return null;
-  }
 }
 
 async function getHmacSecret(teamId: string): Promise<string | undefined> {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the database-backed webhook path and simplified webhook resolution to use the provided webhook or self-hosted config. Also improved AB test comparison logging to correctly distinguish identical content from minor differences.

- **Refactors**
  - Removed DB webhook fetch logic from webhook config; now only uses request webhook or environment config.
  - Deleted unused logger import.

- **Bug Fixes**
  - Log “Minor content differences” only when diffPercentage > 0; otherwise log “Content identical.”

<sup>Written for commit d5f7afe53ae1a1b97a582f4ff8b7c0df9a812933. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

