### PR TITLE
feat(pdf): Allow location setting, and enhanced mode on PDFs

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -437,7 +437,7 @@ const engineOptions: {
       mobile: false,
       skipTlsVerification: false,
       useFastMode: true,
-      stealthProxy: true, // kinda...
+      stealthProxy: false,
       branding: false,
       disableAdblock: true,
     },
@@ -456,7 +456,7 @@ const engineOptions: {
       mobile: false,
       skipTlsVerification: false,
       useFastMode: true,
-      stealthProxy: true, // kinda...
+      stealthProxy: false,
       branding: false,
       disableAdblock: true,
     },

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -190,11 +190,20 @@ function buildFeatureFlags(
     lowerPath.includes(".xlsx/") ||
     lowerPath.includes(".xls/");
 
+  const needsFireEngine =
+    options.proxy === "stealth" ||
+    options.proxy === "enhanced" ||
+    !!options.location;
+
   if (isDocument) {
-    flags.add("document");
+    if (!needsFireEngine) {
+      flags.add("document");
+    }
   } else if (lowerPath.endsWith(".pdf") || lowerPath.includes(".pdf/")) {
     // Only add PDF flag if it's not a document
-    flags.add("pdf");
+    if (!needsFireEngine) {
+      flags.add("pdf");
+    }
   }
 
   if (options.blockAds === false) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable location settings and enhanced/stealth proxy mode for PDFs by routing them through FireEngine when requested. Disabled stealthProxy in engine defaults to avoid conflicts.

- **New Features**
  - PDFs can use location and enhanced/stealth proxy options; FireEngine is selected automatically.

- **Refactors**
  - Skip adding document/pdf flags when FireEngine is required to ensure correct engine selection.
  - Set stealthProxy to false in engine presets.

<sup>Written for commit cc038e6597d5e509b5ad0fe697fe8c9a6cf01c8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

