### PR TITLE
feat(api): log to db async

### DIFF
--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -67,7 +67,7 @@ export async function scrapeController(
     account: req.account,
   });
 
-  await logRequest({
+  logRequest({
     id: jobId,
     kind: "scrape",
     api_version: "v1",
@@ -77,7 +77,9 @@ export async function scrapeController(
     target_hint: req.body.url,
     zeroDataRetention: zeroDataRetention || false,
     api_key_id: req.acuc?.api_key_id ?? null,
-  });
+  }).catch(err =>
+    logger.warn("Background request log failed", { error: err, jobId }),
+  );
 
   const origin = req.body.origin;
   const timeout = req.body.timeout;

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -126,7 +126,7 @@ export async function scrapeController(
       });
 
       if (!agentRequestId) {
-        await logRequest({
+        logRequest({
           id: jobId,
           kind: "scrape",
           api_version: "v2",
@@ -136,7 +136,9 @@ export async function scrapeController(
           target_hint: req.body.url,
           zeroDataRetention: zeroDataRetention || false,
           api_key_id: req.acuc?.api_key_id ?? null,
-        });
+        }).catch(err =>
+          logger.warn("Background request log failed", { error: err, jobId }),
+        );
       }
 
       setSpanAttributes(span, {

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -538,7 +538,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
 
       doc.metadata.creditsUsed = credits_billed ?? undefined;
 
-      await logScrape(
+      logScrape(
         {
           id: job.id,
           request_id: job.data.requestId ?? job.data.crawl_id ?? job.id,
@@ -555,6 +555,11 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
           skipNuq: job.data.skipNuq ?? false,
         },
         false,
+      ).catch(err =>
+        logger.warn("Background scrape log failed", {
+          error: err,
+          jobId: job.id,
+        }),
       );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make request and scrape logging fire-and-forget so API paths don’t wait on DB writes. This lowers latency and avoids blocking when logging is slow or fails.

- **Refactors**
  - v1 and v2 scrape controllers: call logRequest without await and warn on errors with jobId.
  - Scrape worker: call logScrape without await and warn on errors with jobId.
  - No changes to logging payloads; only execution is async.

<sup>Written for commit 124c265dbb82824cc91c06c85fdef5260d8e8484. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

