### PR TITLE
fix(playwright-service): use custom user-agent from headers when provided

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -252,17 +252,27 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    // Extract user-agent from headers if provided, as it needs to be set on the context
-    const customUserAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+    // Extract user-agent from headers if provided (case-insensitive), as it needs to be set on the context
+    let customUserAgent: string | undefined;
+    let headersWithoutUA: Record<string, string> | undefined;
+    
+    if (headers) {
+      const headerEntries = Object.entries(headers);
+      const userAgentEntry = headerEntries.find(([key]) => key.toLowerCase() === 'user-agent');
+      customUserAgent = userAgentEntry?.[1];
+      
+      // Filter out user-agent header (case-insensitive) since it's set on the context
+      const filteredEntries = headerEntries.filter(([key]) => key.toLowerCase() !== 'user-agent');
+      if (filteredEntries.length > 0) {
+        headersWithoutUA = Object.fromEntries(filteredEntries);
+      }
+    }
+    
     requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
-    if (headers) {
-      // Remove user-agent from headers since it's already set on the context
-      const { 'user-agent': _ua, 'User-Agent': _UA, ...otherHeaders } = headers;
-      if (Object.keys(otherHeaders).length > 0) {
-        await page.setExtraHTTPHeaders(otherHeaders);
-      }
+    if (headersWithoutUA) {
+      await page.setExtraHTTPHeaders(headersWithoutUA);
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
## Summary
Fixes #2802

When calling the scrape endpoint with a custom `user-agent` header, the value was being ignored because Playwright sets the user-agent on the browser context, not via `setExtraHTTPHeaders`.

## Changes
- Modified `createContext` to accept an optional `customUserAgent` parameter
- Extract user-agent from headers before creating context
- Pass custom user-agent to `createContext` if provided
- Remove user-agent from headers before calling `setExtraHTTPHeaders` to avoid redundancy

## Testing
To test this fix:
1. Deploy the updated playwright-service
2. Create a test endpoint (e.g., webhook.site) to log HTTP requests
3. Call the scrape endpoint with a custom user-agent:
```bash
curl --request POST \
  --url http://localhost:3000/v2/scrape \
  --header 'content-type: application/json' \
  --data '{
  "url": "https://webhook.site/<your-webhook-id>",
  "headers": {
    "user-agent": "MyCustomUserAgent/1.0"
  }
}'
```
4. Verify that the user-agent logged at webhook.site is `MyCustomUserAgent/1.0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors a custom User-Agent sent to the /scrape endpoint by setting it on the Playwright browser context. Sites now see the provided UA instead of the default.

- **Bug Fixes**
  - Set user-agent on the browser context, not via setExtraHTTPHeaders.
  - Use case-insensitive header lookup to extract the custom UA before creating the context.
  - Pass the custom UA to createContext; fall back to a generated UA if not provided.
  - Strip the UA from headers before setExtraHTTPHeaders to avoid duplication.

<sup>Written for commit 89f4ef95a4a68a7da6d4c8c79b938d629985a310. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

