### PR TITLE
fix(api): schema extract fallback when tools not called

### DIFF
--- a/apps/api/src/lib/json-extraction.test.ts
+++ b/apps/api/src/lib/json-extraction.test.ts
@@ -1,0 +1,35 @@
+import { extractJsonFromText } from "./json-extraction";
+
+describe("extractJsonFromText", () => {
+  it("parses a fenced ```json code block", () => {
+    const res = extractJsonFromText('```json\n{"a":1}\n```');
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.value).toEqual({ a: 1 });
+    }
+  });
+
+  it("parses a fenced generic code block", () => {
+    const res = extractJsonFromText('```\n{"a":1}\n```');
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.value).toEqual({ a: 1 });
+    }
+  });
+
+  it("parses JSON embedded in surrounding text", () => {
+    const res = extractJsonFromText(
+      'Sure! Here you go:\n\n{"a":1,"b":[2,3]}\n\nThanks.',
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.value).toEqual({ a: 1, b: [2, 3] });
+    }
+  });
+
+  it("returns ok=false when no JSON is present", () => {
+    const res = extractJsonFromText("no json here");
+    expect(res.ok).toBe(false);
+  });
+});
+

--- a/apps/api/src/lib/json-extraction.ts
+++ b/apps/api/src/lib/json-extraction.ts
@@ -1,0 +1,93 @@
+export type ExtractJsonFromTextResult =
+  | { ok: true; jsonText: string; value: unknown }
+  | { ok: false; jsonText?: string };
+
+function stripCodeFences(text: string): string {
+  let t = text.trim();
+  if (!t.startsWith("```")) return t;
+
+  // Opening fence: ```json or ```<lang>
+  const firstNewline = t.indexOf("\n");
+  if (firstNewline === -1) return t;
+  t = t.slice(firstNewline + 1);
+
+  // Closing fence
+  const lastFence = t.lastIndexOf("```");
+  if (lastFence !== -1) {
+    t = t.slice(0, lastFence);
+  }
+  return t.trim();
+}
+
+function extractFirstCodeFence(text: string): string | null {
+  const start = text.indexOf("```");
+  if (start === -1) return null;
+  const afterStart = text.slice(start);
+  const end = afterStart.indexOf("```", "```".length);
+  if (end === -1) return null;
+
+  return stripCodeFences(afterStart.slice(0, end + "```".length));
+}
+
+function extractFirstBalancedJsonLike(text: string): string | null {
+  const t = text.trim();
+  if (t.length === 0) return null;
+
+  // Prefer object-like extraction; fall back to arrays.
+  const objStart = t.indexOf("{");
+  const objEnd = t.lastIndexOf("}");
+  if (objStart !== -1 && objEnd !== -1 && objEnd > objStart) {
+    return t.slice(objStart, objEnd + 1);
+  }
+
+  const arrStart = t.indexOf("[");
+  const arrEnd = t.lastIndexOf("]");
+  if (arrStart !== -1 && arrEnd !== -1 && arrEnd > arrStart) {
+    return t.slice(arrStart, arrEnd + 1);
+  }
+
+  return null;
+}
+
+export function extractJsonFromText(text: string): ExtractJsonFromTextResult {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return { ok: false };
+
+  // 1) Whole response is a fenced code block.
+  if (trimmed.startsWith("```") && trimmed.endsWith("```")) {
+    const jsonText = stripCodeFences(trimmed);
+    try {
+      return { ok: true, jsonText, value: JSON.parse(jsonText) };
+    } catch {
+      return { ok: false, jsonText };
+    }
+  }
+
+  // 2) Response contains a fenced code block.
+  const firstFence = extractFirstCodeFence(trimmed);
+  if (firstFence) {
+    try {
+      return { ok: true, jsonText: firstFence, value: JSON.parse(firstFence) };
+    } catch {
+      // fall through to bracket extraction
+    }
+  }
+
+  // 3) Bracket-based extraction (handles "Sure, here's the JSON: {...}").
+  const bracketJson = extractFirstBalancedJsonLike(trimmed);
+  if (bracketJson) {
+    try {
+      return { ok: true, jsonText: bracketJson, value: JSON.parse(bracketJson) };
+    } catch {
+      return { ok: false, jsonText: bracketJson };
+    }
+  }
+
+  // 4) Final attempt: treat whole response as JSON.
+  try {
+    return { ok: true, jsonText: trimmed, value: JSON.parse(trimmed) };
+  } catch {
+    return { ok: false, jsonText: trimmed };
+  }
+}
+

