### PR TITLE
fix(security): allowlist fast-xml-parser vulnerability GHSA-37qj-frw5-hhjh

### DIFF
--- a/apps/api/audit-ci.jsonc
+++ b/apps/api/audit-ci.jsonc
@@ -16,6 +16,7 @@
         "GHSA-w332-q679-j88p|@coinbase/x402>x402>wagmi>@wagmi/connectors>porto>hono", // we don't use hono
         "GHSA-73rr-hh4g-fpgx|git-diff>diff", // dev dependency for diffs, not processing user-supplied patches
         "GHSA-73rr-hh4g-fpgx|ts-node>diff", // dev dependency for TypeScript execution, not processing user-supplied patches
-        "GHSA-mp2g-9vg9-f4cg|@coinbase/x402>x402>wagmi>@wagmi/connectors>@walletconnect/ethereum-provider>@walletconnect/keyvaluestorage>unstorage>h3" // h3 is a storage dependency in x402 payment chain, not used for serving HTTP traffic
+        "GHSA-mp2g-9vg9-f4cg|@coinbase/x402>x402>wagmi>@wagmi/connectors>@walletconnect/ethereum-provider>@walletconnect/keyvaluestorage>unstorage>h3", // h3 is a storage dependency in x402 payment chain, not used for serving HTTP traffic
+        "GHSA-37qj-frw5-hhjh|@google-cloud/storage>fast-xml-parser" // XML parsing is only for Google Cloud API responses (trusted source), not user-supplied XML. Upstream uses 4.x, fix is in 5.x (breaking change).
     ]
 }

--- a/apps/test-site/audit-ci.jsonc
+++ b/apps/test-site/audit-ci.jsonc
@@ -6,6 +6,7 @@
         "GHSA-73rr-hh4g-fpgx|astro>diff", // dev-only dependency - we don't parse untrusted patches
         "GHSA-vw5p-8cq8-m7mv|astro>devalue", // build-time SSR hydration - no untrusted input
         "GHSA-g2pg-6438-jwpf|astro>devalue", // test site doesn't parse untrusted input
-        "GHSA-mp2g-9vg9-f4cg|astro>unstorage>h3" // test site doesn't serve production traffic
+        "GHSA-mp2g-9vg9-f4cg|astro>unstorage>h3", // test site doesn't serve production traffic
+        "GHSA-37qj-frw5-hhjh|@astrojs/rss>fast-xml-parser" // test site only - RSS generation with controlled input, not parsing untrusted XML
     ]
 }

--- a/apps/test-suite/audit-ci.jsonc
+++ b/apps/test-suite/audit-ci.jsonc
@@ -7,6 +7,9 @@
         "GHSA-5j98-mcp5-4vw2|jest>@jest/core>@jest/reporters>glob", // we do not use the glob CLI
         "GHSA-6475-r3vj-m8vf|artillery>artillery-plugin-publish-metrics>@aws-sdk/client-cloudwatch>@smithy/config-resolver", // informational enhancement - we control region input
         "GHSA-73rr-hh4g-fpgx|jest>@jest/core>jest-config>ts-node>diff", // dev-only dependency - we don't parse untrusted patches
-        "GHSA-g9mf-h72j-4rw9|artillery>@artilleryio/int-commons>cheerio>undici" // test-only dependency - load testing doesn't connect to malicious servers
+        "GHSA-g9mf-h72j-4rw9|artillery>@artilleryio/int-commons>cheerio>undici", // test-only dependency - load testing doesn't connect to malicious servers
+        "GHSA-37qj-frw5-hhjh|artillery>@aws-sdk/client-cloudwatch-logs>@aws-sdk/core>@aws-sdk/xml-builder>fast-xml-parser", // test-only dependency - controlled XML input from AWS SDK
+        "GHSA-37qj-frw5-hhjh|artillery>@azure/storage-blob>@azure/core-xml>fast-xml-parser", // test-only dependency - controlled XML input from Azure SDK
+        "GHSA-37qj-frw5-hhjh|artillery>artillery-plugin-publish-metrics>@aws-sdk/client-cloudwatch>@aws-sdk/core>fast-xml-parser" // test-only dependency - controlled XML input from AWS SDK
     ]
 }


### PR DESCRIPTION
## Summary
- Allowlists `fast-xml-parser` vulnerability (GHSA-37qj-frw5-hhjh) in API, test-suite, and test-site audit configs
- The vulnerability is a DoS issue when parsing out-of-range XML entity code points, fixed in v5.3.4
- Upstream dependencies (`@google-cloud/storage`, `artillery`, `@astrojs/rss`) haven't updated yet

## Justification

| Package | Reason for allowlist |
|---------|---------------------|
| `@google-cloud/storage` | Only parses trusted Google Cloud API responses. Upstream uses 4.x, fix requires 5.x (breaking change) |
| `artillery` (AWS/Azure SDKs) | Test-only dependency with controlled XML input, not processing untrusted XML |
| `@astrojs/rss` | Test site only, RSS generation with controlled input |

## Test plan
- [x] Verified all three audits pass locally with `pnpm dlx audit-ci@^7 --config audit-ci.jsonc`
- [ ] CI npm-audit workflow should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allowlisted the fast-xml-parser vulnerability (GHSA-37qj-frw5-hhjh) in audit-ci for API, test-suite, and test-site to unblock npm audit until upstream packages adopt the fix. Audits pass locally; CI npm-audit should pass.

- **Dependencies**
  - @google-cloud/storage>fast-xml-parser — trusted Google Cloud API responses only; upstream on 4.x, fix requires 5.x (breaking).
  - artillery AWS/Azure SDK paths — test-only; controlled XML from SDKs, no untrusted input.
  - @astrojs/rss>fast-xml-parser — test site only; RSS generation with controlled input.

<sup>Written for commit b551b0c3802063e701047a1e239e0c34fbac3198. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

