### PR TITLE
chore(api): Add logging to flaky map redirect test

### DIFF
--- a/apps/api/src/__tests__/snips/v2/map.test.ts
+++ b/apps/api/src/__tests__/snips/v2/map.test.ts
@@ -139,6 +139,17 @@ describe("Map tests", () => {
       expect(response.statusCode).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.links.length).toBeGreaterThan(0);
+
+      const nonFirecrawlLinks = response.body.links.filter(
+        link => !link.url.includes("firecrawl.dev"),
+      );
+      if (nonFirecrawlLinks.length > 0) {
+        console.log(
+          "Links not containing 'firecrawl.dev':",
+          JSON.stringify(nonFirecrawlLinks, null, 2),
+        );
+      }
+
       expect(
         response.body.links.every(link => link.url.includes("firecrawl.dev")),
       ).toBe(true);


### PR DESCRIPTION
## Summary
- Add debug logging to the "handles redirects correctly" map test
- Logs any links that don't contain 'firecrawl.dev' when the assertion fails
- Helps diagnose why this test is intermittently failing

## Test plan
- [ ] Run the map test suite and verify logging appears when test fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add debug logging to the "handles redirects correctly" map test to print any links that don’t include "firecrawl.dev," helping diagnose intermittent redirect failures without changing test behavior.

<sup>Written for commit 9313553931a67cd994edecaa36f99cdbb93aef6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