--- a/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
@@ -379,6 +379,7 @@ export async function extractData({
       error,
     });
     // console.log("failed during extractSmartScrape.ts:generateCompletions", error);
+    throw error;
   }
 
   let extractedData = extract?.extractedData;

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.fallback.test.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.fallback.test.ts
@@ -1,0 +1,91 @@
+describe("generateCompletions NoObjectGeneratedError fallback", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("falls back to JSON-only generateText when tool was not called", async () => {
+    const generateObject = jest.fn();
+    const generateText = jest.fn();
+
+    class MockNoObjectGeneratedError extends Error {
+      static isInstance(err: unknown): boolean {
+        return err instanceof MockNoObjectGeneratedError;
+      }
+    }
+
+    generateObject.mockImplementation(() => {
+      throw new MockNoObjectGeneratedError(
+        "No object generated: the tool was not called.",
+      );
+    });
+    generateText.mockResolvedValue({
+      text: JSON.stringify({
+        extractedData: { is_built_for_scale: true },
+        shouldUseSmartscrape: false,
+      }),
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    });
+
+    jest.doMock("ai", () => ({
+      generateObject,
+      generateText,
+      NoObjectGeneratedError: MockNoObjectGeneratedError,
+      jsonSchema: (schema: any) => schema,
+      AISDKError: class AISDKError extends Error {},
+    }));
+
+    jest.doMock("@dqbd/tiktoken", () => ({
+      encoding_for_model: jest.fn(),
+    }));
+
+    const { generateCompletions } = await import("./llmExtract");
+
+    const logger: any = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      child: function () {
+        return this;
+      },
+    };
+    const costTracking: any = { addCall: jest.fn() };
+
+    const schema = {
+      type: "object",
+      properties: {
+        extractedData: {
+          type: "object",
+          properties: { is_built_for_scale: { type: "boolean" } },
+          required: ["is_built_for_scale"],
+          additionalProperties: false,
+        },
+        shouldUseSmartscrape: { type: "boolean" },
+      },
+      required: ["extractedData", "shouldUseSmartscrape"],
+      additionalProperties: false,
+    };
+
+    const res = await generateCompletions({
+      logger,
+      options: {
+        systemPrompt: "Return JSON.",
+        prompt: "Extract.",
+        schema,
+      },
+      markdown: "# Title",
+      model: "test-model" as any,
+      retryModel: "fallback-model" as any,
+      costTrackingOptions: { costTracking, metadata: {} },
+      metadata: { teamId: "t", functionId: "fn" },
+    });
+
+    expect(generateObject).toHaveBeenCalledTimes(1);
+    expect(generateText).toHaveBeenCalled();
+    expect(res.extract).toEqual({
+      extractedData: { is_built_for_scale: true },
+      shouldUseSmartscrape: false,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Handle `AI_NoObjectGeneratedError` (tool not called) during schema extraction by falling back to JSON-only generation, then parsing/repairing/validating the JSON payload.
- Stop silently swallowing `generateCompletions` failures in `extractSmartScrape` (prevents returning a 200 with missing JSON data).
- Make `@mendable/firecrawl-rs` markdown post-processing optional (lazy load) so unit tests can run without native builds.

Fixes #2491.

## Test plan
- `pnpm test -- src/lib/json-extraction.test.ts src/scraper/scrapeURL/transformers/llmExtract.fallback.test.ts`
- `pnpm test -- src/scraper/scrapeURL/transformers/llmExtract.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a robust fallback for schema extraction when the tool isn’t called by the model: salvage/repair JSON from text or regenerate JSON-only, then validate against the schema. Also stops swallowing extraction errors and lazy-loads markdown post‑processing to unblock tests. Addresses Linear #2491.

- **Bug Fixes**
  - On NoObjectGeneratedError, parse JSON from response text; if missing/invalid, generate JSON-only, repair if needed, and validate via Zod/Ajv with cost tracking.
  - extractSmartScrape now rethrows generateCompletions failures to prevent 200s with missing JSON.
  - @mendable/firecrawl-rs postProcessMarkdown is now optional (lazy-loaded with warnings); falls back to unprocessed markdown.

<sup>Written for commit f7b60bddced6ec361bf7c5b9d75a6faa1be4d32f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

