### PR TITLE
test: add unit tests for srcset preservation and src derivation in htmlTransform

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/__tests__/removeUnwantedElements.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/__tests__/removeUnwantedElements.test.ts
@@ -1,0 +1,109 @@
+jest.mock("@mendable/firecrawl-rs", () => ({
+  transformHtml: jest
+    .fn()
+    .mockRejectedValue(new Error("force Cheerio fallback")),
+}));
+
+import { htmlTransform } from "../removeUnwantedElements";
+import { load } from "cheerio";
+
+const baseUrl = "https://example.com/page.html";
+const defaultOptions = {} as any;
+
+describe("htmlTransform", () => {
+  describe("img[srcset] preservation and src derivation", () => {
+    it("preserves srcset attribute in output when img has srcset", async () => {
+      const html = `
+        <html><body>
+          <img 
+            srcset="small.jpg 480w, medium.jpg 800w, large.jpg 1200w" 
+            alt="Responsive image"
+          >
+        </body></html>
+      `;
+      const result = await htmlTransform(html, baseUrl, defaultOptions);
+      const $ = load(result);
+
+      const img = $("img");
+      expect(img.length).toBe(1);
+
+      expect(img.attr("srcset")).toBe(
+        "small.jpg 480w, medium.jpg 800w, large.jpg 1200w",
+      );
+    });
+
+    it("derives src from the largest width descriptor when no original src", async () => {
+      const inputHtml = `
+        <html><body>
+          <img srcset="small.jpg 480w, large.jpg 1200w" alt="Test">
+        </body></html>
+      `;
+
+      const result = await htmlTransform(inputHtml, baseUrl, defaultOptions);
+      const $ = load(result);
+
+      const img = $("img");
+      expect(img.attr("src")).toBe("https://example.com/large.jpg");
+      expect(img.attr("srcset")).toContain("small.jpg 480w");
+    });
+
+    it("derives src preferring highest DPR when using x-descriptors", async () => {
+      const inputHtml = `
+        <html><body>
+          <img srcset="lo-res.jpg 1x, med-res.jpg 2x, hi-res.jpg 3x" alt="DPR test">
+        </body></html>
+      `;
+
+      const result = await htmlTransform(inputHtml, baseUrl, defaultOptions);
+      const $ = load(result);
+
+      const img = $("img");
+      expect(img.attr("src")).toBe("https://example.com/hi-res.jpg");
+    });
+
+    it("sets src from srcset when original src is missing", async () => {
+      const inputHtml = `
+        <html><body>
+          <img srcset="only-srcset.jpg 1x" alt="Only srcset">
+        </body></html>
+      `;
+
+      const result = await htmlTransform(inputHtml, baseUrl, defaultOptions);
+      const $ = load(result);
+
+      const img = $("img");
+      expect(img.attr("src")).toBe("https://example.com/only-srcset.jpg");
+      expect(img.attr("srcset")).toBe("only-srcset.jpg 1x");
+    });
+
+    it("overrides src with the best candidate from srcset when srcset is present (even if src exists)", async () => {
+      const inputHtml = `
+        <html><body>
+          <img src="already-good.jpg" srcset="better.jpg 2x, worse.jpg 1x" alt="Override src">
+        </body></html>
+      `;
+
+      const result = await htmlTransform(inputHtml, baseUrl, defaultOptions);
+      const $ = load(result);
+
+      const img = $("img");
+
+      expect(img.attr("src")).toBe("https://example.com/better.jpg");
+      expect(img.attr("srcset")).toContain("better.jpg 2x, worse.jpg 1x");
+    });
+
+    it("handles malformed srcset gracefully (preserves as-is)", async () => {
+      const inputHtml = `
+        <html><body>
+          <img srcset="invalid, nonsense 999w" alt="Bad">
+        </body></html>
+      `;
+
+      const result = await htmlTransform(inputHtml, baseUrl, defaultOptions);
+      const $ = load(result);
+
+      const img = $("img");
+      expect(img.attr("srcset")).toContain("invalid, nonsense 999w");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for the HTML transform logic (Cheerio fallback path) that preserves `img[srcset]` attributes and derives/updates `src` from the largest srcset candidate.

Related to #2397 (srcset ignored bug) and builds on the fix in #2515 (absolute srcset URLs).

## What's covered
- **Regression test:** `srcset` attribute is preserved in output (not stripped/ignored).
- **src derivation** from largest width-based candidate (e.g. prefers 1200w over 480w).
- **src derivation** from highest DPR-based candidate (e.g. prefers 3x over 1x), even when fallback `src` exists (documents current override behavior).
- **Images with only srcset** (no original `src`) get `src` set from srcset so they remain usable.
- **Absolute URL rewriting** is asserted for `src` using `baseUrl`; the tests do **not** assert rewriting of URLs inside the `srcset` string, as absolute path rewriting does not currently apply to srcset entries in all scenarios in the Cheerio fallback.

These tests force the Cheerio fallback (via mock) to isolate JS-side logic.

## Testing
Run the specific file:
```bash
pnpm test -- src/scraper/scrapeURL/lib/__tests__/removeUnwantedElements.test.ts
```
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for the Cheerio fallback in htmlTransform to ensure img[srcset] is preserved and src is derived from the best srcset candidate. Tests also confirm absolute URL rewriting, correct width/DPR selection, setting src when missing, overriding existing src when srcset is present, and graceful handling of malformed srcset.

<sup>Written for commit 9d20a9c924b561c72317c5f6ef8489758a2655aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

