### PR TITLE
feat: pass scrapeId to fire engine

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -332,6 +332,7 @@ export async function scrapeURLWithFireEngineChromeCDP(
     const request: FireEngineScrapeRequestCommon &
       FireEngineScrapeRequestChromeCDP = {
       url: meta.rewrittenUrl ?? meta.url,
+      scrapeId: meta.id,
       engine: "chrome-cdp",
       instantReturn: false,
       skipTlsVerification: meta.options.skipTlsVerification,
@@ -469,6 +470,7 @@ export async function scrapeURLWithFireEnginePlaywright(
     const request: FireEngineScrapeRequestCommon &
       FireEngineScrapeRequestPlaywright = {
       url: meta.rewrittenUrl ?? meta.url,
+      scrapeId: meta.id,
       engine: "playwright",
       instantReturn: false,
 
@@ -544,6 +546,7 @@ export async function scrapeURLWithFireEngineTLSClient(
     const request: FireEngineScrapeRequestCommon &
       FireEngineScrapeRequestTLSClient = {
       url: meta.rewrittenUrl ?? meta.url,
+      scrapeId: meta.id,
       engine: "tlsclient",
       instantReturn: false,
 

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -20,6 +20,7 @@ import { Meta } from "../..";
 import { config } from "../../../../config";
 export type FireEngineScrapeRequestCommon = {
   url: string;
+  scrapeId?: string;
 
   headers?: { [K: string]: string };
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pass scrapeId (meta.id) to Fire Engine for Chrome CDP, Playwright, and TLSClient requests to improve traceability and log correlation. Adds an optional scrapeId field to FireEngineScrapeRequest; no behavior change.

<sup>Written for commit d9358ca6626f0d0bcf2b21ead78617f68dd8d99b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

