### PR TITLE
fix: handle 415 Unsupported Media Type without retrying

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
@@ -165,6 +165,14 @@ export async function fireEngineCheckStatus(
   const failedParse = failedSchema.safeParse(status);
 
   if (successParse.success) {
+    // Check if this is an unsupported media type error (e.g., binary file)
+    if (
+      successParse.data.pageStatusCode === 415 &&
+      successParse.data.pageError?.startsWith("Unsupported Media Type:")
+    ) {
+      throw new UnsupportedFileError(successParse.data.pageError);
+    }
+
     logger.debug("Scrape succeeded!", { jobId });
     return successParse.data;
   } else if (processingParse.success) {

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -217,6 +217,14 @@ export async function fireEngineScrape<
   const failedParse = failedSchema.safeParse(status);
 
   if (successParse.success) {
+    // Check if this is an unsupported media type error (e.g., binary file)
+    if (
+      successParse.data.pageStatusCode === 415 &&
+      successParse.data.pageError?.startsWith("Unsupported Media Type:")
+    ) {
+      throw new UnsupportedFileError(successParse.data.pageError);
+    }
+
     logger.debug("Scrape succeeded!");
 
     // Schedule A/B comparison if enabled (fire-and-forget)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop retrying scrapes when Fire Engine returns 415 Unsupported Media Type. We now throw UnsupportedFileError immediately for unsupported or binary content to avoid wasted retries.

- **Bug Fixes**
  - Detect 415 + "Unsupported Media Type" and throw UnsupportedFileError in checkStatus and scrape.
  - Prevents unnecessary retry loops and reduces queue noise for non-HTML pages.

<sup>Written for commit be5f44785a7d24c5197d6da2b8f6609e7b0908b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

