### PR TITLE
chore: ignore docker-compose override files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ apps/python-sdk/.venv/
 
 /apps/go-html-to-md-service/.gomodcache/
 target/
+
+docker-compose.override.yml
+docker-compose.override.yaml


### PR DESCRIPTION
## Summary
This PR adds both `docker-compose.override.yml` and `docker-compose.override.yaml` to the root `.gitignore`.

## Changes
- Updated the root `.gitignore` to exclude `docker-compose.override.yml` and `docker-compose.override.yaml`.

## Justification
Docker Compose uses `docker-compose.override.yml` (or `.yaml`) by default to allow developers to define environment-specific configurations (like local port mapping or extra volume mounts) without modifying the base configuration file. According to [Docker documentation](https://docs.docker.com/compose/how-tos/multiple-compose-files/extending-services/#understanding-multiple-compose-files), these override files are intended for local development and should typically not be committed to version control.

Adding them to `.gitignore` prevents developers from accidentally committing their local development tweaks and ensures a cleaner repository state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docker-compose.override.yml and docker-compose.override.yaml to the root .gitignore to prevent accidental commits of local dev overrides.

<sup>Written for commit 1d7610bbbf2e9b00c64052d3d4c61ce117832b78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

