### PR TITLE
wip feat: Add deployment steps to use with Valkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dump.rdb
 /mongo-data
 apps/js-sdk/node_modules/
 
+apps/valkey-demo/node_modules/
+
 apps/api/.env.local
 
 apps/test-suite/node_modules/

--- a/apps/valkey-demo/.env.example
+++ b/apps/valkey-demo/.env.example
@@ -1,0 +1,11 @@
+# Firecrawl API Configuration
+FIRECRAWL_API_URL=http://localhost:3002
+FIRECRAWL_API_KEY=fc-test-key
+
+# Valkey/Redis Configuration (uses Firecrawl's Valkey instance)
+VALKEY_URL=redis://localhost:6379
+
+# Demo Configuration
+DEMO_RATE_LIMIT_MAX=10
+DEMO_RATE_LIMIT_WINDOW_MS=60000
+DEMO_CACHE_TTL_SECONDS=3600

--- a/apps/valkey-demo/Dockerfile
+++ b/apps/valkey-demo/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install pnpm
+RUN npm install -g pnpm
+
+# Copy package files
+COPY package.json pnpm-lock.yaml* ./
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY . .
+
+# Build TypeScript
+RUN pnpm run build
+
+# Expose port
+EXPOSE 3030
+
+# Run server
+CMD ["node", "dist/server.js"]

--- a/apps/valkey-demo/README.md
+++ b/apps/valkey-demo/README.md
@@ -1,0 +1,288 @@
+# Firecrawl + Valkey GLIDE Demo
+
+A comprehensive demo showcasing Firecrawl running with [Valkey](https://valkey.io/) using the official [Valkey GLIDE](https://glide.valkey.io/) client. This demonstrates caching, rate limiting, and batch operations as a reference implementation.
+
+## Features
+
+- **Rate Limiting** - Sliding window rate limiter using Valkey sorted sets
+- **Caching** - Cache scrape/crawl results to reduce API calls
+- **Batch Operations** - Process multiple URLs with progress tracking and state persistence
+- **Web UI** - Interactive dashboard to test all features
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js 18+
+- pnpm
+- Docker (for running Firecrawl + Valkey)
+
+### 1. Start Firecrawl with Valkey
+
+From the Firecrawl root directory:
+
+```bash
+# Ensure Valkey is enabled in docker-compose.yaml (it is by default)
+docker compose up -d
+```
+
+This starts:
+- Firecrawl API on `localhost:3002`
+- Valkey on `localhost:6379`
+
+### 2. Setup the Demo
+
+```bash
+cd apps/valkey-demo
+pnpm install
+cp .env.example .env
+```
+
+### 3. Run the Demo
+
+**Web UI (recommended):**
+```bash
+pnpm run server
+# Open http://localhost:3030
+```
+
+**CLI demos:**
+```bash
+pnpm run demo:all          # Run all demos
+pnpm run demo:rate-limit   # Rate limiting only
+pnpm run demo:scrape       # Caching demo
+pnpm run demo:crawl        # Crawl state tracking
+pnpm run demo:batch        # Batch operations
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FIRECRAWL_API_URL` | `http://localhost:3002` | Firecrawl API endpoint |
+| `FIRECRAWL_API_KEY` | `fc-test-key` | API key for authentication |
+| `VALKEY_URL` | `redis://localhost:6379` | Valkey connection URL |
+| `DEMO_RATE_LIMIT_MAX` | `10` | Max requests per window |
+| `DEMO_RATE_LIMIT_WINDOW_MS` | `60000` | Rate limit window (ms) |
+| `DEMO_CACHE_TTL_SECONDS` | `3600` | Cache TTL in seconds |
+
+### Connecting to Different Valkey Instances
+
+**Local Valkey:**
+```env
+VALKEY_URL=redis://localhost:6379
+```
+
+**AWS ElastiCache (Valkey mode):**
+```env
+VALKEY_URL=rediss://your-cluster.cache.amazonaws.com:6379
+```
+
+**AWS MemoryDB:**
+```env
+VALKEY_URL=rediss://your-cluster.memorydb.amazonaws.com:6379
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Demo Application                         │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
+│  │ Rate Limiter│  │   Cache     │  │   Batch Manager     │  │
+│  │  (sorted    │  │  (string    │  │  (hash + set        │  │
+│  │   sets)     │  │   keys)     │  │   structures)       │  │
+│  └──────┬──────┘  └──────┬──────┘  └──────────┬──────────┘  │
+│         │                │                     │             │
+│         └────────────────┼─────────────────────┘             │
+│                          │                                   │
+│                   Valkey GLIDE Client                        │
+└──────────────────────────┼───────────────────────────────────┘
+                           │
+              ┌────────────┴────────────┐
+              │                         │
+              ▼                         ▼
+       ┌─────────────┐          ┌─────────────┐
+       │   Valkey    │          │  Firecrawl  │
+       │   :6379     │          │  API :3002  │
+       └─────────────┘          └─────────────┘
+```
+
+## Demo Components
+
+### Rate Limiter (`src/services/rate-limiter.ts`)
+
+Implements sliding window rate limiting using Valkey sorted sets:
+
+```typescript
+const rateLimiter = new RateLimiter(10, 60000); // 10 req/min
+const result = await rateLimiter.checkLimit('user-123');
+// { allowed: true, remaining: 9, resetAt: 1234567890 }
+```
+
+**Valkey commands used:** `ZREMRANGEBYSCORE`, `ZCARD`, `ZADD`, `PEXPIRE`
+
+### Cache Service (`src/services/cache-service.ts`)
+
+Caches Firecrawl results with configurable TTL:
+
+```typescript
+const cache = new CacheService(3600); // 1 hour TTL
+const cached = await cache.getCachedScrape(url);
+if (!cached) {
+  const result = await firecrawl.scrape(url);
+  await cache.cacheScrapeResult(url, result);
+}
+```
+
+**Valkey commands used:** `GET`, `SET` with `EX`, `SCAN`, `DEL`
+
+### Batch Manager (`src/services/batch-manager.ts`)
+
+Manages batch scraping jobs with state persistence:
+
+```typescript
+const batchManager = new BatchManager();
+const batchId = await batchManager.createBatch(urls);
+const result = await batchManager.processBatch(batchId);
+```
+
+**Valkey commands used:** `HSET`, `HGET`, `SADD`, `SREM`, `SMEMBERS`
+
+## API Endpoints (Web Server)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/health` | GET | Health check with Valkey status |
+| `/api/rate-limit/:id` | GET | Get rate limit status |
+| `/api/rate-limit/:id/check` | POST | Check/consume rate limit |
+| `/api/rate-limit/:id/reset` | POST | Reset rate limit |
+| `/api/scrape` | POST | Scrape URL with caching |
+| `/api/cache/stats` | GET | Get cache statistics |
+| `/api/cache/clear` | POST | Clear all cached items |
+| `/api/batch` | POST | Create batch job |
+| `/api/batch/:id` | GET | Get batch status |
+| `/api/batch/:id/process` | POST | Process batch |
+| `/api/batches` | GET | List active batches |
+
+## Troubleshooting
+
+### Connection Issues
+
+**"Connection refused" to Valkey:**
+```bash
+# Check if Valkey is running
+docker compose ps
+# Should show redis service as "running"
+
+# Test connection
+docker compose exec redis redis-cli ping
+# Should return "PONG"
+```
+
+**"Connection timeout" with GLIDE:**
+- Ensure you're not using TLS (`redis://`) for local Valkey
+- For TLS connections (AWS), use `rediss://` and enable TLS in client config
+
+### Rate Limiting Not Working
+
+```bash
+# Check if keys are being created
+docker compose exec redis redis-cli keys "demo:ratelimit:*"
+
+# Monitor commands in real-time
+docker compose exec redis redis-cli monitor
+```
+
+### Cache Not Persisting
+
+```bash
+# Check cache keys
+docker compose exec redis redis-cli keys "demo:cache:*"
+
+# Check TTL on a key
+docker compose exec redis redis-cli ttl "demo:cache:scrape:..."
+```
+
+## Best Practices
+
+### 1. Connection Management
+
+```typescript
+// Reuse client connections - don't create new ones per request
+const client = await getValkeyClient(); // Singleton pattern
+```
+
+### 2. Key Naming
+
+Use consistent prefixes for organization:
+```
+demo:ratelimit:{identifier}
+demo:cache:scrape:{url_hash}
+demo:cache:crawl:{crawl_id}
+demo:batch:{batch_id}
+```
+
+### 3. TTL Strategy
+
+- **Rate limit keys:** Auto-expire with window duration
+- **Cache keys:** Set based on data freshness requirements
+- **Batch keys:** Clean up completed batches periodically
+
+### 4. Error Handling
+
+```typescript
+try {
+  const client = await getValkeyClient();
+  await client.set(key, value);
+} catch (error) {
+  // Log error, fall back to non-cached behavior
+  console.error('Valkey error:', error);
+}
+```
+
+### 5. Production Considerations
+
+- Use connection pooling for high-throughput
+- Enable TLS for cloud deployments
+- Set appropriate timeouts
+- Monitor memory usage with `INFO memory`
+- Use `SCAN` instead of `KEYS` for production
+
+## File Structure
+
+```
+apps/valkey-demo/
+├── public/
+│   └── index.html          # Web UI
+├── src/
+│   ├── config.ts           # Environment configuration
+│   ├── valkey-client.ts    # GLIDE client singleton
+│   ├── firecrawl-client.ts # Firecrawl API client
+│   ├── server.ts           # Express API server
+│   ├── index.ts            # CLI demo runner
+│   ├── services/
+│   │   ├── rate-limiter.ts # Rate limiting service
+│   │   ├── cache-service.ts# Caching service
+│   │   └── batch-manager.ts# Batch job manager
+│   └── demos/
+│       ├── rate-limit-demo.ts
+│       ├── scrape-demo.ts
+│       ├── crawl-demo.ts
+│       └── batch-demo.ts
+├── docs/
+│   ├── DEPLOYMENT.md       # Deployment guide
+│   └── AWS_SETUP.md        # AWS ElastiCache/MemoryDB setup
+├── deploy/
+│   ├── docker-compose.valkey.yaml
+│   └── kubernetes/
+├── package.json
+├── tsconfig.json
+└── .env.example
+```
+
+## License
+
+Apache-2.0 - Same as Firecrawl

--- a/apps/valkey-demo/audit-ci.jsonc
+++ b/apps/valkey-demo/audit-ci.jsonc
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "moderate": true,
+  "allowlist": []
+}

--- a/apps/valkey-demo/deploy/docker-compose.valkey.yaml
+++ b/apps/valkey-demo/deploy/docker-compose.valkey.yaml
@@ -1,0 +1,122 @@
+# Production Docker Compose for Firecrawl with Valkey
+# Usage: docker compose -f deploy/docker-compose.valkey.yaml up -d
+
+name: firecrawl-valkey
+
+services:
+  valkey:
+    image: valkey/valkey:7-alpine
+    restart: unless-stopped
+    command: >
+      valkey-server
+      --bind 0.0.0.0
+      --port 6379
+      --requirepass ${VALKEY_PASSWORD:-changeme}
+      --appendonly yes
+      --appendfsync everysec
+      --maxmemory ${VALKEY_MAXMEMORY:-2gb}
+      --maxmemory-policy allkeys-lru
+      --tcp-keepalive 300
+      --timeout 0
+    volumes:
+      - valkey-data:/data
+    networks:
+      - backend
+    ports:
+      - "${VALKEY_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "valkey-cli", "-a", "${VALKEY_PASSWORD:-changeme}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 2.5G
+        reservations:
+          memory: 512M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  api:
+    image: ghcr.io/firecrawl/firecrawl:latest
+    restart: unless-stopped
+    environment:
+      HOST: "0.0.0.0"
+      PORT: 3002
+      REDIS_URL: redis://:${VALKEY_PASSWORD:-changeme}@valkey:6379
+      REDIS_RATE_LIMIT_URL: redis://:${VALKEY_PASSWORD:-changeme}@valkey:6379
+      NUM_WORKERS_PER_QUEUE: ${NUM_WORKERS:-8}
+      PLAYWRIGHT_MICROSERVICE_URL: http://playwright-service:3000/scrape
+    depends_on:
+      valkey:
+        condition: service_healthy
+      playwright-service:
+        condition: service_started
+    networks:
+      - backend
+    ports:
+      - "${API_PORT:-3002}:3002"
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 1G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  playwright-service:
+    image: ghcr.io/firecrawl/playwright-service:latest
+    restart: unless-stopped
+    environment:
+      PORT: 3000
+      MAX_CONCURRENT_PAGES: 10
+    networks:
+      - backend
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # Optional: Valkey demo app
+  valkey-demo:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      FIRECRAWL_API_URL: http://api:3002
+      VALKEY_URL: redis://:${VALKEY_PASSWORD:-changeme}@valkey:6379
+      PORT: 3030
+    depends_on:
+      - api
+      - valkey
+    networks:
+      - backend
+    ports:
+      - "${DEMO_PORT:-3030}:3030"
+    profiles:
+      - demo
+
+volumes:
+  valkey-data:
+    driver: local
+
+networks:
+  backend:
+    driver: bridge

