### PR TITLE
Fix crawl status transient Job not found

### DIFF
--- a/apps/api/src/controllers/v1/__tests__/crawl-status-consistency.test.ts
+++ b/apps/api/src/controllers/v1/__tests__/crawl-status-consistency.test.ts
@@ -1,0 +1,135 @@
+import type { Response } from "express";
+import type { RequestWithAuth } from "../types";
+import { crawlStatusController } from "../crawl-status";
+import { getCrawl, getCrawlExpiry } from "../../../lib/crawl-redis";
+import { crawlGroup, normalizeOwnerId, scrapeQueue } from "../../../services/worker/nuq";
+
+jest.mock("../../../lib/crawl-redis", () => ({
+  getCrawl: jest.fn(),
+  getCrawlExpiry: jest.fn(),
+}));
+
+jest.mock("../../../services/worker/nuq", () => ({
+  crawlGroup: {
+    getGroup: jest.fn(),
+  },
+  scrapeQueue: {
+    getGroupAnyJob: jest.fn(),
+    getGroupNumericStats: jest.fn(),
+    getCrawlJobsForListing: jest.fn(),
+  },
+  normalizeOwnerId: jest.fn((x: string) => x),
+}));
+
+describe("v1 crawlStatusController consistency", () => {
+  const buildReq = (jobId: string, teamId = "bypass") =>
+    ({
+      params: { jobId },
+      query: {},
+      auth: { team_id: teamId },
+      protocol: "http",
+      get: jest.fn().mockReturnValue("localhost"),
+    }) as unknown as RequestWithAuth<{ jobId: string }, any, any>;
+
+  const buildRes = () =>
+    ({
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }) as unknown as Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 when Redis crawl is missing but any NuQ job exists", async () => {
+    const jobId = "job-123";
+    (crawlGroup.getGroup as jest.Mock).mockResolvedValue({
+      id: jobId,
+      status: "active",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      ownerId: "bypass",
+      ttl: 24 * 60 * 60 * 1000,
+      expiresAt: new Date("2026-01-02T00:00:00Z"),
+    });
+    (scrapeQueue.getGroupAnyJob as jest.Mock).mockResolvedValue({
+      id: "kickoff-1",
+      status: "queued",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      priority: 0,
+      data: { zeroDataRetention: false },
+      groupId: jobId,
+      ownerId: "bypass",
+    });
+    (getCrawl as jest.Mock).mockResolvedValue(null);
+    (scrapeQueue.getGroupNumericStats as jest.Mock).mockResolvedValue({});
+    (scrapeQueue.getCrawlJobsForListing as jest.Mock).mockResolvedValue([]);
+    (normalizeOwnerId as jest.Mock).mockReturnValue("bypass");
+
+    const req = buildReq(jobId);
+    const res = buildRes();
+
+    await crawlStatusController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        status: "scraping",
+        total: 0,
+        completed: 0,
+      }),
+    );
+    // Should not depend on Redis TTL when `sc` is missing
+    expect(getCrawlExpiry).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 when group is missing but a job exists for the group", async () => {
+    const jobId = "job-123";
+    const createdAt = new Date("2026-01-01T00:00:00Z");
+
+    (crawlGroup.getGroup as jest.Mock).mockResolvedValue(null);
+    (scrapeQueue.getGroupAnyJob as jest.Mock).mockResolvedValue({
+      id: "kickoff-1",
+      status: "queued",
+      createdAt,
+      priority: 0,
+      data: { zeroDataRetention: false },
+      groupId: jobId,
+      ownerId: "bypass",
+    });
+    (getCrawl as jest.Mock).mockResolvedValue(null);
+    (scrapeQueue.getGroupNumericStats as jest.Mock).mockResolvedValue({});
+    (scrapeQueue.getCrawlJobsForListing as jest.Mock).mockResolvedValue([]);
+
+    const req = buildReq(jobId);
+    const res = buildRes();
+
+    await crawlStatusController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, status: "scraping" }),
+    );
+
+    const expiresAt = (res.json as jest.Mock).mock.calls[0]![0]!.expiresAt as string;
+    expect(new Date(expiresAt).getTime()).toBe(createdAt.getTime() + 24 * 60 * 60 * 1000);
+  });
+
+  it("returns 404 when no backing state exists", async () => {
+    const jobId = "job-123";
+    (crawlGroup.getGroup as jest.Mock).mockResolvedValue(null);
+    (scrapeQueue.getGroupAnyJob as jest.Mock).mockResolvedValue(null);
+    (getCrawl as jest.Mock).mockResolvedValue(null);
+
+    const req = buildReq(jobId);
+    const res = buildRes();
+
+    await crawlStatusController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, error: "Job not found" }),
+    );
+  });
+});
+

--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -27,6 +27,7 @@ import {
   NuQJob,
   NuQJobStatus,
   crawlGroup,
+  normalizeOwnerId,
 } from "../../services/worker/nuq";
 import { ScrapeJobSingleUrls } from "../../types";
 configDotenv();
