### PR TITLE
Fix duplicate crawl URLs with userinfo (user@host)

### DIFF
--- a/apps/api/src/lib/canonical-url.test.ts
+++ b/apps/api/src/lib/canonical-url.test.ts
@@ -48,6 +48,12 @@ describe("normalizeUrlOnlyHostname", () => {
     const expected = "dev.blog.example.com";
     expect(normalizeUrlOnlyHostname(url)).toBe(expected);
   });
+
+  it("should strip username/password userinfo from hostname", () => {
+    const url = "https://user:pass@www.example.com/path/to/resource";
+    const expected = "example.com";
+    expect(normalizeUrlOnlyHostname(url)).toBe(expected);
+  });
 });
 
 describe("normalizeUrl", () => {
@@ -96,6 +102,12 @@ describe("normalizeUrl", () => {
   it("should handle invalid URLs gracefully", () => {
     const url = "not a valid url";
     const expected = "not a valid url";
+    expect(normalizeUrl(url)).toBe(expected);
+  });
+
+  it("should strip username/password userinfo from the authority", () => {
+    const url = "https://user:pass@www.example.com/path/";
+    const expected = "example.com/path";
     expect(normalizeUrl(url)).toBe(expected);
   });
 });

--- a/apps/api/src/lib/canonical-url.ts
+++ b/apps/api/src/lib/canonical-url.ts
@@ -1,5 +1,9 @@
+import { stripAuthorityUserInfo } from "./url-sanitization";
+
 export function normalizeUrl(url: string) {
-  url = url.replace(/^https?:\/\//, "").replace(/^www\./, "");
+  url = url.replace(/^https?:\/\//i, "");
+  url = stripAuthorityUserInfo(url);
+  url = url.replace(/^www\./i, "");
   if (url.endsWith("/")) {
     url = url.slice(0, -1);
   }
@@ -11,9 +15,8 @@ export function normalizeUrlOnlyHostname(url: string) {
     const urlObj = new URL(url);
     return urlObj.hostname.replace(/^www\./, "");
   } catch (error) {
-    return url
-      .replace(/^https?:\/\//, "")
-      .replace(/^www\./, "")
-      .split("/")[0];
+    const withoutProtocol = url.replace(/^https?:\/\//i, "");
+    const withoutUserInfo = stripAuthorityUserInfo(withoutProtocol);
+    return withoutUserInfo.replace(/^www\./i, "").split("/")[0];
   }
 }

--- a/apps/api/src/lib/url-sanitization.test.ts
+++ b/apps/api/src/lib/url-sanitization.test.ts
@@ -1,0 +1,53 @@
+import { stripAuthorityUserInfo, stripUrlUserInfo } from "./url-sanitization";
+
+describe("stripUrlUserInfo", () => {
+  it("returns input unchanged when no userinfo is present", () => {
+    const url = "https://example.com/path";
+    expect(stripUrlUserInfo(url)).toBe(url);
+  });
+
+  it("strips username only", () => {
+    const url = "https://user@example.com/path";
+    expect(stripUrlUserInfo(url)).toBe("https://example.com/path");
+  });
+
+  it("strips username and password", () => {
+    const url = "https://user:pass@example.com/";
+    expect(stripUrlUserInfo(url)).toBe("https://example.com/");
+  });
+
+  it("does not modify non-http(s) URLs", () => {
+    const url = "mailto:test@example.com";
+    expect(stripUrlUserInfo(url)).toBe(url);
+  });
+
+  it("does not throw on invalid URLs", () => {
+    const url = "not a url";
+    expect(stripUrlUserInfo(url)).toBe(url);
+  });
+});
+
+describe("stripAuthorityUserInfo", () => {
+  it("strips userinfo from an authority-only string", () => {
+    expect(stripAuthorityUserInfo("user:pass@www.example.com/path")).toBe(
+      "www.example.com/path",
+    );
+  });
+
+  it("strips username from a host without protocol", () => {
+    expect(stripAuthorityUserInfo("user@domain.com")).toBe("domain.com");
+  });
+
+  it("leaves strings without userinfo unchanged", () => {
+    expect(stripAuthorityUserInfo("www.example.com/path")).toBe(
+      "www.example.com/path",
+    );
+  });
+
+  it("does not treat '@' in the path as authority userinfo", () => {
+    expect(stripAuthorityUserInfo("example.com/path@foo")).toBe(
+      "example.com/path@foo",
+    );
+  });
+});
+

--- a/apps/api/src/lib/url-sanitization.ts
+++ b/apps/api/src/lib/url-sanitization.ts
@@ -1,0 +1,60 @@
+/**
+ * URL sanitization helpers used across crawl/scrape flows.
+ *
+ * We explicitly strip credentials/userinfo (`https://user:pass@host/...`) because:
+ * - Modern browsers strip it and it is almost always accidental/misconfigured.
+ * - It breaks URL de-duplication, causing duplicate crawling.
+ * - It can accidentally leak credentials into logs/metrics and HTTP requests.
+ */
+
+/**
+ * Strip `username:password@` (userinfo) from an absolute HTTP(S) URL.
+ *
+ * If the URL is not parseable or isn't HTTP(S), returns the input unchanged.
+ */
+export function stripUrlUserInfo(url: string): string {
+  try {
+    const u = new URL(url);
+
+    if (u.protocol !== "http:" && u.protocol !== "https:") {
+      return url;
+    }
+
+    if (!u.username && !u.password) {
+      return url;
+    }
+
+    // Clear password first to avoid transient `:pass@host` serialization.
+    u.password = "";
+    u.username = "";
+
+    return u.href;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Strip `userinfo@` from the authority part of a URL string that does NOT include
+ * a scheme, e.g. `user:pass@www.example.com/path?x#y`.
+ *
+ * This is intended for "canonicalization" helpers that first strip `http(s)://`.
+ */
+export function stripAuthorityUserInfo(urlWithoutProtocol: string): string {
+  const authorityEnd = urlWithoutProtocol.search(/[/?#]/);
+  const authority =
+    authorityEnd === -1
+      ? urlWithoutProtocol
+      : urlWithoutProtocol.slice(0, authorityEnd);
+  const rest =
+    authorityEnd === -1 ? "" : urlWithoutProtocol.slice(authorityEnd);
+
+  const at = authority.lastIndexOf("@");
+  if (at === -1) {
+    return urlWithoutProtocol;
+  }
+
+  const hostPort = authority.slice(at + 1);
+  return hostPort + rest;
+}
+


### PR DESCRIPTION
## Summary
- Strip URL credentials/userinfo (e.g. `https://user:pass@host/...` and `https://user@host/...`) from crawl URL canonicalization and discovery.
- This prevents crawl de-duplication from treating `user@host` variants as distinct URLs (a common CMS misconfiguration for mailto links and basic-auth style URLs).

## Changes
- **Canonicalization**: `normalizeUrl()` now strips `userinfo@` from the authority before removing `www.` / trailing slash.
- **Crawl de-dupe**: crawl visited locking (`normalizeURL`) strips userinfo before writing to `crawl:<id>:visited`.
- **Link discovery**: `WebCrawler.filterLinks()` / `filterURL()` sanitize returned URLs so scheduled crawl jobs use the canonical URL (without userinfo).
- Added small, focused unit tests for the new sanitization helpers + canonical-url behavior.

## Why
Issue #2591 reports high-probability duplicate crawling when pages contain links like `https://email@domain.com` or `https://user:pass@domain.com`. Modern browsers strip userinfo; Firecrawl should treat those as the same URL and avoid re-crawling the entire site.

Fixes #2591

## Test plan
- `pnpm -C apps/api install --ignore-scripts`
- `pnpm -C apps/api exec jest src/lib/url-sanitization.test.ts src/lib/canonical-url.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips username/password userinfo from URLs across canonicalization, discovery, and de-duplication to stop duplicate crawling and avoid leaking credentials. Fixes #2591.

- **Bug Fixes**
  - Canonicalization: normalizeUrl and hostname normalization now remove userinfo before handling www and trailing slashes.
  - De-duplication: visited locking and URL permutations clear username/password; respects ignoreQueryParameters.
  - Link discovery: sanitize and de-dupe links in Rust and JS paths; filterURL returns sanitized URLs; initial URL is sanitized.
  - Added shared sanitization helpers and unit tests; non-http(s) URLs remain unchanged.

<sup>Written for commit 7d54f3c448d64e0be13468d54adac596727c3d2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

