### PR TITLE
fix(api): use OpenAI Chat Completions API instead of Responses API

### DIFF
--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -57,9 +57,12 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
   if (name === "gemini-2.5-pro") {
     name = "gemini-2.5-pro";
   }
-  return config.MODEL_NAME
-    ? providerList[provider](config.MODEL_NAME)
-    : providerList[provider](name);
+  const modelName = config.MODEL_NAME || name;
+  // o3-mini returns empty text via the Responses API — force Chat Completions
+  if (provider === "openai" && modelName.startsWith("o3-mini")) {
+    return providerList.openai.chat(modelName);
+  }
+  return providerList[provider](modelName);
 }
 
 export function getEmbeddingModel(


### PR DESCRIPTION
## Summary
- `@ai-sdk/openai` v2 defaults `openai()` calls to the **Responses API** (`/v1/responses`), which returns empty text for reasoning models like `o3-mini` — all output tokens go to encrypted reasoning with no visible content
- This broke deep research final analysis generation (always returned `finalAnalysis: ""`)
- Fix: explicitly use `openai.chat()` in `getModel()` to route through the **Chat Completions API** (`/v1/chat/completions`), which correctly returns text output

## Test plan
- [x] Verified `openai.chat("o3-mini")` returns text via AI SDK `generateText`
- [x] Verified deep research endpoint returns non-empty `finalAnalysis` (9,660 chars) after fix
- [x] Run deep research E2E test: `pnpm harness jest deep-research`
- [x] Verify other LLM-dependent features (extract, search) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force OpenAI o3-mini to use the Chat Completions API to restore visible text and fix empty deep research finalAnalysis. Other models are unchanged.

- **Bug Fixes**
  - In getModel, route providerList.openai.chat(modelName) only when provider is "openai" and modelName starts with "o3-mini".
  - Avoids the Responses API path that returns empty text for o3-mini in @ai-sdk/openai v2.
  - Restores non-empty finalAnalysis in deep research without affecting other providers or models.

<sup>Written for commit 439a8863f3c3d0ab5f5dbce93b490b2f07475bf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

