### PR TITLE
fix(api): Await document uploads after returning responses

### DIFF
--- a/apps/api/src/controllers/v1/x402-search.ts
+++ b/apps/api/src/controllers/v1/x402-search.ts
@@ -328,7 +328,9 @@ export async function x402SearchController(
       time_taken: timeTakenInSeconds,
     });
 
-    logSearch(
+    res.status(200).json(responseData);
+
+    await logSearch(
       {
         id: jobId,
         request_id: jobId,
@@ -344,9 +346,11 @@ export async function x402SearchController(
         zeroDataRetention: false, // not supported
       },
       false,
+    ).catch(err =>
+      logger.error("Failed to log search to GCS", { error: err, jobId }),
     );
 
-    return res.status(200).json(responseData);
+    return;
   } catch (error) {
     if (error instanceof ScrapeJobTimeoutError) {
       return res.status(408).json({

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -538,7 +538,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
 
       doc.metadata.creditsUsed = credits_billed ?? undefined;
 
-      logScrape(
+      await logScrape(
         {
           id: job.id,
           request_id: job.data.requestId ?? job.data.crawl_id ?? job.id,
@@ -555,11 +555,6 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
           skipNuq: job.data.skipNuq ?? false,
         },
         false,
-      ).catch(err =>
-        logger.warn("Background scrape log failed", {
-          error: err,
-          jobId: job.id,
-        }),
       );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return API responses immediately, then await document upload/logging to ensure reliability without blocking clients. Adds error logging when uploads fail.

- **Bug Fixes**
  - Move logMap/logSearch after res.json and await completion; log failures to GCS.
  - Apply to v1/v2 map, search, and x402 endpoints.
  - Await logScrape in the worker to ensure background uploads finish.

<sup>Written for commit ae4e9d4b2efc15ec90d7e3a13e344566ca128dc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

