### PR TITLE
fix(branding): use spread operator instead of Array.from for Set conversion

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/brandingScript.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/brandingScript.ts
@@ -296,7 +296,9 @@ export const getBrandingScript = () => String.raw`
     pushQ('input, select, textarea, [class*="form-control"]', 25);
     pushQ("h1, h2, h3, p, a", 50);
 
-    return Array.from(picksSet).filter(Boolean);
+    const result = [...picksSet];
+    
+    return result.filter(Boolean);
   };
 
   const getStyleSnapshot = el => {


### PR DESCRIPTION
## Problem
Some pages override `Array.from` with custom implementations that don't handle Sets correctly. When `Array.from(picksSet)` was called, it returned an array containing the Set itself instead of its elements, causing:

```
TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
```

This occurred because the Set object was being passed to `getStyleSnapshot` instead of the actual DOM elements.

## Root Cause
- Some websites override `Array.from` with polyfills or custom implementations (e.g., MooTools)
- These implementations don't properly handle Set objects
- `Array.from(picksSet)` returned `[picksSet]` instead of the Set's elements
- The affected page was using MooTools which overrides `Array.from` with an implementation that doesn't handle Sets correctly

## Solution
Replace `Array.from(picksSet)` with the spread operator `[...picksSet]` which:
- Works correctly even when `Array.from` is overridden (e.g., by MooTools or other libraries)
- Is a standard JavaScript feature that pages can't easily break
- Returns the actual elements from the Set

## Changes
- Changed `return Array.from(picksSet).filter(Boolean);` to `return [...picksSet].filter(Boolean);` in `sampleElements()`

## Testing
Verified that the spread operator correctly converts the Set to an array of Elements even on pages that override `Array.from` (tested on a page using MooTools).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Array.from with the spread operator in brandingScript to correctly convert Sets of elements. Prevents TypeError in getStyleSnapshot on pages that override Array.from (e.g., MooTools).

- **Bug Fixes**
  - Updated sampleElements to return [...picksSet].filter(Boolean).
  - Ensures we get the actual elements, not the Set, even when Array.from is overridden.

<sup>Written for commit 310a6d87b05c300bfda70ed67f41f93b23f81dc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