@@ -175,23 +176,52 @@ export async function crawlStatusController(
       ? start + parseInt(req.query.limit, 10) - 1
       : undefined;
 
-  const group = await crawlGroup.getGroup(req.params.jobId);
-  const groupAnyJob = await scrapeQueue.getGroupAnyJob(
-    req.params.jobId,
-    req.auth.team_id,
-  );
-  const sc = await getCrawl(req.params.jobId);
+  const jobId = req.params.jobId;
+  const [group, groupAnyJob, sc] = await Promise.all([
+    crawlGroup.getGroup(jobId),
+    scrapeQueue.getGroupAnyJob(jobId, req.auth.team_id),
+    getCrawl(jobId),
+  ]);
 
-  if (!group || (!groupAnyJob && (!sc || sc.team_id !== req.auth.team_id))) {
+  // Authorization (and existence) can come from multiple sources:
+  // - `sc` (Redis) is the most immediate for newly created crawls
+  // - `groupAnyJob` (NuQ) is useful when Redis state is missing/evicted
+  // - `group` (NuQ) allows access even before any single_urls jobs exist
+  const normalizedTeamOwnerId = normalizeOwnerId(req.auth.team_id);
+  const authorized =
+    (sc?.team_id === req.auth.team_id) ||
+    groupAnyJob !== null ||
+    (group !== null &&
+      normalizedTeamOwnerId !== null &&
+      group.ownerId === normalizedTeamOwnerId);
+
+  if (!authorized) {
     return res.status(404).json({ success: false, error: "Job not found" });
   }
 
   const zeroDataRetention = !!(
-    groupAnyJob?.data?.zeroDataRetention ?? sc?.zeroDataRetention
+    groupAnyJob?.data?.zeroDataRetention ?? sc?.zeroDataRetention ?? false
   );
 
+  let expiresAt: string;
+  if (sc) {
+    expiresAt = (await getCrawlExpiry(jobId)).toISOString();
+  } else if (group) {
+    const expiryDate =
+      group.expiresAt ?? new Date(group.createdAt.getTime() + group.ttl);
+    expiresAt = expiryDate.toISOString();
+  } else if (groupAnyJob) {
+    // Best-effort fallback: NuQ groups default to 24h TTL.
+    expiresAt = new Date(
+      groupAnyJob.createdAt.getTime() + 24 * 60 * 60 * 1000,
+    ).toISOString();
+  } else {
+    // Should be unreachable because `authorized` would be false, but keep safe.
+    expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  }
+
   const numericStats = await scrapeQueue.getGroupNumericStats(
-    req.params.jobId,
+    jobId,
     logger.child({ zeroDataRetention }),
   );
 
@@ -205,13 +235,14 @@ export async function crawlStatusController(
       )
     : null;
 
+  const groupStatus = group?.status ?? "active";
   let outputBulkA: {
     status?: "completed" | "scraping" | "cancelled";
     completed?: number;
     total?: number;
     creditsUsed?: number;
   } = {
-    status: group.status === "active" ? "scraping" : group.status,
+    status: groupStatus === "active" ? "scraping" : groupStatus,
     completed: numericStats.completed ?? 0,
     total:
       (numericStats.completed ?? 0) +
@@ -227,7 +258,7 @@ export async function crawlStatusController(
   };
 
   const doneJobs = await scrapeQueue.getCrawlJobsForListing(
-    req.params.jobId,
+    jobId,
     end !== undefined ? end - start + 1 : 100,
     start,
     logger.child({ zeroDataRetention }),
@@ -284,7 +315,7 @@ export async function crawlStatusController(
     completed: outputBulkA.completed ?? 0,
     total: outputBulkA.total ?? 0,
     creditsUsed: outputBulkA.creditsUsed ?? 0,
-    expiresAt: (await getCrawlExpiry(req.params.jobId)).toISOString(),
+    expiresAt,
     next: outputBulkB.next,
     data: outputBulkB.data,
   });

--- a/apps/api/src/controllers/v2/__tests__/crawl-status-consistency.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/crawl-status-consistency.test.ts
@@ -1,0 +1,101 @@
+import type { Response } from "express";
+import type { RequestWithAuth } from "../types";
+import { crawlStatusController } from "../crawl-status";
+import { getCrawl, getCrawlExpiry } from "../../../lib/crawl-redis";
+import { crawlGroup, normalizeOwnerId, scrapeQueue } from "../../../services/worker/nuq";
+import { redisEvictConnection } from "../../../services/redis";
+
+jest.mock("../../../lib/crawl-redis", () => ({
+  getCrawl: jest.fn(),
+  getCrawlExpiry: jest.fn(),
+}));
+
+jest.mock("../../../services/worker/nuq", () => ({
+  crawlGroup: {
+    getGroup: jest.fn(),
+  },
+  scrapeQueue: {
+    getGroupAnyJob: jest.fn(),
+    getGroupNumericStats: jest.fn(),
+    getCrawlJobsForListing: jest.fn(),
+  },
+  normalizeOwnerId: jest.fn((x: string) => x),
+}));
+
+jest.mock("../../../services/redis", () => ({
+  redisEvictConnection: {
+    smembers: jest.fn(),
+  },
+}));
+
+describe("v2 crawlStatusController consistency", () => {
+  const buildReq = (jobId: string, teamId = "bypass") =>
+    ({
+      params: { jobId },
+      query: {},
+      auth: { team_id: teamId },
+      protocol: "http",
+      get: jest.fn().mockReturnValue("localhost"),
+    }) as unknown as RequestWithAuth<{ jobId: string }, any, any>;
+
+  const buildRes = () =>
+    ({
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }) as unknown as Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (redisEvictConnection.smembers as jest.Mock).mockResolvedValue([]);
+  });
+
+  it("returns 200 when Redis crawl is missing but any NuQ job exists", async () => {
+    const jobId = "123e4567-e89b-12d3-a456-426614174000";
+
+    (crawlGroup.getGroup as jest.Mock).mockResolvedValue({
+      id: jobId,
+      status: "active",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      ownerId: "bypass",
+      ttl: 24 * 60 * 60 * 1000,
+      expiresAt: new Date("2026-01-02T00:00:00Z"),
+    });
+    (scrapeQueue.getGroupAnyJob as jest.Mock).mockResolvedValue({
+      id: "kickoff-1",
+      status: "queued",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      priority: 0,
+      data: { zeroDataRetention: false },
+      groupId: jobId,
+      ownerId: "bypass",
+    });
+    (getCrawl as jest.Mock).mockResolvedValue(null);
+    (scrapeQueue.getGroupNumericStats as jest.Mock).mockResolvedValue({});
+    (scrapeQueue.getCrawlJobsForListing as jest.Mock).mockResolvedValue([]);
+    (normalizeOwnerId as jest.Mock).mockReturnValue("bypass");
+
+    const req = buildReq(jobId);
+    const res = buildRes();
+
+    await crawlStatusController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, status: "scraping" }),
+    );
+    expect(getCrawlExpiry).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for invalid job IDs", async () => {
+    const req = buildReq("not-a-uuid");
+    const res = buildRes();
+
+    await crawlStatusController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, error: "Invalid job ID" }),
+    );
+  });
+});
+

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -54,7 +54,9 @@ type NuQOptions = {
 
 // owner IDs can sometimes be non-UUID, so let's normalize it to avoid query breakage - mogery
 const normalizedUUIDNamespace = "0f38e00e-d7ee-4b77-8a7a-a787a3537ca2";
-function normalizeOwnerId(ownerId: string | undefined | null): string | null {
+export function normalizeOwnerId(
+  ownerId: string | undefined | null,
+): string | null {
   if (typeof ownerId !== "string") return null;
   if (isUUID(ownerId)) return ownerId;
   return uuidv5(ownerId, normalizedUUIDNamespace);
@@ -594,7 +596,6 @@ class NuQ<JobData = any, JobReturnValue = any> {
             FROM ${this.queueName}
             WHERE ${this.queueName}.group_id = $1
               AND ${this.queueName}.owner_id = $2
-              AND ${this.queueName}.data->>'mode' = 'single_urls'
             LIMIT 1;
           `,
           [groupId, normalizeOwnerId(ownerId)],


### PR DESCRIPTION
## Summary
- Make `GET /v1/crawl/:jobId` and `GET /v2/crawl/:jobId` resilient to early consistency gaps by authorizing via crawl group ownership or *any* NuQ job for the crawl (including the initial `kickoff` job).
- Avoid relying on Redis TTL (`getCrawlExpiry`) when the crawl redis state is missing; fall back to NuQ group expiry / best-effort TTL.
- Update `scrapeQueue.getGroupAnyJob` to truly mean “any job”, not only `single_urls`.

## Why
Immediately querying crawl status after creation can intermittently return `Job not found` even for valid IDs. This change removes the transient window where the crawl exists but is not yet queryable.

Fixes #2662

## Test plan
- `pnpm -C apps/api install --ignore-scripts`
- `pnpm -C apps/api exec jest src/controllers/v1/__tests__/crawl-status-consistency.test.ts src/controllers/v2/__tests__/crawl-status-consistency.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes GET /v1 and /v2 crawl/:jobId resilient to early consistency gaps so valid jobs don’t briefly return “Job not found” after creation. Falls back to NuQ group/job state and safe TTLs when Redis is missing. Fixes #2662.

- **Bug Fixes**
  - Authorize by crawl group ownership or any NuQ job for the crawl (including kickoff).
  - Compute expiresAt without Redis when needed (use group.expiresAt/ttl or 24h fallback).
  - getGroupAnyJob now returns any job, not only single_urls.
  - Added v1/v2 tests covering missing Redis/group states and invalid job IDs.

<sup>Written for commit c8a8e5d40f753f02a90fd28ee421f86b156e99ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

