### PR TITLE
fix(scraper): proxy=auto not trying stealth in some cases

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -1120,6 +1120,20 @@ export async function scrapeURL(
                 throw error;
               }
             }
+          } else if (
+            error instanceof NoEnginesLeftError &&
+            meta.options.proxy === "auto" &&
+            !meta.featureFlags.has("stealthProxy") &&
+            (meta.internalOptions.forceEngine === undefined ||
+              Array.isArray(meta.internalOptions.forceEngine))
+          ) {
+            // When proxy="auto" and all basic proxy engines failed,
+            // retry with stealth proxy enabled
+            meta.logger.info(
+              "All engines failed with proxy=auto, retrying with stealthProxy",
+              { error, existingFlags: Array.from(meta.featureFlags) },
+            );
+            meta.featureFlags.add("stealthProxy");
           } else {
             throw error;
           }


### PR DESCRIPTION
`proxy="auto"` was supposed to try basic proxy first, then escalate to stealth if it failed. But this only worked when engines got HTTP 401/403/429.

If engines failed with connection errors like `ERR_TUNNEL_CONNECTION_FAILED` (blocked at network level, we have seen this for some websites), all engines just fail and throw NoEnginesLeftError. Not trying stealth proxy, stealth looks to be working good when we hit this error.

The Fix, catch `NoEnginesLeftError` when `proxy="auto"` and stealth hasn't been tried yet, set stealthProxy flag and let the retry loop continue.

Test is left commented out, had some trouble getting things to run without fireengine.

Let me know if you have any feedback/questions 🙌


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes proxy=auto fallback to try stealth when all basic proxy engines fail on connection errors (e.g., ERR_TUNNEL_CONNECTION_FAILED). This reduces NoEnginesLeftError and improves scrape success on network-level proxy blocks.

- **Bug Fixes**
  - When proxy=auto and engines exhaust with NoEnginesLeftError, enable stealthProxy and continue the retry loop.
  - Fallback now triggers on connection failures, not only HTTP 401/403/429.
  - Added an info log when switching to stealth; only applies when no single forceEngine is set.

<sup>Written for commit 492ec288f2f95bf1bda6bb43c33b8376da28ee10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

