### PR TITLE
fix(branding): improve error messages for PDFs and documents

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -609,9 +609,16 @@ export async function buildFallbackList(meta: Meta): Promise<
       f => !f.unsupportedFeatures.has("branding"),
     );
     if (!hasCDPEngine) {
-      throw new Error(
-        "Branding extraction requires Chrome CDP (fire-engine). ",
-      );
+      if (meta.featureFlags.has("pdf")) {
+        throw new Error(
+          "Branding extraction is only supported for HTML web pages. PDFs are not supported.",
+        );
+      } else if (meta.featureFlags.has("document")) {
+        throw new Error(
+          "Branding extraction is only supported for HTML web pages. Documents (docx, xlsx, etc.) are not supported.",
+        );
+      }
+      throw new Error("Branding extraction requires Chrome CDP (fire-engine).");
     }
   }
 


### PR DESCRIPTION
## Summary
- Show user-friendly error messages when branding extraction is requested for PDFs or documents
- Explains that branding is only supported for HTML web pages
- Keeps the technical error message for other cases (forced engines, self-hosted without fire-engine)

## Test plan
- [ ] Request branding format for a PDF URL → should see "Branding extraction is only supported for HTML web pages. PDFs are not supported."
- [ ] Request branding format for a document URL (docx, xlsx, etc.) → should see "Branding extraction is only supported for HTML web pages. Documents (docx, xlsx, etc.) are not supported."
- [ ] Force an engine that doesn't support branding → should see original "Branding extraction requires Chrome CDP (fire-engine)." message

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve branding extraction errors for PDFs and other documents by showing clear, user-friendly messages that branding works only on HTML pages. Keep the existing "Chrome CDP (fire-engine)" error for other cases like forced engines or self-hosted without fire-engine.

- **Bug Fixes**
  - PDFs: "Branding extraction is only supported for HTML web pages. PDFs are not supported."
  - Documents (docx, xlsx, etc.): "Branding extraction is only supported for HTML web pages. Documents (docx, xlsx, etc.) are not supported."

<sup>Written for commit 0479d421cfb8bf8671f4ca66bc32431d79f08a2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

