### PR TITLE
fix(index): Fix OMCE domain hash mismatch between insert and query

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index/index.ts
@@ -210,9 +210,11 @@ export async function scrapeURLWithIndex(
   if (meta.options.maxAge !== undefined) {
     maxAge = meta.options.maxAge;
   } else {
-    const domainSplitsHash = generateDomainSplits(
-      new URL(meta.url).hostname,
-    ).map(x => hashURL(x));
+    const hostname = new URL(meta.url).hostname;
+    const fakeDomain = meta.options.__experimental_omceDomain;
+    const domainSplitsHash = generateDomainSplits(hostname, fakeDomain).map(x =>
+      hashURL(x),
+    );
     const level = domainSplitsHash.length - 1;
 
     if (

--- a/apps/api/src/scraper/scrapeURL/lib/removeUnwantedElements.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/removeUnwantedElements.ts
@@ -75,9 +75,13 @@ export const htmlTransform = async (
 
   if (scrapeOptions.__experimental_omce) {
     try {
-      const hostname =
-        scrapeOptions.__experimental_omceDomain || new URL(url).hostname;
-      omceSignatures = await queryOMCESignatures(hostname);
+      const hostname = new URL(url).hostname;
+      const fakeDomain = scrapeOptions.__experimental_omceDomain;
+      omceSignatures = await queryOMCESignatures(
+        hostname,
+        undefined,
+        fakeDomain,
+      );
       logger.info("Got OMCE signatures", { signatures: omceSignatures.length });
     } catch (error) {
       logger.warn("Failed to get omce signatures.", {

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -527,12 +527,15 @@ export async function queryIndexAtDomainSplitLevel(
 export async function queryOMCESignatures(
   hostname: string,
   maxAge = 2 * 24 * 60 * 60 * 1000,
+  fakeDomain?: string,
 ): Promise<string[]> {
   if (!useIndex || config.FIRECRAWL_INDEX_WRITE_ONLY) {
     return [];
   }
 
-  const domainSplitsHash = generateDomainSplits(hostname).map(x => hashURL(x));
+  const domainSplitsHash = generateDomainSplits(hostname, fakeDomain).map(x =>
+    hashURL(x),
+  );
 
   const level = domainSplitsHash.length - 1;
   if (domainSplitsHash.length === 0) {


### PR DESCRIPTION
## Problem
OMCE jobs were stored with one domain hash and queried with another, so lookups could miss data.

- **Insert** (`insert_omce_job_if_needed`): used `generateDomainSplits(hostname, fakeDomain)` with `__experimental_omceDomain`, so the stored hash was based on the (possibly fake) OMCE domain.
- **Query** (`query_max_age`, `query_omce_signatures`): used `generateDomainSplits(hostname)` only, so the hash was always based on the real URL hostname.

When `__experimental_omceDomain` was set, insert and query used different inputs and produced different hashes, so queries didn’t match inserted rows.

## Solution
Use the same domain-split (and thus hash) logic for both insert and query:

- **`query_max_age`** (index engine): compute domain splits with `generateDomainSplits(hostname, meta.options.__experimental_omceDomain)` so the hash matches the one used when inserting OMCE jobs.
- **`queryOMCESignatures`**: add an optional `fakeDomain` and use `generateDomainSplits(hostname, fakeDomain)` so the hash matches the insert path.
- **OMCE caller** (removeUnwantedElements): pass real hostname and `__experimental_omceDomain` into `queryOMCESignatures` so it uses the same hash as insert.

Insert and query now both use `generateDomainSplits(hostname, fakeDomain)` and therefore the same hash for OMCE.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mismatched OMCE domain hashing so queries match inserted jobs, including when __experimental_omceDomain is set. Standardizes domain-split hashing by passing the fake domain through all query paths.

- **Bug Fixes**
  - Index engine: compute maxAge domain splits with generateDomainSplits(hostname, __experimental_omceDomain).
  - queryOMCESignatures: add optional fakeDomain and use it for hashing.
  - removeUnwantedElements: pass real hostname and __experimental_omceDomain into queryOMCESignatures.

<sup>Written for commit 6209053d51ad45acd4b1150200a6d20564bea3de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