--- a/apps/valkey-demo/docs/AWS_SETUP.md
+++ b/apps/valkey-demo/docs/AWS_SETUP.md
@@ -1,0 +1,301 @@
+# AWS ElastiCache & MemoryDB Setup
+
+This guide covers using Firecrawl with AWS managed Valkey-compatible services.
+
+## Table of Contents
+
+- [Amazon ElastiCache (Valkey)](#amazon-elasticache-valkey)
+- [Amazon MemoryDB](#amazon-memorydb)
+- [Connection Configuration](#connection-configuration)
+- [Security Best Practices](#security-best-practices)
+
+---
+
+## Amazon ElastiCache (Valkey)
+
+Amazon ElastiCache now supports Valkey as a drop-in Redis replacement.
+
+### Create ElastiCache Cluster (Console)
+
+1. Go to **ElastiCache** → **Valkey caches** → **Create**
+2. Configure:
+   - **Engine**: Valkey
+   - **Engine version**: 7.2 (or latest)
+   - **Node type**: `cache.t3.medium` (adjust for workload)
+   - **Number of replicas**: 1-2 for HA
+   - **Multi-AZ**: Enable for production
+
+3. Network settings:
+   - **VPC**: Same VPC as your Firecrawl deployment
+   - **Subnet group**: Private subnets
+   - **Security group**: Allow port 6379 from Firecrawl
+
+4. Security:
+   - **Encryption in-transit**: Enable (TLS)
+   - **Encryption at-rest**: Enable
+   - **AUTH token**: Set a strong password
+
+### Create ElastiCache Cluster (CLI)
+
+```bash
+# Create subnet group
+aws elasticache create-cache-subnet-group \
+  --cache-subnet-group-name firecrawl-valkey-subnet \
+  --cache-subnet-group-description "Subnet group for Firecrawl Valkey" \
+  --subnet-ids subnet-xxx subnet-yyy
+
+# Create security group
+aws ec2 create-security-group \
+  --group-name firecrawl-valkey-sg \
+  --description "Security group for Firecrawl Valkey" \
+  --vpc-id vpc-xxx
+
+# Allow inbound from Firecrawl security group
+aws ec2 authorize-security-group-ingress \
+  --group-id sg-valkey \
+  --protocol tcp \
+  --port 6379 \
+  --source-group sg-firecrawl
+
+# Create Valkey cluster
+aws elasticache create-replication-group \
+  --replication-group-id firecrawl-valkey \
+  --replication-group-description "Valkey for Firecrawl" \
+  --engine valkey \
+  --engine-version 7.2 \
+  --cache-node-type cache.t3.medium \
+  --num-cache-clusters 2 \
+  --cache-subnet-group-name firecrawl-valkey-subnet \
+  --security-group-ids sg-xxx \
+  --transit-encryption-enabled \
+  --at-rest-encryption-enabled \
+  --auth-token "your-secure-auth-token"
+```
+
+### Get Connection Endpoint
+
+```bash
+aws elasticache describe-replication-groups \
+  --replication-group-id firecrawl-valkey \
+  --query 'ReplicationGroups[0].NodeGroups[0].PrimaryEndpoint'
+```
+
+---
+
+## Amazon MemoryDB
+
+MemoryDB provides Redis/Valkey-compatible, durable, in-memory database with Multi-AZ durability.
+
+### Create MemoryDB Cluster (Console)
+
+1. Go to **MemoryDB** → **Clusters** → **Create cluster**
+2. Configure:
+   - **Name**: `firecrawl-memorydb`
+   - **Node type**: `db.t4g.medium`
+   - **Number of shards**: 1 (increase for larger workloads)
+   - **Replicas per shard**: 1
+
+3. Subnet group and security:
+   - Create or select subnet group in your VPC
+   - Configure security group for port 6379
+
+4. Security:
+   - **TLS**: Enabled (required)
+   - **ACL**: Create user with password
+
+### Create MemoryDB Cluster (CLI)
+
+```bash
+# Create subnet group
+aws memorydb create-subnet-group \
+  --subnet-group-name firecrawl-memorydb-subnet \
+  --subnet-ids subnet-xxx subnet-yyy
+
+# Create ACL with user
+aws memorydb create-user \
+  --user-name firecrawl-user \
+  --authentication-mode Type=password,Passwords="your-secure-password" \
+  --access-string "on ~* +@all"
+
+aws memorydb create-acl \
+  --acl-name firecrawl-acl \
+  --user-names firecrawl-user
+
+# Create cluster
+aws memorydb create-cluster \
+  --cluster-name firecrawl-memorydb \
+  --node-type db.t4g.medium \
+  --acl-name firecrawl-acl \
+  --subnet-group-name firecrawl-memorydb-subnet \
+  --security-group-ids sg-xxx \
+  --num-shards 1 \
+  --num-replicas-per-shard 1 \
+  --tls-enabled
+```
+
+### Get Connection Endpoint
+
+```bash
+aws memorydb describe-clusters \
+  --cluster-name firecrawl-memorydb \
+  --query 'Clusters[0].ClusterEndpoint'
+```
+
+---
+
+## Connection Configuration
+
+### ElastiCache Connection
+
+```env
+# .env for Firecrawl
+# Note: Use 'rediss://' for TLS connections
+REDIS_URL=rediss://:your-auth-token@your-cluster.xxx.cache.amazonaws.com:6379
+REDIS_RATE_LIMIT_URL=rediss://:your-auth-token@your-cluster.xxx.cache.amazonaws.com:6379
+```
+
+### MemoryDB Connection
+
+```env
+# .env for Firecrawl
+# MemoryDB always requires TLS
+REDIS_URL=rediss://firecrawl-user:your-password@your-cluster.xxx.memorydb.amazonaws.com:6379
+REDIS_RATE_LIMIT_URL=rediss://firecrawl-user:your-password@your-cluster.xxx.memorydb.amazonaws.com:6379
+```
+
+### Demo App Configuration
+
+For the Valkey demo app, update `.env`:
+
+```env
+# ElastiCache
+VALKEY_URL=rediss://:your-auth-token@your-cluster.xxx.cache.amazonaws.com:6379
+
+# MemoryDB
+VALKEY_URL=rediss://firecrawl-user:your-password@your-cluster.xxx.memorydb.amazonaws.com:6379
+```
+
+Update `valkey-client.ts` to enable TLS:
+
+```typescript
+import { GlideClient } from '@valkey/valkey-glide';
+
+export async function getValkeyClient(): Promise<GlideClient> {
+  const url = new URL(config.valkey.url.replace('rediss://', 'https://'));
+  const useTLS = config.valkey.url.startsWith('rediss://');
+  
+  // Extract credentials from URL
+  const password = url.password || undefined;
+  const username = url.username || undefined;
+
+  client = await GlideClient.createClient({
+    addresses: [{ host: url.hostname, port: parseInt(url.port) || 6379 }],
+    useTLS: useTLS,
+    credentials: password ? { password, username } : undefined,
+    requestTimeout: 5000,
+    clientName: 'valkey-demo',
+  });
+  
+  return client;
+}
+```
+
+---
+
+## Security Best Practices
+
+### Network Security
+
+1. **VPC Placement**: Deploy ElastiCache/MemoryDB in private subnets
+2. **Security Groups**: Only allow traffic from Firecrawl instances
+3. **No Public Access**: Never expose to the internet
+
+### Authentication
+
+1. **Strong Passwords**: Use 32+ character random passwords
+2. **Rotate Credentials**: Use AWS Secrets Manager for rotation
+3. **IAM Auth** (MemoryDB): Consider IAM authentication for enhanced security
+
+### Encryption
+
+1. **In-Transit**: Always enable TLS (`rediss://`)
+2. **At-Rest**: Enable encryption at rest
+3. **KMS**: Use customer-managed KMS keys for sensitive workloads
+
+### Monitoring
+
+```bash
+# CloudWatch metrics to monitor
+- CPUUtilization
+- FreeableMemory
+- CurrConnections
+- CacheHits / CacheMisses
+- ReplicationLag
+```
+
+### Cost Optimization
+
+| Use Case | Recommended Service | Node Type |
+|----------|---------------------|-----------|
+| Development | ElastiCache | cache.t3.micro |
+| Small Production | ElastiCache | cache.t3.medium |
+| High Availability | ElastiCache Multi-AZ | cache.r6g.large |
+| Durability Required | MemoryDB | db.t4g.medium |
+| High Throughput | MemoryDB | db.r6g.xlarge |
+
+---
+
+## Terraform Example
+
+```hcl
+# elasticache.tf
+resource "aws_elasticache_replication_group" "firecrawl_valkey" {
+  replication_group_id       = "firecrawl-valkey"
+  description                = "Valkey cluster for Firecrawl"
+  engine                     = "valkey"
+  engine_version             = "7.2"
+  node_type                  = "cache.t3.medium"
+  num_cache_clusters         = 2
+  port                       = 6379
+  
+  subnet_group_name          = aws_elasticache_subnet_group.firecrawl.name
+  security_group_ids         = [aws_security_group.valkey.id]
+  
+  transit_encryption_enabled = true
+  at_rest_encryption_enabled = true
+  auth_token                 = var.valkey_auth_token
+  
+  automatic_failover_enabled = true
+  multi_az_enabled           = true
+  
+  tags = {
+    Name = "firecrawl-valkey"
+  }
+}
+
+output "valkey_endpoint" {
+  value = aws_elasticache_replication_group.firecrawl_valkey.primary_endpoint_address
+}
+```
+
+---
+
+## Troubleshooting
+
+### Connection Timeout
+
+- Verify security group allows port 6379
+- Check VPC routing and NAT gateway
+- Ensure TLS is enabled in client (`rediss://`)
+
+### Authentication Failed
+
+- Verify AUTH token/password is correct
+- Check ACL permissions (MemoryDB)
+- Ensure username is included if required
+
+### High Latency
+
+- Check node CPU/memory utilization
+- Consider upgrading node type
+- Review network path (same AZ preferred)

--- a/apps/valkey-demo/docs/DEPLOYMENT.md
+++ b/apps/valkey-demo/docs/DEPLOYMENT.md
@@ -1,0 +1,290 @@
+# Deployment Guide
+
+This guide covers deploying Firecrawl with Valkey in various environments.
+
+## Table of Contents
+
+- [Docker Compose (Local/Development)](#docker-compose)
+- [Docker Compose (Production)](#docker-compose-production)
+- [Kubernetes](#kubernetes)
+- [Self-Hosted Valkey](#self-hosted-valkey)
+
+---
+
+## Docker Compose
+
+### Development Setup
+
+The simplest way to run Firecrawl with Valkey locally:
+
+```bash
+# From Firecrawl root directory
+docker compose up -d
+```
+
+The default `docker-compose.yaml` already uses Valkey:
+
+```yaml
+redis:
+  image: valkey/valkey:alpine
+  networks:
+    - backend
+  command: redis-server --bind 0.0.0.0
+```
+
+### Verify Valkey is Running
+
+```bash
+# Check container status
+docker compose ps
+
+# Test Valkey connection
+docker compose exec redis redis-cli ping
+# Expected: PONG
+
+# Check Valkey version
+docker compose exec redis redis-cli info server | grep valkey_version
+```
+
+---
+
+## Docker Compose Production
+
+For production deployments, use a dedicated compose file with persistence and security:
+
+### `deploy/docker-compose.valkey.yaml`
+
+```yaml
+name: firecrawl-valkey-prod
+
+services:
+  valkey:
+    image: valkey/valkey:7-alpine
+    restart: unless-stopped
+    command: >
+      valkey-server
+      --bind 0.0.0.0
+      --requirepass ${VALKEY_PASSWORD:-changeme}
+      --appendonly yes
+      --appendfsync everysec
+      --maxmemory 2gb
+      --maxmemory-policy allkeys-lru
+    volumes:
+      - valkey-data:/data
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD", "valkey-cli", "-a", "${VALKEY_PASSWORD:-changeme}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 2.5G
+        reservations:
+          memory: 1G
+
+  api:
+    image: ghcr.io/firecrawl/firecrawl:latest
+    restart: unless-stopped
+    environment:
+      REDIS_URL: redis://:${VALKEY_PASSWORD:-changeme}@valkey:6379
+      REDIS_RATE_LIMIT_URL: redis://:${VALKEY_PASSWORD:-changeme}@valkey:6379
+      # ... other env vars
+    depends_on:
+      valkey:
+        condition: service_healthy
+    networks:
+      - backend
+    ports:
+      - "3002:3002"
+
+volumes:
+  valkey-data:
+
+networks:
+  backend:
+    driver: bridge
+```
+
+### Production Environment Variables
+
+```env
+# .env.production
+VALKEY_PASSWORD=your-secure-password-here
+REDIS_URL=redis://:${VALKEY_PASSWORD}@valkey:6379
+REDIS_RATE_LIMIT_URL=redis://:${VALKEY_PASSWORD}@valkey:6379
+```
+
+### Deploy
+
+```bash
+docker compose -f deploy/docker-compose.valkey.yaml --env-file .env.production up -d
+```
+
+---
+
+## Kubernetes
+
+### Prerequisites
+
+- Kubernetes cluster 
+- kubectl configured
+
+### Firecrawl Deployment
+
+Create `deploy/kubernetes/firecrawl.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: firecrawl-api
+  namespace: firecrawl
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: firecrawl-api
+  template:
+    metadata:
+      labels:
+        app: firecrawl-api
+    spec:
+      containers:
+      - name: api
+        image: ghcr.io/firecrawl/firecrawl:latest
+        env:
+        - name: VALKEY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: valkey-secret
+              key: password
+        - name: REDIS_URL
+          value: "redis://:$(VALKEY_PASSWORD)@valkey:6379"
+        - name: REDIS_RATE_LIMIT_URL
+          value: "redis://:$(VALKEY_PASSWORD)@valkey:6379"
+        ports:
+        - containerPort: 3002
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "1000m"
+          limits:
+            memory: "4Gi"
+            cpu: "2000m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: firecrawl-api
+  namespace: firecrawl
+spec:
+  selector:
+    app: firecrawl-api
+  ports:
+  - port: 3002
+    targetPort: 3002
+  type: ClusterIP
+```
+
+### Deploy to Kubernetes
+
+```bash
+kubectl create namespace firecrawl
+kubectl apply -f deploy/kubernetes/valkey.yaml
+kubectl apply -f deploy/kubernetes/firecrawl.yaml
+
+# Verify
+kubectl get pods -n firecrawl
+kubectl logs -n firecrawl deployment/firecrawl-api
+```
+
+---
+
+## Self-Hosted Valkey
+
+### Ubuntu/Debian
+
+```bash
+# Install dependencies
+sudo apt update
+sudo apt install -y build-essential tcl
+
+# Download and build Valkey
+wget https://github.com/valkey-io/valkey/archive/refs/tags/7.2.5.tar.gz
+tar xzf 7.2.5.tar.gz
+cd valkey-7.2.5
+make
+sudo make install
+
+# Create config directory
+sudo mkdir -p /etc/valkey
+sudo cp valkey.conf /etc/valkey/
+
+# Edit config
+sudo nano /etc/valkey/valkey.conf
+```
+
+**Recommended config changes:**
+
+```conf
+# /etc/valkey/valkey.conf
+bind 0.0.0.0
+port 6379
+requirepass your-secure-password
+daemonize yes
+pidfile /var/run/valkey.pid
+logfile /var/log/valkey/valkey.log
+dir /var/lib/valkey
+appendonly yes
+appendfsync everysec
+maxmemory 2gb
+maxmemory-policy allkeys-lru
+```
+
+### Systemd Service
+
+Create `/etc/systemd/system/valkey.service`:
+
+```ini
+[Unit]
+Description=Valkey In-Memory Data Store
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/usr/local/bin/valkey-server /etc/valkey/valkey.conf
+ExecStop=/usr/local/bin/valkey-cli -a your-secure-password shutdown
+Restart=always
+User=valkey
+Group=valkey
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+# Create user and directories
+sudo useradd -r -s /bin/false valkey
+sudo mkdir -p /var/lib/valkey /var/log/valkey
+sudo chown valkey:valkey /var/lib/valkey /var/log/valkey
+
+# Enable and start
+sudo systemctl daemon-reload
+sudo systemctl enable valkey
+sudo systemctl start valkey
+
+# Verify
+sudo systemctl status valkey
+valkey-cli -a your-secure-password ping
+```
+
+### Connect Firecrawl
+
+```env
+# .env
+REDIS_URL=redis://:your-secure-password@your-valkey-host:6379
+REDIS_RATE_LIMIT_URL=redis://:your-secure-password@your-valkey-host:6379
+```

--- a/apps/valkey-demo/package.json
+++ b/apps/valkey-demo/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "valkey-demo",
+  "version": "1.0.0",
+  "description": "Demo application showcasing Firecrawl with Valkey GLIDE for caching, rate limiting, and batch operations",
+  "author": "",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "server": "ts-node src/server.ts",
+    "demo:scrape": "ts-node src/demos/scrape-demo.ts",
+    "demo:crawl": "ts-node src/demos/crawl-demo.ts",
+    "demo:batch": "ts-node src/demos/batch-demo.ts",
+    "demo:rate-limit": "ts-node src/demos/rate-limit-demo.ts",
+    "demo:all": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "@valkey/valkey-glide": "^1.3.0",
+    "axios": "^1.6.0",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.10.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.0"
+  }
+}

--- a/apps/valkey-demo/pnpm-lock.yaml
+++ b/apps/valkey-demo/pnpm-lock.yaml
@@ -1,0 +1,1105 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@valkey/valkey-glide':
+        specifier: ^1.3.0
+        version: 1.3.4
+      axios:
+        specifier: ^1.6.0
+        version: 1.13.3
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.6.1
+      express:
+        specifier: ^4.18.2
+        version: 4.22.1
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.30
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.19.30)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
+packages:
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/node@20.19.30':
+    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
+
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  '@valkey/valkey-glide-darwin-arm64@1.3.4':
+    resolution: {integrity: sha512-Ry8PEWdMtENju/thkqMEDCcf9wJSz5JavpwTJ8+NEaTVeYUSNK7PJ91ZrgxTWyDr51YAdA8e5MjyK2+p2X1HiQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+    bundledDependencies:
+      - glide-rs
+
+  '@valkey/valkey-glide-darwin-x64@1.3.4':
+    resolution: {integrity: sha512-Jl/x1WovhwiP7lWUcA99tw68Usb3GCHZ/ISD/1F23cVErXJ9qB4ZNCFI8Y1QrmwEPSeojKsxSpqylrsInuv1ng==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+    bundledDependencies:
+      - glide-rs
+
+  '@valkey/valkey-glide-linux-arm64@1.3.4':
+    resolution: {integrity: sha512-ubTZDaEqlwS8NNuIggWt36I1BbtUNE17uHrCaBvUfc+aR1870r4xqvQNyvpQhT/VezfJisSBGKudFdLKeFrIjg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+    deprecated: This package will be replaced by @valkey/valkey-glide-linux-arm64-gnu in v2.0
+    bundledDependencies:
+      - glide-rs
+
+  '@valkey/valkey-glide-linux-musl-arm64@1.3.4':
+    resolution: {integrity: sha512-zNkmKXrT9ebe/XWtevzFleRrXycrzsLtmDjdQJGVUC96gUA3DcczK/gfu2rgvgH84C5s5jKbSM7oeo8f8eX4Vw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+    deprecated: This package will be replaced by @valkey/valkey-glide-linux-arm64-musl in v2.0
+    bundledDependencies:
+      - glide-rs
+
+  '@valkey/valkey-glide-linux-musl-x64@1.3.4':
+    resolution: {integrity: sha512-QSaLTp81V0agKcGXsr3LUF+Vl4nTHrf5eBNV7/2GwbA4Pwed2x8TzORAjv+aS368hWR/9zftbVA1Xjn8TAND3w==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+    deprecated: This package will be replaced by @valkey/valkey-glide-linux-x64-musl in v2.0
+    bundledDependencies:
+      - glide-rs
+
+  '@valkey/valkey-glide-linux-x64@1.3.4':
+    resolution: {integrity: sha512-j9acGMsr7T1oY377xBsIkY4rjtDqb78/OSH3CFcdntcJZU6u6fvcqGXG5Co/iRDvsm+q9uuYd/H5ITnGx60kng==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+    deprecated: This package will be replaced by @valkey/valkey-glide-linux-x64-gnu in v2.0
+    bundledDependencies:
+      - glide-rs
+
+  '@valkey/valkey-glide@1.3.4':
+    resolution: {integrity: sha512-EXjpGEeTjs2uhJm8ZNkHEK8d3qCQmppmxsv+553S6L9fArZTBvKMmfh7P2H7nxletHx6sxs+fc2UFFw9M5k5SQ==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.13.3:
+    resolution: {integrity: sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==}
+
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
+
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+snapshots:
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@protobufjs/aspromise@1.1.2':
+    optional: true
+
+  '@protobufjs/base64@1.1.2':
+    optional: true
+
+  '@protobufjs/codegen@2.0.4':
+    optional: true
+
+  '@protobufjs/eventemitter@1.1.0':
+    optional: true
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+    optional: true
+
+  '@protobufjs/float@1.0.2':
+    optional: true
+
+  '@protobufjs/inquire@1.1.0':
+    optional: true
+
+  '@protobufjs/path@1.1.2':
+    optional: true
+
+  '@protobufjs/pool@1.1.0':
+    optional: true
+
+  '@protobufjs/utf8@1.1.0':
+    optional: true
+
+  '@tsconfig/node10@1.0.12': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.30
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.30
+
+  '@types/express-serve-static-core@4.19.8':
+    dependencies:
+      '@types/node': 20.19.30
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.8
+      '@types/qs': 6.14.0
+      '@types/serve-static': 1.15.10
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/mime@1.3.5': {}
+
+  '@types/node@20.19.30':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 20.19.30
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.30
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.30
+      '@types/send': 0.17.6
+
+  '@valkey/valkey-glide-darwin-arm64@1.3.4':
+    dependencies:
+      long: 5.3.2
+      protobufjs: 7.5.4
+    optional: true
+
+  '@valkey/valkey-glide-darwin-x64@1.3.4':
+    dependencies:
+      long: 5.3.2
+      protobufjs: 7.5.4
+    optional: true
+
+  '@valkey/valkey-glide-linux-arm64@1.3.4':
+    dependencies:
+      long: 5.3.2
+      protobufjs: 7.5.4
+    optional: true
+
+  '@valkey/valkey-glide-linux-musl-arm64@1.3.4':
+    dependencies:
+      long: 5.3.2
+      protobufjs: 7.5.4
+    optional: true
+
+  '@valkey/valkey-glide-linux-musl-x64@1.3.4':
+    dependencies:
+      long: 5.3.2
+      protobufjs: 7.5.4
+    optional: true
+
+  '@valkey/valkey-glide-linux-x64@1.3.4':
+    dependencies:
+      long: 5.3.2
+      protobufjs: 7.5.4
+    optional: true
+
+  '@valkey/valkey-glide@1.3.4':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@valkey/valkey-glide-darwin-arm64': 1.3.4
+      '@valkey/valkey-glide-darwin-x64': 1.3.4
+      '@valkey/valkey-glide-linux-arm64': 1.3.4
+      '@valkey/valkey-glide-linux-musl-arm64': 1.3.4
+      '@valkey/valkey-glide-linux-musl-x64': 1.3.4
+      '@valkey/valkey-glide-linux-x64': 1.3.4
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  arg@4.1.3: {}
+
+  array-flatten@1.1.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.13.3:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.1
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.0.7: {}
+
+  cookie@0.7.2: {}
+
+  create-require@1.1.1: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
+  destroy@1.2.0: {}
+
+  detect-libc@2.1.2: {}
+
+  diff@4.0.4: {}
+
+  dotenv@16.6.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  long@5.3.2:
+    optional: true
+
+  make-error@1.3.6: {}
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  ms@2.0.0: {}
+
+  ms@2.1.3: {}
+
+  negotiator@0.6.3: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  parseurl@1.3.3: {}
+
+  path-to-regexp@0.1.12: {}
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.19.30
+      long: 5.3.2
+    optional: true
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
+
+  qs@6.14.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  statuses@2.0.2: {}
+
+  toidentifier@1.0.1: {}
+
+  ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.30
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  utils-merge@1.0.1: {}
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  vary@1.1.2: {}
+
+  yn@3.1.1: {}

--- a/apps/valkey-demo/public/index.html
+++ b/apps/valkey-demo/public/index.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Firecrawl + Valkey GLIDE Demo</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { 
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f172a; color: #e2e8f0; line-height: 1.6;
+    }
+    .container { max-width: 1200px; margin: 0 auto; padding: 2rem; }
+    header { text-align: center; margin-bottom: 2rem; }
+    header h1 { font-size: 2rem; color: #38bdf8; margin-bottom: 0.5rem; }
+    header p { color: #94a3b8; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 1.5rem; }
+    .card { background: #1e293b; border-radius: 12px; padding: 1.5rem; border: 1px solid #334155; }
+    .card h2 { color: #38bdf8; font-size: 1.1rem; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem; }
+    .card h2::before { content: ''; width: 8px; height: 8px; background: #38bdf8; border-radius: 50%; }
+    input, button { padding: 0.75rem 1rem; border-radius: 8px; border: none; font-size: 0.9rem; }
+    input { background: #0f172a; color: #e2e8f0; border: 1px solid #334155; width: 100%; margin-bottom: 0.75rem; }
+    input:focus { outline: none; border-color: #38bdf8; }
+    button { background: #38bdf8; color: #0f172a; cursor: pointer; font-weight: 600; transition: all 0.2s; }
+    button:hover { background: #0ea5e9; }
+    button:disabled { background: #475569; cursor: not-allowed; }
+    button.secondary { background: #334155; color: #e2e8f0; }
+    button.secondary:hover { background: #475569; }
+    .btn-row { display: flex; gap: 0.5rem; margin-top: 0.5rem; }
+    .btn-row button { flex: 1; }
+    .status { padding: 1rem; background: #0f172a; border-radius: 8px; margin-top: 1rem; font-family: monospace; font-size: 0.85rem; max-height: 200px; overflow-y: auto; }
+    .status.success { border-left: 3px solid #22c55e; }
+    .status.error { border-left: 3px solid #ef4444; }
+    .status.info { border-left: 3px solid #38bdf8; }
+    .meter { height: 8px; background: #334155; border-radius: 4px; overflow: hidden; margin: 0.5rem 0; }
+    .meter-fill { height: 100%; background: linear-gradient(90deg, #38bdf8, #22c55e); transition: width 0.3s; }
+    .stats { display: flex; gap: 1rem; margin-top: 1rem; }
+    .stat { flex: 1; text-align: center; padding: 0.75rem; background: #0f172a; border-radius: 8px; }
+    .stat-value { font-size: 1.5rem; font-weight: bold; color: #38bdf8; }
+    .stat-label { font-size: 0.75rem; color: #94a3b8; }
+    .tag { display: inline-block; padding: 0.25rem 0.5rem; background: #334155; border-radius: 4px; font-size: 0.75rem; margin-right: 0.5rem; }
+    .tag.success { background: #166534; color: #22c55e; }
+    .tag.error { background: #7f1d1d; color: #ef4444; }
+    .connection { position: fixed; top: 1rem; right: 1rem; padding: 0.5rem 1rem; border-radius: 20px; font-size: 0.8rem; }
+    .connection.connected { background: #166534; color: #22c55e; }
+    .connection.disconnected { background: #7f1d1d; color: #ef4444; }
+    textarea { width: 100%; min-height: 80px; background: #0f172a; color: #e2e8f0; border: 1px solid #334155; border-radius: 8px; padding: 0.75rem; font-family: inherit; resize: vertical; }
+  </style>
+</head>
+<body>
+  <div id="connection" class="connection disconnected">● Disconnected</div>
+  
+  <div class="container">
+    <header>
+      <h1>🔥 Firecrawl + Valkey GLIDE Demo</h1>
+      <p>Demonstrating caching, rate limiting, and batch operations</p>
+    </header>
+
+    <div class="grid">
+      <!-- Rate Limiting -->
+      <div class="card">
+        <h2>Rate Limiting</h2>
+        <input type="text" id="rateLimitId" placeholder="User/Client ID (e.g., user-123)" value="demo-user">
+        <div class="stats">
+          <div class="stat">
+            <div class="stat-value" id="remainingRequests">-</div>
+            <div class="stat-label">Remaining</div>
+          </div>
+          <div class="stat">
+            <div class="stat-value" id="maxRequests">10</div>
+            <div class="stat-label">Max/Window</div>
+          </div>
+        </div>
+        <div class="meter"><div class="meter-fill" id="rateMeter" style="width: 100%"></div></div>
+        <div class="btn-row">
+          <button onclick="checkRateLimit()">Make Request</button>
+          <button class="secondary" onclick="resetRateLimit()">Reset</button>
+        </div>
+        <div id="rateLimitStatus" class="status info" style="display:none"></div>
+      </div>
+
+      <!-- Scrape with Cache -->
+      <div class="card">
+        <h2>Scrape with Caching</h2>
+        <input type="url" id="scrapeUrl" placeholder="URL to scrape" value="https://example.com">
+        <div class="btn-row">
+          <button onclick="scrapeUrl()">Scrape</button>
+          <button class="secondary" onclick="clearCache()">Clear Cache</button>
+        </div>
+        <div class="stats">
+          <div class="stat">
+            <div class="stat-value" id="cacheKeys">-</div>
+            <div class="stat-label">Cached Items</div>
+          </div>
+          <div class="stat">
+            <div class="stat-value" id="cacheMemory">-</div>
+            <div class="stat-label">Memory</div>
+          </div>
+        </div>
+        <div id="scrapeStatus" class="status info" style="display:none"></div>
+      </div>
+
+      <!-- Batch Operations -->
+      <div class="card" style="grid-column: span 2;">
+        <h2>Batch Operations</h2>
+        <textarea id="batchUrls" placeholder="Enter URLs (one per line)">https://example.com
+https://example.org
+https://example.net</textarea>
+        <div class="btn-row" style="margin-top: 0.75rem;">
+          <button onclick="createBatch()">Create Batch</button>
+          <button class="secondary" onclick="processBatch()">Process</button>
+        </div>
+        <div class="stats">
+          <div class="stat">
+            <div class="stat-value" id="batchId">-</div>
+            <div class="stat-label">Current Batch</div>
+          </div>
+          <div class="stat">
+            <div class="stat-value" id="batchStatus">-</div>
+            <div class="stat-label">Status</div>
+          </div>
+          <div class="stat">
+            <div class="stat-value" id="batchProgress">0%</div>
+            <div class="stat-label">Progress</div>
+          </div>
+        </div>
+        <div class="meter"><div class="meter-fill" id="batchMeter" style="width: 0%"></div></div>
+        <div id="batchResults" class="status info" style="display:none"></div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const API = '';
+    let currentBatchId = null;
+
+    async function checkConnection() {
+      try {
+        const res = await fetch(`${API}/api/health`);
+        const data = await res.json();
+        const el = document.getElementById('connection');
+        if (data.status === 'ok') {
+          el.className = 'connection connected';
+          el.textContent = '● Connected to Valkey';
+          loadCacheStats();
+          loadRateLimitStatus();
+        } else {
+          throw new Error('Not connected');
+        }
+      } catch {
+        document.getElementById('connection').className = 'connection disconnected';
+        document.getElementById('connection').textContent = '● Disconnected';
+      }
+    }
+
+    async function loadRateLimitStatus() {
+      const id = document.getElementById('rateLimitId').value || 'demo-user';
+      try {
+        const res = await fetch(`${API}/api/rate-limit/${id}`);
+        const data = await res.json();
+        document.getElementById('remainingRequests').textContent = data.remaining;
+        document.getElementById('maxRequests').textContent = data.max;
+        document.getElementById('rateMeter').style.width = `${(data.remaining / data.max) * 100}%`;
+      } catch {}
+    }
+
+    async function checkRateLimit() {
+      const id = document.getElementById('rateLimitId').value || 'demo-user';
+      const statusEl = document.getElementById('rateLimitStatus');
+      try {
+        const res = await fetch(`${API}/api/rate-limit/${id}/check`, { method: 'POST' });
+        const data = await res.json();
+        statusEl.style.display = 'block';
+        statusEl.className = `status ${data.allowed ? 'success' : 'error'}`;
+        statusEl.textContent = data.allowed 
+          ? `✅ Request allowed (${data.remaining} remaining)`
+          : `❌ Rate limited (resets in ${Math.ceil((data.resetAt - Date.now()) / 1000)}s)`;
+        loadRateLimitStatus();
+      } catch (e) {
+        statusEl.style.display = 'block';
+        statusEl.className = 'status error';
+        statusEl.textContent = `Error: ${e.message}`;
+      }
+    }
+
+    async function resetRateLimit() {
+      const id = document.getElementById('rateLimitId').value || 'demo-user';
+      await fetch(`${API}/api/rate-limit/${id}/reset`, { method: 'POST' });
+      loadRateLimitStatus();
+      const statusEl = document.getElementById('rateLimitStatus');
+      statusEl.style.display = 'block';
+      statusEl.className = 'status success';
+      statusEl.textContent = '✅ Rate limit reset';
+    }
+
+    async function loadCacheStats() {
+      try {
+        const res = await fetch(`${API}/api/cache/stats`);
+        const data = await res.json();
+        document.getElementById('cacheKeys').textContent = data.keys;
+        document.getElementById('cacheMemory').textContent = data.memoryUsage;
+      } catch {}
+    }
+
+    async function scrapeUrl() {
+      const url = document.getElementById('scrapeUrl').value;
+      const statusEl = document.getElementById('scrapeStatus');
+      statusEl.style.display = 'block';
+      statusEl.className = 'status info';
+      statusEl.textContent = 'Scraping...';
+
+      try {
+        const res = await fetch(`${API}/api/scrape`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url })
+        });
+        const data = await res.json();
+        statusEl.className = `status ${data.success ? 'success' : 'error'}`;
+        const cacheTag = data.fromCache ? '📦 FROM CACHE' : '🌐 FRESH';
+        if (data.success) {
+          const preview = data.data?.markdown?.slice(0, 300) || 'No content';
+          statusEl.textContent = `${cacheTag}\n\n${preview}...`;
+        } else {
+          statusEl.textContent = `❌ ${data.error || 'Scrape failed'}`;
+        }
+        loadCacheStats();
+      } catch (e) {
+        statusEl.className = 'status error';
+        statusEl.textContent = `Error: ${e.message}`;
+      }
+    }
+
+    async function clearCache() {
+      await fetch(`${API}/api/cache/clear`, { method: 'POST' });
+      loadCacheStats();
+      const statusEl = document.getElementById('scrapeStatus');
+      statusEl.style.display = 'block';
+      statusEl.className = 'status success';
+      statusEl.textContent = '✅ Cache cleared';
+    }
+
+    async function createBatch() {
+      const urls = document.getElementById('batchUrls').value.split('\n').filter(u => u.trim());
+      const resultsEl = document.getElementById('batchResults');
+      
+      try {
+        const res = await fetch(`${API}/api/batch`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ urls })
+        });
+        const data = await res.json();
+        currentBatchId = data.batchId;
+        document.getElementById('batchId').textContent = data.batchId.slice(-12);
+        document.getElementById('batchStatus').textContent = 'pending';
+        document.getElementById('batchProgress').textContent = '0%';
+        document.getElementById('batchMeter').style.width = '0%';
+        resultsEl.style.display = 'block';
+        resultsEl.className = 'status success';
+        resultsEl.textContent = `✅ Batch created: ${data.batchId}\n${urls.length} URLs queued`;
+      } catch (e) {
+        resultsEl.style.display = 'block';
+        resultsEl.className = 'status error';
+        resultsEl.textContent = `Error: ${e.message}`;
+      }
+    }
+
+    async function processBatch() {
+      if (!currentBatchId) {
+        alert('Create a batch first');
+        return;
+      }
+      
+      const resultsEl = document.getElementById('batchResults');
+      resultsEl.style.display = 'block';
+      resultsEl.className = 'status info';
+      resultsEl.textContent = 'Processing batch...';
+      document.getElementById('batchStatus').textContent = 'processing';
+
+      try {
+        const res = await fetch(`${API}/api/batch/${currentBatchId}/process`, { method: 'POST' });
+        const data = await res.json();
+        
+        document.getElementById('batchStatus').textContent = data.status;
+        document.getElementById('batchProgress').textContent = `${data.progress}%`;
+        document.getElementById('batchMeter').style.width = `${data.progress}%`;
+        
+        resultsEl.className = 'status success';
+        let output = `✅ Batch ${data.status}\nDuration: ${data.completedAt - data.createdAt}ms\n\nResults:\n`;
+        for (const [url, result] of Object.entries(data.results)) {
+          const icon = result.success ? '✅' : '❌';
+          output += `${icon} ${url}\n`;
+        }
+        resultsEl.textContent = output;
+        loadCacheStats();
+      } catch (e) {
+        resultsEl.className = 'status error';
+        resultsEl.textContent = `Error: ${e.message}`;
+      }
+    }
+
+    // Init
+    checkConnection();
+    setInterval(checkConnection, 10000);
+    document.getElementById('rateLimitId').addEventListener('change', loadRateLimitStatus);
+  </script>
+</body>
+</html>

--- a/apps/valkey-demo/scripts/test-deployment.sh
+++ b/apps/valkey-demo/scripts/test-deployment.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Test script for Valkey deployments
+# Usage: ./scripts/test-deployment.sh [local|docker|k8s]
+
+set -e
+
+VALKEY_URL="${VALKEY_URL:-redis://localhost:6379}"
+FIRECRAWL_URL="${FIRECRAWL_API_URL:-http://localhost:3002}"
+
+echo "=== Valkey Deployment Test ==="
+echo "Valkey URL: $VALKEY_URL"
+echo "Firecrawl URL: $FIRECRAWL_URL"
+echo ""
+
+# Parse Valkey URL for redis-cli
+parse_url() {
+    local url=$1
+    # Remove redis:// or rediss://
+    url="${url#redis://}"
+    url="${url#rediss://}"
+    
+    # Extract password if present
+    if [[ "$url" == *"@"* ]]; then
+        local auth="${url%%@*}"
+        url="${url#*@}"
+        if [[ "$auth" == *":"* ]]; then
+            REDIS_PASSWORD="${auth#*:}"
+        else
+            REDIS_PASSWORD="$auth"
+        fi
+    fi
+    
+    # Extract host and port
+    REDIS_HOST="${url%%:*}"
+    REDIS_PORT="${url#*:}"
+    REDIS_PORT="${REDIS_PORT%%/*}"
+    
+    [ -z "$REDIS_HOST" ] && REDIS_HOST="localhost"
+    [ -z "$REDIS_PORT" ] && REDIS_PORT="6379"
+}
+
+parse_url "$VALKEY_URL"
+
+echo "1. Testing Valkey Connection..."
+if [ -n "$REDIS_PASSWORD" ]; then
+    PING_RESULT=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning ping 2>/dev/null || echo "FAILED")
+else
+    PING_RESULT=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" ping 2>/dev/null || echo "FAILED")
+fi
+
+if [ "$PING_RESULT" = "PONG" ]; then
+    echo "   ✅ Valkey connection: OK"
+else
+    echo "   ❌ Valkey connection: FAILED"
+    echo "   Make sure Valkey is running and accessible"
+    exit 1
+fi
+
+echo ""
+echo "2. Testing Valkey Info..."
+if [ -n "$REDIS_PASSWORD" ]; then
+    VERSION=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning info server 2>/dev/null | grep -E "redis_version|valkey_version" | head -1)
+else
+    VERSION=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" info server 2>/dev/null | grep -E "redis_version|valkey_version" | head -1)
+fi
+echo "   $VERSION"
+
+echo ""
+echo "3. Testing Firecrawl API..."
+HEALTH=$(curl -s "$FIRECRAWL_URL/health" 2>/dev/null || echo '{"error":"connection failed"}')
+if echo "$HEALTH" | grep -q "error"; then
+    echo "   ⚠️  Firecrawl API: Not available (optional for Valkey-only tests)"
+else
+    echo "   ✅ Firecrawl API: OK"
+fi
+
+echo ""
+echo "4. Testing Demo App Operations..."
+
+# Test rate limiter
+echo "   Testing rate limiter..."
+if [ -n "$REDIS_PASSWORD" ]; then
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning del "demo:ratelimit:test-user" > /dev/null 2>&1
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning zadd "demo:ratelimit:test-user" "$(date +%s)000" "test-1" > /dev/null 2>&1
+    COUNT=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning zcard "demo:ratelimit:test-user" 2>/dev/null)
+else
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" del "demo:ratelimit:test-user" > /dev/null 2>&1
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" zadd "demo:ratelimit:test-user" "$(date +%s)000" "test-1" > /dev/null 2>&1
+    COUNT=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" zcard "demo:ratelimit:test-user" 2>/dev/null)
+fi
+
+if [ "$COUNT" = "1" ]; then
+    echo "   ✅ Rate limiter (sorted set): OK"
+else
+    echo "   ❌ Rate limiter: FAILED"
+fi
+
+# Test cache
+echo "   Testing cache..."
+if [ -n "$REDIS_PASSWORD" ]; then
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning setex "demo:cache:test" 60 "test-value" > /dev/null 2>&1
+    VALUE=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning get "demo:cache:test" 2>/dev/null)
+else
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" setex "demo:cache:test" 60 "test-value" > /dev/null 2>&1
+    VALUE=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" get "demo:cache:test" 2>/dev/null)
+fi
+
+if [ "$VALUE" = "test-value" ]; then
+    echo "   ✅ Cache (string with TTL): OK"
+else
+    echo "   ❌ Cache: FAILED"
+fi
+
+# Test batch state
+echo "   Testing batch state..."
+if [ -n "$REDIS_PASSWORD" ]; then
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning hset "demo:batch:test" "data" '{"status":"pending"}' > /dev/null 2>&1
+    DATA=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning hget "demo:batch:test" "data" 2>/dev/null)
+else
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" hset "demo:batch:test" "data" '{"status":"pending"}' > /dev/null 2>&1
+    DATA=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" hget "demo:batch:test" "data" 2>/dev/null)
+fi
+
+if echo "$DATA" | grep -q "pending"; then
+    echo "   ✅ Batch state (hash): OK"
+else
+    echo "   ❌ Batch state: FAILED"
+fi
+
+# Cleanup test keys
+echo ""
+echo "5. Cleaning up test keys..."
+if [ -n "$REDIS_PASSWORD" ]; then
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" --no-auth-warning del "demo:ratelimit:test-user" "demo:cache:test" "demo:batch:test" > /dev/null 2>&1
+else
+    redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" del "demo:ratelimit:test-user" "demo:cache:test" "demo:batch:test" > /dev/null 2>&1
+fi
+echo "   ✅ Cleanup complete"
+
+echo ""
+echo "=== All Tests Passed ==="
+echo ""
+echo "Next steps:"
+echo "  - Run full demo: pnpm run demo:all"
+echo "  - Start web UI: pnpm run server"

--- a/apps/valkey-demo/scripts/test-k8s.sh
+++ b/apps/valkey-demo/scripts/test-k8s.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+# Test Kubernetes deployment for Firecrawl + Valkey
+# Usage: ./scripts/test-k8s.sh [deploy|test|cleanup|all]
+#
+# This script uses the existing Firecrawl K8s manifests from examples/kubernetes/cluster-install
+# but swaps redis.yaml for valkey.yaml
+#
+# Prerequisites:
+#   - kubectl configured with a cluster (Docker Desktop K8s, minikube, etc.)
+#   - Node.js and pnpm installed
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+FIRECRAWL_ROOT="$(dirname "$(dirname "$PROJECT_DIR")")"
+K8S_MANIFESTS="$FIRECRAWL_ROOT/examples/kubernetes/cluster-install"
+NAMESPACE="default"
+LOCAL_PORT=6380
+
+cd "$PROJECT_DIR"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+check_prerequisites() {
+    log "Checking prerequisites..."
+    
+    command -v kubectl >/dev/null 2>&1 || error "kubectl not found. Install it first."
+    command -v pnpm >/dev/null 2>&1 || error "pnpm not found. Install it first."
+    
+    # Check if cluster is accessible
+    kubectl cluster-info >/dev/null 2>&1 || error "Cannot connect to Kubernetes cluster. Is it running?"
+    
+    # Check if manifests exist
+    [ -d "$K8S_MANIFESTS" ] || error "K8s manifests not found at $K8S_MANIFESTS"
+    [ -f "$K8S_MANIFESTS/valkey.yaml" ] || error "valkey.yaml not found. Run from firecrawl repo."
+    
+    log "Prerequisites OK"
+}
+
+deploy() {
+    log "Deploying Firecrawl + Valkey to Kubernetes..."
+    log "Using manifests from: $K8S_MANIFESTS"
+    
+    cd "$K8S_MANIFESTS"
+    
+    # Deploy in order
+    log "Applying configmap..."
+    kubectl apply -f configmap.yaml -n $NAMESPACE
+    
+    log "Applying secrets..."
+    kubectl apply -f secret.yaml -n $NAMESPACE
+    
+    log "Applying Valkey (instead of Redis)..."
+    kubectl apply -f valkey.yaml -n $NAMESPACE
+    
+    log "Applying playwright-service..."
+    kubectl apply -f playwright-service.yaml -n $NAMESPACE
+    
+    log "Applying api..."
+    kubectl apply -f api.yaml -n $NAMESPACE
+    
+    log "Applying worker..."
+    kubectl apply -f worker.yaml -n $NAMESPACE
+    
+    log "Applying nuq-worker..."
+    kubectl apply -f nuq-worker.yaml -n $NAMESPACE
+    
+    log "Applying nuq-postgres..."
+    kubectl apply -f nuq-postgres.yaml -n $NAMESPACE
+    
+    cd "$PROJECT_DIR"
+    
+    log "Waiting for Valkey (redis service) to be ready..."
+    kubectl wait --for=condition=available --timeout=120s deployment/redis -n $NAMESPACE || {
+        warn "Valkey deployment not ready yet, checking status..."
+        kubectl get pods -n $NAMESPACE
+    }
+    
+    log "Waiting for Firecrawl API to be ready..."
+    kubectl wait --for=condition=available --timeout=300s deployment/api -n $NAMESPACE || {
+        warn "API deployment not ready yet. This can take a few minutes for image pull."
+        kubectl get pods -n $NAMESPACE
+    }
+    
+    # Extra wait for API to fully initialize
+    log "Waiting for API to initialize (30s)..."
+    sleep 30
+    
+    log "Deployment complete!"
+    echo ""
+    kubectl get pods -n $NAMESPACE
+}
+
+start_port_forward() {
+    log "Starting port-forward to Valkey (redis service) on localhost:$LOCAL_PORT..."
+    
+    # Kill any existing port-forwards
+    pkill -f "port-forward.*svc/redis.*$LOCAL_PORT" 2>/dev/null || true
+    pkill -f "port-forward.*svc/api.*3002" 2>/dev/null || true
+    sleep 1
+    
+    # Start Valkey port-forward in background
+    kubectl port-forward svc/redis $LOCAL_PORT:6379 -n $NAMESPACE &
+    VALKEY_PF_PID=$!
+    
+    # Start API port-forward in background
+    log "Starting port-forward to Firecrawl API on localhost:3002..."
+    kubectl port-forward svc/api 3002:3002 -n $NAMESPACE &
+    API_PF_PID=$!
+    
+    # Wait for port-forwards to be ready
+    sleep 5
+    
+    # Verify Valkey connection (no auth by default in the example manifests)
+    if redis-cli -p $LOCAL_PORT ping 2>/dev/null | grep -q PONG; then
+        log "Valkey port-forward ready (PID: $VALKEY_PF_PID)"
+    else
+        # Try with password from secret
+        REDIS_PASS=$(kubectl get secret firecrawl-secret -n $NAMESPACE -o jsonpath='{.data.REDIS_PASSWORD}' 2>/dev/null | base64 -d 2>/dev/null || echo "")
+        if [ -n "$REDIS_PASS" ] && redis-cli -p $LOCAL_PORT -a "$REDIS_PASS" --no-auth-warning ping | grep -q PONG; then
+            log "Valkey port-forward ready with auth (PID: $VALKEY_PF_PID)"
+            export VALKEY_PASSWORD="$REDIS_PASS"
+        else
+            warn "Could not verify Valkey connection, but continuing..."
+        fi
+    fi
+    
+    # Verify API connection
+    if curl -s http://localhost:3002/v0/health/liveness >/dev/null 2>&1; then
+        log "API port-forward ready (PID: $API_PF_PID)"
+    else
+        warn "API not responding yet. Scrape/crawl tests may fail."
+    fi
+}
+
+stop_port_forward() {
+    log "Stopping port-forwards..."
+    pkill -f "port-forward.*svc/redis.*$LOCAL_PORT" 2>/dev/null || true
+    pkill -f "port-forward.*svc/api.*3002" 2>/dev/null || true
+}
+
+run_tests() {
+    log "Running demo tests against Kubernetes Valkey..."
+    
+    cd "$PROJECT_DIR"
+    
+    # Ensure dependencies are installed
+    if [ ! -d "node_modules" ]; then
+        log "Installing dependencies..."
+        pnpm install
+    fi
+    
+    # Build connection URL
+    if [ -n "$VALKEY_PASSWORD" ]; then
+        VALKEY_URL="redis://:$VALKEY_PASSWORD@localhost:$LOCAL_PORT"
+    else
+        VALKEY_URL="redis://localhost:$LOCAL_PORT"
+    fi
+    
+    log "Connecting to Valkey: $VALKEY_URL"
+    log "Connecting to Firecrawl API: http://localhost:3002"
+    
+    # Run the demo
+    VALKEY_URL="$VALKEY_URL" FIRECRAWL_API_URL="http://localhost:3002" pnpm run demo:all
+    
+    log "Tests complete!"
+}
+
+cleanup() {
+    log "Cleaning up Kubernetes resources..."
+    
+    stop_port_forward
+    
+    cd "$K8S_MANIFESTS"
+    
+    kubectl delete -f nuq-postgres.yaml -n $NAMESPACE --ignore-not-found=true
+    kubectl delete -f nuq-worker.yaml -n $NAMESPACE --ignore-not-found=true
+    kubectl delete -f worker.yaml -n $NAMESPACE --ignore-not-found=true
+    kubectl delete -f api.yaml -n $NAMESPACE --ignore-not-found=true
+    kubectl delete -f playwright-service.yaml -n $NAMESPACE --ignore-not-found=true
+    kubectl delete -f valkey.yaml -n $NAMESPACE --ignore-not-found=true
+    kubectl delete -f secret.yaml -n $NAMESPACE --ignore-not-found=true
+    kubectl delete -f configmap.yaml -n $NAMESPACE --ignore-not-found=true
+    
+    cd "$PROJECT_DIR"
+    
+    log "Cleanup complete!"
+}
+
+show_status() {
+    log "Current status in namespace: $NAMESPACE"
+    echo ""
+    echo "Pods:"
+    kubectl get pods -n $NAMESPACE 2>/dev/null || echo "  None"
+    echo ""
+    echo "Services:"
+    kubectl get svc -n $NAMESPACE 2>/dev/null || echo "  None"
+    echo ""
+    echo "Deployments:"
+    kubectl get deployments -n $NAMESPACE 2>/dev/null || echo "  None"
+}
+
+usage() {
+    echo "Usage: $0 [command]"
+    echo ""
+    echo "Commands:"
+    echo "  deploy    - Deploy Firecrawl + Valkey to Kubernetes"
+    echo "  test      - Run demo tests (requires deploy first)"
+    echo "  cleanup   - Remove all Kubernetes resources"
+    echo "  status    - Show current deployment status"
+    echo "  all       - Deploy, test, and cleanup (full cycle)"
+    echo ""
+    echo "This script uses the Firecrawl K8s manifests from:"
+    echo "  examples/kubernetes/cluster-install/"
+    echo ""
+    echo "It deploys valkey.yaml instead of redis.yaml to use Valkey."
+    echo ""
+    echo "Examples:"
+    echo "  $0 deploy     # Deploy to K8s"
+    echo "  $0 test       # Run tests"
+    echo "  $0 cleanup    # Clean up"
+    echo "  $0 all        # Full test cycle"
+}
+
+# Main
+case "${1:-all}" in
+    deploy)
+        check_prerequisites
+        deploy
+        ;;
+    test)
+        check_prerequisites
+        start_port_forward
+        run_tests
+        stop_port_forward
+        ;;
+    cleanup)
+        cleanup
+        ;;
+    status)
+        show_status
+        ;;
+    all)
+        check_prerequisites
+        deploy
+        start_port_forward
+        run_tests
+        stop_port_forward
+        echo ""
+        read -p "Press Enter to cleanup, or Ctrl+C to keep running... "
+        cleanup
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        echo "Unknown command: $1"
+        usage
+        exit 1
+        ;;
+esac

--- a/apps/valkey-demo/src/config.ts
+++ b/apps/valkey-demo/src/config.ts
@@ -1,0 +1,21 @@
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+export const config = {
+  firecrawl: {
+    apiUrl: process.env.FIRECRAWL_API_URL || 'http://localhost:3002',
+    apiKey: process.env.FIRECRAWL_API_KEY || 'fc-test-key',
+  },
+  valkey: {
+    url: process.env.VALKEY_URL || 'redis://localhost:6379',
+  },
+  rateLimit: {
+    max: parseInt(process.env.DEMO_RATE_LIMIT_MAX || '10', 10),
+    windowMs: parseInt(process.env.DEMO_RATE_LIMIT_WINDOW_MS || '60000', 10),
+  },
+  cache: {
+    ttlSeconds: parseInt(process.env.DEMO_CACHE_TTL_SECONDS || '3600', 10),
+  },
+};

--- a/apps/valkey-demo/src/demos/batch-demo.ts
+++ b/apps/valkey-demo/src/demos/batch-demo.ts
@@ -1,0 +1,60 @@
+import { BatchManager } from '../services/batch-manager';
+import { getValkeyClient, closeValkeyClient } from '../valkey-client';
+
+/**
+ * Demo: Batch operations with Valkey GLIDE state management
+ * Shows batch scraping with progress tracking and caching
+ */
+export async function runBatchDemo(): Promise<void> {
+  console.log('\n=== Batch Operations Demo with Valkey GLIDE ===\n');
+
+  const batchManager = new BatchManager();
+  
+  const urls = [
+    'https://example.com',
+    'https://example.org',
+    'https://example.net',
+  ];
+
+  try {
+    const client = await getValkeyClient();
+    await client.ping();
+    console.log('[Demo] Connected to Valkey via GLIDE\n');
+
+    // Create a batch job
+    console.log(`[Demo] Creating batch job for ${urls.length} URLs...`);
+    const batchId = await batchManager.createBatch(urls);
+    console.log(`[Demo] Batch ID: ${batchId}\n`);
+
+    // Check active batches
+    const activeBatches = await batchManager.listActiveBatches();
+    console.log(`[Demo] Active batches: ${activeBatches.length}`);
+
+    // Process the batch
+    console.log('\n[Demo] Processing batch (with rate limiting and caching)...\n');
+    const result = await batchManager.processBatch(batchId, 2);
+
+    // Show results
+    console.log(`\n[Demo] Batch completed!`);
+    console.log(`[Demo] Status: ${result.status}`);
+    console.log(`[Demo] Duration: ${result.completedAt! - result.createdAt}ms`);
+    console.log(`[Demo] Results:`);
+    
+    for (const [url, scrapeResult] of Object.entries(result.results)) {
+      const status = scrapeResult.success ? '✅' : '❌';
+      const preview = scrapeResult.data?.markdown?.slice(0, 50) || scrapeResult.error || 'No content';
+      console.log(`  ${status} ${url}: ${preview}...`);
+    }
+
+    // Verify batch status from Valkey
+    const storedStatus = await batchManager.getBatchStatus(batchId);
+    console.log(`\n[Demo] Stored status in Valkey: ${storedStatus?.status}`);
+
+  } finally {
+    await closeValkeyClient();
+  }
+}
+
+if (require.main === module) {
+  runBatchDemo().catch(console.error);
+}

--- a/apps/valkey-demo/src/demos/crawl-demo.ts
+++ b/apps/valkey-demo/src/demos/crawl-demo.ts
@@ -1,0 +1,84 @@
+import { FirecrawlClient } from '../firecrawl-client';
+import { CacheService } from '../services/cache-service';
+import { getValkeyClient, closeValkeyClient } from '../valkey-client';
+
+/**
+ * Demo: Web crawling with Valkey GLIDE state tracking
+ * Shows how to track crawl progress and cache results
+ */
+export async function runCrawlDemo(): Promise<void> {
+  console.log('\n=== Crawl Demo with Valkey GLIDE State Tracking ===\n');
+
+  const firecrawl = new FirecrawlClient();
+  const cache = new CacheService();
+  const testUrl = 'https://example.com';
+
+  try {
+    const client = await getValkeyClient();
+    await client.ping();
+    console.log('[Demo] Connected to Valkey via GLIDE\n');
+
+    // Start a crawl
+    console.log(`[Demo] Starting crawl of ${testUrl}...`);
+    const crawlResult = await firecrawl.crawl(testUrl, { limit: 5 });
+
+    if (!crawlResult.success || !crawlResult.id) {
+      console.log(`[Demo] Failed to start crawl: ${crawlResult.error}`);
+      return;
+    }
+
+    const crawlId = crawlResult.id;
+    console.log(`[Demo] Crawl started with ID: ${crawlId}`);
+
+    // Store crawl ID in Valkey for tracking
+    await client.hset('demo:crawls:active', [{ 
+      field: crawlId, 
+      value: JSON.stringify({ url: testUrl, startedAt: Date.now() })
+    }]);
+
+    // Poll for completion
+    console.log('[Demo] Polling for crawl completion...');
+    let status = await firecrawl.getCrawlStatus(crawlId);
+    let attempts = 0;
+    const maxAttempts = 30;
+
+    while (status.status !== 'completed' && status.status !== 'failed' && attempts < maxAttempts) {
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      status = await firecrawl.getCrawlStatus(crawlId);
+      attempts++;
+      console.log(`[Demo] Status: ${status.status} (attempt ${attempts}/${maxAttempts})`);
+    }
+
+    if (status.status === 'completed') {
+      console.log(`\n[Demo] Crawl completed! Found ${status.data?.length || 0} pages`);
+      
+      // Cache the result
+      await cache.cacheCrawlResult(crawlId, status);
+      
+      // Show sample results
+      status.data?.slice(0, 3).forEach((page, i) => {
+        console.log(`[Demo] Page ${i + 1}: ${page.url}`);
+      });
+
+      // Move from active to completed in Valkey
+      await client.hdel('demo:crawls:active', [crawlId]);
+      await client.hset('demo:crawls:completed', [{
+        field: crawlId,
+        value: JSON.stringify({
+          url: testUrl,
+          completedAt: Date.now(),
+          pageCount: status.data?.length || 0,
+        })
+      }]);
+    } else {
+      console.log(`[Demo] Crawl ended with status: ${status.status}`);
+    }
+
+  } finally {
+    await closeValkeyClient();
+  }
+}
+
+if (require.main === module) {
+  runCrawlDemo().catch(console.error);
+}

--- a/apps/valkey-demo/src/demos/rate-limit-demo.ts
+++ b/apps/valkey-demo/src/demos/rate-limit-demo.ts
@@ -1,0 +1,63 @@
+import { RateLimiter } from '../services/rate-limiter';
+import { getValkeyClient, closeValkeyClient } from '../valkey-client';
+
+/**
+ * Demo: Rate limiting with Valkey GLIDE
+ * Shows sliding window rate limiting for API protection
+ */
+export async function runRateLimitDemo(): Promise<void> {
+  console.log('\n=== Rate Limiting Demo with Valkey GLIDE ===\n');
+
+  // Create a rate limiter: 5 requests per 10 seconds for demo
+  const rateLimiter = new RateLimiter(5, 10000);
+  const userId = 'demo-user-123';
+
+  try {
+    const client = await getValkeyClient();
+    await client.ping();
+    console.log('[Demo] Connected to Valkey via GLIDE\n');
+
+    // Reset any existing limits for clean demo
+    await rateLimiter.resetLimit(userId);
+    console.log(`[Demo] Rate limit config: 5 requests per 10 seconds\n`);
+
+    // Simulate rapid requests
+    console.log('[Demo] Simulating 8 rapid requests...\n');
+    
+    for (let i = 1; i <= 8; i++) {
+      const result = await rateLimiter.checkLimit(userId);
+      
+      if (result.allowed) {
+        console.log(`[Demo] Request ${i}: ✅ ALLOWED (${result.remaining} remaining)`);
+      } else {
+        const resetIn = Math.ceil((result.resetAt - Date.now()) / 1000);
+        console.log(`[Demo] Request ${i}: ❌ BLOCKED (resets in ${resetIn}s)`);
+      }
+      
+      // Small delay between requests
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    // Wait for window to partially reset
+    console.log('\n[Demo] Waiting 5 seconds...\n');
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    // Check remaining
+    const remaining = await rateLimiter.getRemainingRequests(userId);
+    console.log(`[Demo] After waiting: ${remaining} requests available`);
+
+    // Try a few more requests
+    console.log('\n[Demo] Trying 3 more requests...\n');
+    for (let i = 1; i <= 3; i++) {
+      const result = await rateLimiter.checkLimit(userId);
+      console.log(`[Demo] Request ${i}: ${result.allowed ? '✅ ALLOWED' : '❌ BLOCKED'} (${result.remaining} remaining)`);
+    }
+
+  } finally {
+    await closeValkeyClient();
+  }
+}
+
+if (require.main === module) {
+  runRateLimitDemo().catch(console.error);
+}

--- a/apps/valkey-demo/src/demos/scrape-demo.ts
+++ b/apps/valkey-demo/src/demos/scrape-demo.ts
@@ -1,0 +1,59 @@
+import { FirecrawlClient } from '../firecrawl-client';
+import { CacheService } from '../services/cache-service';
+import { getValkeyClient, closeValkeyClient } from '../valkey-client';
+
+/**
+ * Demo: Web scraping with Valkey GLIDE caching
+ * Shows how to cache scrape results to avoid redundant API calls
+ */
+export async function runScrapeDemo(): Promise<void> {
+  console.log('\n=== Scrape Demo with Valkey GLIDE Caching ===\n');
+
+  const firecrawl = new FirecrawlClient();
+  const cache = new CacheService(300); // 5 minute TTL for demo
+  const testUrl = 'https://example.com';
+
+  try {
+    // Connect to Valkey
+    const client = await getValkeyClient();
+    await client.ping();
+    console.log('[Demo] Connected to Valkey via GLIDE\n');
+
+    // First scrape - should be a cache miss
+    console.log('[Demo] First scrape (expecting cache miss)...');
+    let result = await cache.getCachedScrape(testUrl);
+    
+    if (!result) {
+      console.log('[Demo] Calling Firecrawl API...');
+      result = await firecrawl.scrape(testUrl, { formats: ['markdown'] });
+      
+      if (result.success) {
+        await cache.cacheScrapeResult(testUrl, result);
+        console.log('[Demo] Scrape successful, result cached');
+        console.log(`[Demo] Content preview: ${result.data?.markdown?.slice(0, 200)}...`);
+      } else {
+        console.log(`[Demo] Scrape failed: ${result.error}`);
+      }
+    }
+
+    // Second scrape - should be a cache hit
+    console.log('\n[Demo] Second scrape (expecting cache hit)...');
+    const cachedResult = await cache.getCachedScrape(testUrl);
+    
+    if (cachedResult) {
+      console.log('[Demo] Retrieved from cache - no API call needed!');
+    }
+
+    // Show cache stats
+    const stats = await cache.getStats();
+    console.log(`\n[Demo] Cache stats: ${stats.keys} keys, ${stats.memoryUsage} memory used`);
+
+  } finally {
+    await closeValkeyClient();
+  }
+}
+
+// Run if executed directly
+if (require.main === module) {
+  runScrapeDemo().catch(console.error);
+}

--- a/apps/valkey-demo/src/firecrawl-client.ts
+++ b/apps/valkey-demo/src/firecrawl-client.ts
@@ -1,0 +1,75 @@
+import axios, { AxiosInstance } from 'axios';
+import { config } from './config';
+
+export interface ScrapeResult {
+  success: boolean;
+  data?: {
+    markdown?: string;
+    html?: string;
+    metadata?: Record<string, unknown>;
+  };
+  error?: string;
+}
+
+export interface CrawlResult {
+  success: boolean;
+  id?: string;
+  status?: string;
+  data?: Array<{
+    markdown?: string;
+    url?: string;
+    metadata?: Record<string, unknown>;
+  }>;
+  error?: string;
+}
+
+export class FirecrawlClient {
+  private client: AxiosInstance;
+
+  constructor() {
+    this.client = axios.create({
+      baseURL: config.firecrawl.apiUrl,
+      headers: {
+        'Authorization': `Bearer ${config.firecrawl.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      timeout: 60000,
+    });
+  }
+
+  async scrape(url: string, options: Record<string, unknown> = {}): Promise<ScrapeResult> {
+    try {
+      const response = await this.client.post('/v1/scrape', { url, ...options });
+      return { success: true, data: response.data.data };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  }
+
+  async crawl(url: string, options: Record<string, unknown> = {}): Promise<CrawlResult> {
+    try {
+      const response = await this.client.post('/v1/crawl', { url, ...options });
+      return { success: true, id: response.data.id };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  }
+
+  async getCrawlStatus(crawlId: string): Promise<CrawlResult> {
+    try {
+      const response = await this.client.get(`/v1/crawl/${crawlId}`);
+      return { success: true, ...response.data };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  }
+
+  async cancelCrawl(crawlId: string): Promise<{ success: boolean; error?: string }> {
+    try {
+      await this.client.delete(`/v1/crawl/${crawlId}`);
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  }
+}

--- a/apps/valkey-demo/src/index.ts
+++ b/apps/valkey-demo/src/index.ts
@@ -1,0 +1,63 @@
+import { runScrapeDemo } from './demos/scrape-demo';
+import { runCrawlDemo } from './demos/crawl-demo';
+import { runRateLimitDemo } from './demos/rate-limit-demo';
+import { runBatchDemo } from './demos/batch-demo';
+import { closeValkeyClient } from './valkey-client';
+
+async function runAllDemos(): Promise<void> {
+  console.log('╔════════════════════════════════════════════════════════════╗');
+  console.log('║     Firecrawl + Valkey Demo Application                    ║');
+  console.log('║     Demonstrating caching, rate limiting, and batching     ║');
+  console.log('╚════════════════════════════════════════════════════════════╝');
+
+  const demos = [
+    { name: 'Rate Limiting', fn: runRateLimitDemo },
+    { name: 'Scrape with Caching', fn: runScrapeDemo },
+    { name: 'Crawl with State Tracking', fn: runCrawlDemo },
+    { name: 'Batch Operations', fn: runBatchDemo },
+  ];
+
+  for (const demo of demos) {
+    console.log(`\n${'─'.repeat(60)}`);
+    console.log(`Running: ${demo.name}`);
+    console.log('─'.repeat(60));
+    
+    try {
+      await demo.fn();
+    } catch (error: any) {
+      console.error(`[Error] ${demo.name} failed: ${error.message}`);
+    }
+  }
+
+  console.log(`\n${'═'.repeat(60)}`);
+  console.log('All demos completed!');
+  console.log('═'.repeat(60));
+}
+
+// Parse command line args for individual demos
+const arg = process.argv[2];
+
+async function main(): Promise<void> {
+  try {
+    switch (arg) {
+      case 'scrape':
+        await runScrapeDemo();
+        break;
+      case 'crawl':
+        await runCrawlDemo();
+        break;
+      case 'rate-limit':
+        await runRateLimitDemo();
+        break;
+      case 'batch':
+        await runBatchDemo();
+        break;
+      default:
+        await runAllDemos();
+    }
+  } finally {
+    await closeValkeyClient();
+  }
+}
+
+main().catch(console.error);

--- a/apps/valkey-demo/src/server.ts
+++ b/apps/valkey-demo/src/server.ts
@@ -1,0 +1,177 @@
+import express from 'express';
+import path from 'path';
+import { config } from './config';
+import { getValkeyClient, closeValkeyClient } from './valkey-client';
+import { RateLimiter } from './services/rate-limiter';
+import { CacheService } from './services/cache-service';
+import { BatchManager } from './services/batch-manager';
+import { FirecrawlClient } from './firecrawl-client';
+
+const app = express();
+app.use(express.json());
+app.use(express.static(path.join(__dirname, '../public')));
+
+const rateLimiter = new RateLimiter();
+const cache = new CacheService();
+const batchManager = new BatchManager();
+const firecrawl = new FirecrawlClient();
+
+// Health check
+app.get('/api/health', async (_req, res) => {
+  try {
+    const client = await getValkeyClient();
+    await client.ping();
+    res.json({ status: 'ok', valkey: 'connected' });
+  } catch (error: any) {
+    res.status(500).json({ status: 'error', error: error.message });
+  }
+});
+
+// Rate limit status
+app.get('/api/rate-limit/:id', async (req, res) => {
+  try {
+    const remaining = await rateLimiter.getRemainingRequests(req.params.id);
+    res.json({ identifier: req.params.id, remaining, max: config.rateLimit.max });
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Check rate limit
+app.post('/api/rate-limit/:id/check', async (req, res) => {
+  try {
+    const result = await rateLimiter.checkLimit(req.params.id);
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Reset rate limit
+app.post('/api/rate-limit/:id/reset', async (req, res) => {
+  try {
+    await rateLimiter.resetLimit(req.params.id);
+    res.json({ success: true });
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Scrape with caching
+app.post('/api/scrape', async (req, res) => {
+  const { url } = req.body;
+  if (!url) {
+    return res.status(400).json({ error: 'URL required' });
+  }
+
+  try {
+    // Check cache first
+    let result = await cache.getCachedScrape(url);
+    let fromCache = true;
+
+    if (!result) {
+      fromCache = false;
+      result = await firecrawl.scrape(url, { formats: ['markdown'] });
+      if (result.success) {
+        await cache.cacheScrapeResult(url, result);
+      }
+    }
+
+    return res.json({ ...result, fromCache });
+  } catch (error: any) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+// Cache stats
+app.get('/api/cache/stats', async (_req, res) => {
+  try {
+    const stats = await cache.getStats();
+    res.json(stats);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Clear cache
+app.post('/api/cache/clear', async (_req, res) => {
+  try {
+    const count = await cache.invalidate('*');
+    res.json({ cleared: count });
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Create batch
+app.post('/api/batch', async (req, res) => {
+  const { urls } = req.body;
+  if (!urls || !Array.isArray(urls)) {
+    return res.status(400).json({ error: 'URLs array required' });
+  }
+
+  try {
+    const batchId = await batchManager.createBatch(urls);
+    return res.json({ batchId });
+  } catch (error: any) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+// Get batch status
+app.get('/api/batch/:id', async (req, res) => {
+  try {
+    const status = await batchManager.getBatchStatus(req.params.id);
+    if (!status) {
+      return res.status(404).json({ error: 'Batch not found' });
+    }
+    return res.json(status);
+  } catch (error: any) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+// Process batch
+app.post('/api/batch/:id/process', async (req, res) => {
+  try {
+    const result = await batchManager.processBatch(req.params.id);
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// List active batches
+app.get('/api/batches', async (_req, res) => {
+  try {
+    const batches = await batchManager.listActiveBatches();
+    res.json({ batches });
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Valkey info
+app.get('/api/valkey/info', async (_req, res) => {
+  try {
+    const client = await getValkeyClient();
+    const info = await client.customCommand(['INFO']);
+    res.json({ info: info?.toString() });
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+const PORT = process.env.PORT || 3030;
+
+app.listen(PORT, () => {
+  console.log(`\n🚀 Valkey Demo Server running at http://localhost:${PORT}`);
+  console.log(`   Firecrawl API: ${config.firecrawl.apiUrl}`);
+  console.log(`   Valkey: ${config.valkey.url}\n`);
+});
+
+process.on('SIGINT', async () => {
+  console.log('\nShutting down...');
+  await closeValkeyClient();
+  process.exit(0);
+});

--- a/apps/valkey-demo/src/services/batch-manager.ts
+++ b/apps/valkey-demo/src/services/batch-manager.ts
@@ -1,0 +1,150 @@
+import { getValkeyClient } from '../valkey-client';
+import { FirecrawlClient, ScrapeResult } from '../firecrawl-client';
+import { RateLimiter } from './rate-limiter';
+import { CacheService } from './cache-service';
+
+export interface BatchJob {
+  id: string;
+  urls: string[];
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  progress: number;
+  results: Record<string, ScrapeResult>;
+  createdAt: number;
+  completedAt?: number;
+}
+
+/**
+ * Batch operation manager using Valkey GLIDE for state management
+ * Demonstrates batch processing with progress tracking
+ */
+export class BatchManager {
+  private prefix = 'demo:batch';
+  private firecrawl: FirecrawlClient;
+  private rateLimiter: RateLimiter;
+  private cache: CacheService;
+
+  constructor() {
+    this.firecrawl = new FirecrawlClient();
+    this.rateLimiter = new RateLimiter();
+    this.cache = new CacheService();
+  }
+
+  async createBatch(urls: string[]): Promise<string> {
+    const client = await getValkeyClient();
+    const batchId = `batch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    
+    const job: BatchJob = {
+      id: batchId,
+      urls,
+      status: 'pending',
+      progress: 0,
+      results: {},
+      createdAt: Date.now(),
+    };
+
+    await client.hset(`${this.prefix}:${batchId}`, [{ field: 'data', value: JSON.stringify(job) }]);
+    await client.sadd(`${this.prefix}:active`, [batchId]);
+    
+    console.log(`[Batch] Created batch ${batchId} with ${urls.length} URLs`);
+    return batchId;
+  }
+
+  async processBatch(batchId: string, concurrency: number = 3): Promise<BatchJob> {
+    const client = await getValkeyClient();
+    const jobData = await client.hget(`${this.prefix}:${batchId}`, 'data');
+    
+    if (!jobData) {
+      throw new Error(`Batch ${batchId} not found`);
+    }
+
+    const job = JSON.parse(jobData.toString()) as BatchJob;
+    job.status = 'processing';
+    job.results = {};
+
+    await this.updateJobState(batchId, job);
+
+    const results: Record<string, ScrapeResult> = {};
+    const urls = [...job.urls];
+    let completed = 0;
+
+    const processUrl = async (url: string): Promise<void> => {
+      const rateCheck = await this.rateLimiter.checkLimit('batch-scrape');
+      if (!rateCheck.allowed) {
+        console.log(`[Batch] Rate limited, waiting...`);
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+
+      let result = await this.cache.getCachedScrape(url);
+      
+      if (!result) {
+        result = await this.firecrawl.scrape(url);
+        if (result.success) {
+          await this.cache.cacheScrapeResult(url, result);
+        }
+      }
+
+      results[url] = result;
+      completed++;
+      job.progress = Math.round((completed / job.urls.length) * 100);
+      job.results = results;
+      
+      await this.updateJobState(batchId, job);
+      console.log(`[Batch] Progress: ${job.progress}% (${completed}/${job.urls.length})`);
+    };
+
+    for (let i = 0; i < urls.length; i += concurrency) {
+      const batch = urls.slice(i, i + concurrency);
+      await Promise.all(batch.map(processUrl));
+    }
+
+    job.status = 'completed';
+    job.progress = 100;
+    job.completedAt = Date.now();
+
+    await this.updateJobState(batchId, job);
+    await client.srem(`${this.prefix}:active`, [batchId]);
+    await client.sadd(`${this.prefix}:completed`, [batchId]);
+
+    console.log(`[Batch] Completed batch ${batchId}`);
+    return job;
+  }
+
+  private async updateJobState(batchId: string, job: BatchJob): Promise<void> {
+    const client = await getValkeyClient();
+    await client.hset(`${this.prefix}:${batchId}`, [{ field: 'data', value: JSON.stringify(job) }]);
+  }
+
+  async getBatchStatus(batchId: string): Promise<BatchJob | null> {
+    const client = await getValkeyClient();
+    const jobData = await client.hget(`${this.prefix}:${batchId}`, 'data');
+    
+    if (!jobData) return null;
+    return JSON.parse(jobData.toString()) as BatchJob;
+  }
+
+  async listActiveBatches(): Promise<string[]> {
+    const client = await getValkeyClient();
+    const members = await client.smembers(`${this.prefix}:active`);
+    return Array.from(members).map(m => m.toString());
+  }
+
+  async cancelBatch(batchId: string): Promise<boolean> {
+    const client = await getValkeyClient();
+    const exists = await client.exists([`${this.prefix}:${batchId}`]);
+    
+    if (!exists) return false;
+
+    await client.srem(`${this.prefix}:active`, [batchId]);
+    await client.sadd(`${this.prefix}:cancelled`, [batchId]);
+    
+    const jobData = await client.hget(`${this.prefix}:${batchId}`, 'data');
+    if (jobData) {
+      const job = JSON.parse(jobData.toString()) as BatchJob;
+      job.status = 'failed';
+      await this.updateJobState(batchId, job);
+    }
+
+    console.log(`[Batch] Cancelled batch ${batchId}`);
+    return true;
+  }
+}

--- a/apps/valkey-demo/src/services/cache-service.ts
+++ b/apps/valkey-demo/src/services/cache-service.ts
@@ -1,0 +1,116 @@
+import { getValkeyClient } from '../valkey-client';
+import { config } from '../config';
+import { ScrapeResult, CrawlResult } from '../firecrawl-client';
+import { TimeUnit } from '@valkey/valkey-glide';
+
+/**
+ * Caching service for Firecrawl results using Valkey GLIDE
+ * Demonstrates caching patterns for web scraping data
+ */
+export class CacheService {
+  private prefix = 'demo:cache';
+  private ttlSeconds: number;
+
+  constructor(ttlSeconds?: number) {
+    this.ttlSeconds = ttlSeconds ?? config.cache.ttlSeconds;
+  }
+
+  private generateKey(type: string, url: string): string {
+    // Create a simple hash of the URL for the key
+    const urlHash = Buffer.from(url).toString('base64').slice(0, 32);
+    return `${this.prefix}:${type}:${urlHash}`;
+  }
+
+  async getCachedScrape(url: string): Promise<ScrapeResult | null> {
+    const client = await getValkeyClient();
+    const key = this.generateKey('scrape', url);
+    
+    const cached = await client.get(key);
+    if (cached) {
+      console.log(`[Cache] HIT for scrape: ${url}`);
+      return JSON.parse(cached.toString());
+    }
+    
+    console.log(`[Cache] MISS for scrape: ${url}`);
+    return null;
+  }
+
+  async cacheScrapeResult(url: string, result: ScrapeResult): Promise<void> {
+    if (!result.success) return; // Don't cache failures
+    
+    const client = await getValkeyClient();
+    const key = this.generateKey('scrape', url);
+    
+    await client.set(key, JSON.stringify(result), { expiry: { type: TimeUnit.Seconds, count: this.ttlSeconds } });
+    console.log(`[Cache] Stored scrape result for: ${url} (TTL: ${this.ttlSeconds}s)`);
+  }
+
+  async getCachedCrawl(crawlId: string): Promise<CrawlResult | null> {
+    const client = await getValkeyClient();
+    const key = `${this.prefix}:crawl:${crawlId}`;
+    
+    const cached = await client.get(key);
+    if (cached) {
+      console.log(`[Cache] HIT for crawl: ${crawlId}`);
+      return JSON.parse(cached.toString());
+    }
+    
+    console.log(`[Cache] MISS for crawl: ${crawlId}`);
+    return null;
+  }
+
+  async cacheCrawlResult(crawlId: string, result: CrawlResult): Promise<void> {
+    if (!result.success || result.status !== 'completed') return;
+    
+    const client = await getValkeyClient();
+    const key = `${this.prefix}:crawl:${crawlId}`;
+    
+    await client.set(key, JSON.stringify(result), { expiry: { type: TimeUnit.Seconds, count: this.ttlSeconds } });
+    console.log(`[Cache] Stored crawl result: ${crawlId} (TTL: ${this.ttlSeconds}s)`);
+  }
+
+  async invalidate(pattern: string): Promise<number> {
+    const client = await getValkeyClient();
+    // GLIDE uses scan for pattern matching
+    const keys: string[] = [];
+    let cursor = '0';
+    
+    do {
+      const result = await client.customCommand(['SCAN', cursor, 'MATCH', `${this.prefix}:${pattern}*`, 'COUNT', '100']);
+      const [nextCursor, foundKeys] = result as [string, string[]];
+      cursor = nextCursor.toString();
+      keys.push(...foundKeys.map(k => k.toString()));
+    } while (cursor !== '0');
+    
+    if (keys.length > 0) {
+      await client.del(keys);
+      console.log(`[Cache] Invalidated ${keys.length} keys matching: ${pattern}`);
+    }
+    
+    return keys.length;
+  }
+
+  async getStats(): Promise<{ keys: number; memoryUsage: string }> {
+    const client = await getValkeyClient();
+    
+    // Count keys with our prefix
+    const keys: string[] = [];
+    let cursor = '0';
+    do {
+      const result = await client.customCommand(['SCAN', cursor, 'MATCH', `${this.prefix}:*`, 'COUNT', '100']);
+      const [nextCursor, foundKeys] = result as [string, string[]];
+      cursor = nextCursor.toString();
+      keys.push(...foundKeys.map(k => k.toString()));
+    } while (cursor !== '0');
+
+    // Get memory info
+    const info = await client.customCommand(['INFO', 'memory']);
+    const infoStr = info?.toString() || '';
+    const memMatch = infoStr.match(/used_memory_human:(\S+)/);
+    
+    return {
+      keys: keys.length,
+      memoryUsage: memMatch?.[1] || 'unknown',
+    };
+  }
+}

--- a/apps/valkey-demo/src/services/rate-limiter.ts
+++ b/apps/valkey-demo/src/services/rate-limiter.ts
@@ -1,0 +1,68 @@
+import { getValkeyClient } from '../valkey-client';
+import { config } from '../config';
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+}
+
+/**
+ * Sliding window rate limiter using Valkey GLIDE
+ * Demonstrates rate limiting pattern for API calls
+ */
+export class RateLimiter {
+  private prefix = 'demo:ratelimit';
+  private maxRequests: number;
+  private windowMs: number;
+
+  constructor(maxRequests?: number, windowMs?: number) {
+    this.maxRequests = maxRequests ?? config.rateLimit.max;
+    this.windowMs = windowMs ?? config.rateLimit.windowMs;
+  }
+
+  async checkLimit(identifier: string): Promise<RateLimitResult> {
+    const client = await getValkeyClient();
+    const key = `${this.prefix}:${identifier}`;
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+
+    // Remove old entries outside the window
+    await client.zremRangeByScore(key, { value: 0, isInclusive: true }, { value: windowStart, isInclusive: true });
+    
+    // Count current requests in window
+    const currentCount = await client.zcard(key);
+    
+    const allowed = currentCount < this.maxRequests;
+    
+    if (allowed) {
+      // Add current request
+      await client.zadd(key, [{ element: `${now}-${Math.random()}`, score: now }]);
+      // Set expiry on the key
+      await client.pexpire(key, this.windowMs);
+    }
+
+    const remaining = Math.max(0, this.maxRequests - currentCount - (allowed ? 1 : 0));
+    const resetAt = now + this.windowMs;
+
+    return { allowed, remaining, resetAt };
+  }
+
+  async getRemainingRequests(identifier: string): Promise<number> {
+    const client = await getValkeyClient();
+    const key = `${this.prefix}:${identifier}`;
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+
+    await client.zremRangeByScore(key, { value: 0, isInclusive: true }, { value: windowStart, isInclusive: true });
+    const count = await client.zcard(key);
+    
+    return Math.max(0, this.maxRequests - count);
+  }
+
+  async resetLimit(identifier: string): Promise<void> {
+    const client = await getValkeyClient();
+    const key = `${this.prefix}:${identifier}`;
+    await client.del([key]);
+  }
+}

--- a/apps/valkey-demo/src/valkey-client.ts
+++ b/apps/valkey-demo/src/valkey-client.ts
@@ -1,0 +1,52 @@
+import { GlideClient } from '@valkey/valkey-glide';
+import { config } from './config';
+
+let client: GlideClient | null = null;
+
+export async function getValkeyClient(): Promise<GlideClient> {
+  if (!client) {
+    // Parse URL to extract host, port, and password
+    // Supports: redis://localhost:6379, redis://:password@localhost:6379
+    const url = config.valkey.url;
+    let host = 'localhost';
+    let port = 6379;
+    let password: string | undefined;
+
+    try {
+      // Replace redis:// with http:// for URL parsing
+      const parsed = new URL(url.replace(/^rediss?:\/\//, 'http://'));
+      host = parsed.hostname || 'localhost';
+      port = parseInt(parsed.port, 10) || 6379;
+      
+      // Password can be in the format redis://:password@host or redis://user:password@host
+      if (parsed.password) {
+        password = decodeURIComponent(parsed.password);
+      }
+    } catch (e) {
+      console.warn('[Valkey GLIDE] Could not parse URL, using defaults');
+    }
+
+    const clientConfig: Parameters<typeof GlideClient.createClient>[0] = {
+      addresses: [{ host, port }],
+      requestTimeout: 5000,
+      clientName: 'valkey-demo',
+    };
+
+    // Add credentials if password is provided
+    if (password) {
+      clientConfig.credentials = { password };
+    }
+
+    client = await GlideClient.createClient(clientConfig);
+    console.log(`[Valkey GLIDE] Connected to ${host}:${port}${password ? ' (authenticated)' : ''}`);
+  }
+  return client;
+}
+
+export async function closeValkeyClient(): Promise<void> {
+  if (client) {
+    client.close();
+    client = null;
+    console.log('[Valkey GLIDE] Connection closed');
+  }
+}

--- a/apps/valkey-demo/tsconfig.json
+++ b/apps/valkey-demo/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/kubernetes/cluster-install/README.md
+++ b/examples/kubernetes/cluster-install/README.md
@@ -1,5 +1,7 @@
 # Install Firecrawl on a Kubernetes Cluster (Simple Version)
-# Before installing
+
+## Before Installing
+
 1. Set [secret.yaml](secret.yaml) and [configmap.yaml](configmap.yaml) and do not check in secrets
    - **Note**: If `REDIS_PASSWORD` is configured in the secret, please modify the ConfigMap to reflect the following format for `REDIS_URL` and `REDIS_RATE_LIMIT_URL`:
      ```yaml
@@ -9,6 +11,7 @@
      Replace `password`, `host`, and `port` with the appropriate values.
 
 ## Install
+
 ```bash
 kubectl apply -f configmap.yaml
 kubectl apply -f secret.yaml
@@ -20,13 +23,26 @@ kubectl apply -f nuq-postgres.yaml
 kubectl apply -f redis.yaml
 ```
 
+### Using Valkey Instead of Redis
 
-# Port Forwarding for Testing
+[Valkey](https://valkey.io/) is a fully compatible, open-source alternative to Redis. To use Valkey instead:
+
+```bash
+# Replace redis.yaml with valkey.yaml
+kubectl apply -f valkey.yaml
+# instead of: kubectl apply -f redis.yaml
+```
+
+No other changes are needed - Valkey is a drop-in replacement. The service is still named `redis` for compatibility with existing configurations.
+
+## Port Forwarding for Testing
+
 ```bash
 kubectl port-forward svc/api 3002:3002 -n dev
 ```
 
-# Delete Firecrawl
+## Delete Firecrawl
+
 ```bash
 kubectl delete -f configmap.yaml
 kubectl delete -f secret.yaml
@@ -35,5 +51,5 @@ kubectl delete -f api.yaml
 kubectl delete -f worker.yaml
 kubectl delete -f nuq-worker.yaml
 kubectl delete -f nuq-postgres.yaml
-kubectl delete -f redis.yaml
+kubectl delete -f redis.yaml  # or valkey.yaml if using Valkey
 ```

--- a/examples/kubernetes/cluster-install/valkey.yaml
+++ b/examples/kubernetes/cluster-install/valkey.yaml
@@ -1,0 +1,61 @@
+# Valkey deployment for Firecrawl
+# Use this instead of redis.yaml if you want to use Valkey
+# Valkey is a drop-in replacement for Redis - no code changes needed
+#
+# To use: Replace `kubectl apply -f redis.yaml` with `kubectl apply -f valkey.yaml`
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis  # Keep name as 'redis' for compatibility with existing configs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: valkey
+        image: valkey/valkey:7-alpine
+        command: [ "/bin/sh", "-c" ]
+        args:
+          - |
+            if [ -n "$REDIS_PASSWORD" ]; then
+              echo "Starting Valkey with authentication"
+              exec valkey-server --bind 0.0.0.0 --requirepass "$REDIS_PASSWORD"
+            else
+              echo "Starting Valkey without authentication"
+              exec valkey-server --bind 0.0.0.0
+            fi
+        env:
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: firecrawl-secret
+                key: REDIS_PASSWORD
+                optional: true
+        ports:
+          - containerPort: 6379
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis  # Keep name as 'redis' for compatibility with existing configs
+spec:
+  selector:
+    app: redis
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379


### PR DESCRIPTION
## Add Valkey GLIDE demo application and deployment support

### Summary

Adds a comprehensive demo application showcasing Firecrawl integration with [Valkey](https://valkey.io/) using the official [Valkey GLIDE](https://glide.valkey.io/) client, plus Kubernetes deployment support for Valkey as a Redis alternative.

### Changes

**New Demo Application (`apps/valkey-demo/`)**
- Rate limiting using Valkey sorted sets (sliding window algorithm)
- Caching layer for scrape/crawl results with configurable TTL
- Batch job manager with progress tracking and state persistence
- Interactive web UI dashboard for testing all features
- CLI demos for each feature

**Kubernetes Support**
- Added `valkey.yaml` as drop-in replacement for `redis.yaml` in `examples/kubernetes/cluster-install/`
- Updated cluster-install README with Valkey instructions

**Documentation**
- Deployment guide covering Docker Compose, Kubernetes, and self-hosted setups
- AWS setup guide for ElastiCache (Valkey mode) and MemoryDB
- Test scripts for validating deployments

### How to Test

```bash
# Start Firecrawl with Valkey
docker compose up -d

# Run the demo
cd apps/valkey-demo
pnpm install
pnpm run server  # Web UI at http://localhost:3030
# or
pnpm run demo:all  # CLI demos


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Valkey GLIDE demo app and deployment support to run Firecrawl with Valkey as a Redis-compatible backend. Includes a web UI/CLI showcasing caching, rate limiting, and batching, plus Kubernetes and Docker Compose configs and guides.

- New Features
  - Demo app (apps/valkey-demo) using Valkey GLIDE: sliding-window rate limiting, TTL caching, batch manager, web UI, and CLI demos.
  - Kubernetes: valkey.yaml as a drop-in for redis.yaml and updated cluster README.
  - Docker Compose: production file (deploy/docker-compose.valkey.yaml) for Valkey.
  - Docs and tooling: deployment and AWS guides, test scripts for local/K8s.

- Migration
  - On Kubernetes, apply valkey.yaml instead of redis.yaml; no app code changes needed.
  - Set VALKEY_URL/REDIS_URL (and password if used). Defaults work with local docker compose.
  - Try locally: docker compose up, then run the demo app (pnpm run server or pnpm run demo:all).

<sup>Written for commit 9405d5e33745e3f8b6664d399588de7ce9955af3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

