### PR TITLE
chore(ci): Increase nuq worker count for self-hosted tests

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -39,6 +39,7 @@ jobs:
       HOST: 0.0.0.0
       TEST_SUITE_SELF_HOSTED: true
       TEST_SUITE_WEBSITE: http://127.0.0.1:4321
+      NUQ_WORKER_COUNT: 8
       OPENAI_API_KEY: ${{ matrix.ai == 'openai' && secrets.OPENAI_API_KEY || '' }}
       SEARXNG_ENDPOINT: ${{ matrix.search == 'searxng' && 'http://localhost:3434' || '' }}
       PLAYWRIGHT_MICROSERVICE_URL: ${{ matrix.engine == 'playwright' && 'http://localhost:3003/scrape' || '' }}


### PR DESCRIPTION
## Summary
- Increase `NUQ_WORKER_COUNT` from default 5 to 8 in CI for self-hosted tests
- Should improve test parallelism and reduce overall test runtime

## Test plan
- [ ] Verify CI self-hosted tests run with 8 nuq workers
- [ ] Compare test duration with previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases NUQ_WORKER_COUNT from 5 to 8 for self-hosted tests in CI to boost parallelism and shorten run times. CI-only change with no effect on production.

<sup>Written for commit 7c34c83362e8b124117ca9b9251a8c7c2bcb0eab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

