### PR TITLE
fix: a/b test logic

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -227,7 +227,6 @@ export async function fireEngineScrape<
         {
           content: successParse.data.content,
           pageStatusCode: successParse.data.pageStatusCode,
-          timeTaken: successParse.data.timeTaken,
         },
         productionTimeTaken,
         abTest.mirrorPromise,

--- a/apps/api/src/services/ab-test-comparison.ts
+++ b/apps/api/src/services/ab-test-comparison.ts
@@ -1,15 +1,11 @@
 import { Logger } from "winston";
-import gitDiff from "git-diff";
-import parseDiff from "parse-diff";
 
 const AB_LOG_PREFIX = "[FE_AB_COMPARE]";
-const DIFF_THRESHOLD_PERCENT = 5;
-const MAX_CONTENT_SIZE = 1000000; // 1 MB
+const MAX_CONTENT_SIZE = 1_000_000; // 1 MB
 
 export interface FireEngineResponse {
   content: string;
   pageStatusCode: number;
-  timeTaken: number;
 }
 
 export interface MirrorResult {
@@ -18,131 +14,8 @@ export interface MirrorResult {
   timeTaken: number;
 }
 
-interface ContentDiffResult {
-  identical: boolean;
-  skipped?: boolean;
-  skipReason?: string;
-  addedLines?: number;
-  removedLines?: number;
-  diffPercentage?: number;
-}
-
-function computeContentDiff(
-  productionContent: string,
-  mirrorContent: string,
-): ContentDiffResult {
-  // Skip if content too large
-  if (
-    productionContent.length > MAX_CONTENT_SIZE ||
-    mirrorContent.length > MAX_CONTENT_SIZE
-  ) {
-    return { identical: false, skipped: true, skipReason: "content_too_large" };
-  }
-
-  // Tier 1: Quick normalized comparison
-  const normalize = (s: string) => s.replace(/\s+/g, " ").trim();
-  if (normalize(productionContent) === normalize(mirrorContent)) {
-    return { identical: true };
-  }
-
-  // Tier 2: Compute line diff
-  const diffText = gitDiff(productionContent, mirrorContent, {
-    color: false,
-    wordDiff: false,
-  });
-
-  if (!diffText) {
-    return { identical: true };
-  }
-
-  const parsed = parseDiff(diffText);
-  let addedLines = 0;
-  let removedLines = 0;
-
-  for (const file of parsed) {
-    addedLines += file.additions;
-    removedLines += file.deletions;
-  }
-
-  const totalLines = productionContent.split("\n").length;
-  const diffPercentage =
-    totalLines > 0 ? ((addedLines + removedLines) / totalLines) * 100 : 0;
-
-  return {
-    identical: false,
-    addedLines,
-    removedLines,
-    diffPercentage: Math.round(diffPercentage * 100) / 100,
-  };
-}
-
-async function runComparison(
-  url: string,
-  productionResponse: FireEngineResponse,
-  productionTimeTaken: number,
-  mirrorPromise: Promise<MirrorResult>,
-  abLogger: Logger,
-): Promise<void> {
-  const mirrorResult = await mirrorPromise;
-
-  if (mirrorResult.error || !mirrorResult.response) {
-    abLogger.warn(
-      `${AB_LOG_PREFIX} Mirror request failed - unable to compare`,
-      {
-        url,
-        error: mirrorResult.error?.message ?? "unknown",
-        prod_ms: productionTimeTaken,
-      },
-    );
-    return;
-  }
-
-  const contentDiff = computeContentDiff(
-    productionResponse.content,
-    mirrorResult.response.content,
-  );
-
-  const baseLogData = {
-    url,
-    prod_ms: productionTimeTaken,
-    mirror_ms: mirrorResult.timeTaken,
-    diff_ms: mirrorResult.timeTaken - productionTimeTaken,
-  };
-
-  if (contentDiff.skipped) {
-    abLogger.info(`${AB_LOG_PREFIX} Comparison skipped - content too large`, {
-      ...baseLogData,
-      skip_reason: contentDiff.skipReason,
-    });
-    return;
-  }
-
-  if (contentDiff.identical) {
-    abLogger.info(`${AB_LOG_PREFIX} Content identical`, baseLogData);
-    return;
-  }
-
-  const diffLogData = {
-    ...baseLogData,
-    diff_pct: contentDiff.diffPercentage,
-    added: contentDiff.addedLines,
-    removed: contentDiff.removedLines,
-  };
-  const diffMessage = `+${contentDiff.addedLines}/-${contentDiff.removedLines} lines, ${contentDiff.diffPercentage}%`;
-
-  if (contentDiff.diffPercentage! > DIFF_THRESHOLD_PERCENT) {
-    abLogger.warn(
-      `${AB_LOG_PREFIX} Content mismatch detected (${diffMessage})`,
-      diffLogData,
-    );
-  } else if (contentDiff.diffPercentage! > 0) {
-    abLogger.info(
-      `${AB_LOG_PREFIX} Minor content differences (${diffMessage})`,
-      diffLogData,
-    );
-  } else {
-    abLogger.info(`${AB_LOG_PREFIX} Content identical`, baseLogData);
-  }
+function normalizeContent(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
 }
 
 export function scheduleABComparison(
@@ -154,16 +27,51 @@ export function scheduleABComparison(
 ): void {
   const abLogger = logger.child({ method: "ABTestComparison" });
 
-  runComparison(
-    url,
-    productionResponse,
-    productionTimeTaken,
-    mirrorPromise,
-    abLogger,
-  ).catch(error => {
-    abLogger.error(`${AB_LOG_PREFIX} comparison failed unexpectedly`, {
-      error,
-      url,
+  mirrorPromise
+    .then(mirrorResult => {
+      const baseLogData = {
+        url,
+        prod_ms: productionTimeTaken,
+        mirror_ms: mirrorResult.timeTaken,
+        diff_ms: mirrorResult.timeTaken - productionTimeTaken,
+      };
+
+      if (mirrorResult.error || !mirrorResult.response) {
+        abLogger.warn(`${AB_LOG_PREFIX} Mirror request failed`, {
+          ...baseLogData,
+          error: mirrorResult.error?.message ?? "unknown",
+        });
+        return;
+      }
+
+      // Skip comparison if content too large
+      if (
+        productionResponse.content.length > MAX_CONTENT_SIZE ||
+        mirrorResult.response.content.length > MAX_CONTENT_SIZE
+      ) {
+        return;
+      }
+
+      const prodNormalized = normalizeContent(productionResponse.content);
+      const mirrorNormalized = normalizeContent(mirrorResult.response.content);
+      const identical = prodNormalized === mirrorNormalized;
+
+      if (identical) {
+        abLogger.info(`${AB_LOG_PREFIX} Content identical`, baseLogData);
+      } else {
+        abLogger.warn(`${AB_LOG_PREFIX} Content mismatch`, {
+          ...baseLogData,
+          prod_len: productionResponse.content.length,
+          mirror_len: mirrorResult.response.content.length,
+          prod_status: productionResponse.pageStatusCode,
+          mirror_status: mirrorResult.response.pageStatusCode,
+        });
+      }
+    })
+    .catch(error => {
+      abLogger.error(`${AB_LOG_PREFIX} Comparison failed unexpectedly`, {
+        error,
+        url,
+      });
     });
-  });
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes A/B test logic for fire-engine and scrapeURL by simplifying content comparison and using the correct config-driven behavior. Improves reliability, logging, and cleans up staging jobs.

- **Bug Fixes**
  - Compare normalized content only; skip when >1 MB; log status codes and timing.
  - Use correct config values for rates, hosts, and compare flag; stable timeout/abort; compute timeTaken locally.
  - Fetch missing content from GCS when docUrl is returned and delete the staging job after completion.

- **Refactors**
  - Removed git-diff/parse-diff logic and the timeTaken field from FireEngineResponse; streamlined promise handling in comparison.
  - Minor logging and naming updates (ABTestFireEngine).

<sup>Written for commit 30b92258285a2a2d578c116e0ed183e760cb85f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

