### PR TITLE
fix: strip userinfo from URLs to prevent duplicate crawls (Fixes #2591)

### DIFF
--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -2,6 +2,7 @@ import { InternalOptions } from "../scraper/scrapeURL";
 import { ScrapeOptions, TeamFlags } from "../controllers/v2/types";
 import { WebCrawler } from "../scraper/WebScraper/crawler";
 import { redisEvictConnection } from "../services/redis";
+import { stripUrlUserInfo } from "./url-utils";
 import { logger as _logger } from "./logger";
 import { getAdjustedMaxDepth } from "../scraper/WebScraper/utils/maxDepthUtils";
 import type { Logger } from "winston";
@@ -298,7 +299,8 @@ export async function getCrawlQualifiedJobCount(id: string): Promise<number> {
 }
 
 export function normalizeURL(url: string, sc: StoredCrawl): string {
-  const urlO = new URL(url);
+  const urlWithoutUserInfo = stripUrlUserInfo(url);
+  const urlO = new URL(urlWithoutUserInfo);
   if (sc && sc.crawlerOptions && sc.crawlerOptions.ignoreQueryParameters) {
     urlO.search = "";
   }
@@ -327,7 +329,8 @@ export function normalizeURL(url: string, sc: StoredCrawl): string {
 // Points 1 and 2 are proven in permu-refactor.test.ts, point 3 is not as proving a negative is hard and outside the scope of a web crawler.
 // - mogery
 export function generateURLPermutations(url: string | URL): URL[] {
-  const urlO = new URL(url);
+  const strippedUrl = stripUrlUserInfo(typeof url === "string" ? url : url.href);
+  const urlO = new URL(strippedUrl);
 
   // Construct two versions, one with www., one without
   const urlWithWWW = new URL(urlO);

--- a/apps/api/src/lib/url-utils.ts
+++ b/apps/api/src/lib/url-utils.ts
@@ -64,3 +64,33 @@ export function extractBaseDomain(url: string): string | null {
     return null;
   }
 }
+
+/**
+ * Strips userinfo (username:password@ or username@) from HTTP(S) URLs.
+ * Modern browsers strip credentials from URLs before sending requests.
+ * This normalization prevents duplicate crawls when the same page is
+ * discovered via both https://domain.com/page and https://user@domain.com/page.
+ *
+ * Handles:
+ * - Malformed mailto links that become https://email@domain.com
+ * - Basic auth URLs: https://user@domain.com, https://user:pass@domain.com
+ */
+export function stripUrlUserInfo(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    if (
+      urlObj.protocol !== "http:" &&
+      urlObj.protocol !== "https:"
+    ) {
+      return url;
+    }
+    if (urlObj.username || urlObj.password) {
+      urlObj.username = "";
+      urlObj.password = "";
+      return urlObj.href;
+    }
+    return url;
+  } catch {
+    return url;
+  }
+}

--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -13,6 +13,7 @@ import {
   createRobotsChecker,
   isUrlAllowedByRobots,
 } from "../../lib/robots-txt";
+import { stripUrlUserInfo } from "../../lib/url-utils";
 import { ScrapeJobTimeoutError } from "../../lib/error";
 import { ScrapeOptions } from "../../controllers/v2/types";
 import { filterLinks, filterUrl } from "@mendable/firecrawl-rs";
@@ -520,6 +521,7 @@ export class WebCrawler {
     let leftOfLimit = this.limit;
 
     const normalizeUrl = (url: string) => {
+      url = stripUrlUserInfo(url);
       url = url.replace(/^https?:\/\//, "").replace(/^www\./, "");
       if (url.endsWith("/")) {
         url = url.slice(0, -1);
@@ -666,7 +668,7 @@ export class WebCrawler {
     for (const link of links) {
       const filterResult = await this.filterURL(link, url);
       if (filterResult.allowed && filterResult.url) {
-        filteredLinks.push(filterResult.url);
+        filteredLinks.push(stripUrlUserInfo(filterResult.url));
       }
     }
     return filteredLinks;
@@ -685,7 +687,7 @@ export class WebCrawler {
         }
         const filterResult = await this.filterURL(href, url);
         if (filterResult.allowed && filterResult.url) {
-          links.push(filterResult.url);
+          links.push(stripUrlUserInfo(filterResult.url));
         }
       }
     }

--- a/apps/api/src/scraper/scrapeURL/lib/__tests__/extractLinks.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/__tests__/extractLinks.test.ts
@@ -61,4 +61,49 @@ describe("extractLinks integration", () => {
     const links = await extractLinks(html, "https://example.org/foo/bar");
     expect(links).toContain("https://example.org/foo/page.php");
   });
+
+  describe("userinfo and malformed mailto normalization", () => {
+    it("strips userinfo from basic auth URLs", async () => {
+      const html = `
+        <html>
+          <body>
+            <a href="https://user@example.com/page">Auth link</a>
+            <a href="https://user:pass@example.com/other">Auth with pass</a>
+          </body>
+        </html>
+      `;
+      const links = await extractLinks(html, "https://example.org/");
+      expect(links).toContain("https://example.com/page");
+      expect(links).toContain("https://example.com/other");
+      expect(links).not.toContain("https://user@example.com/page");
+      expect(links).not.toContain("https://user:pass@example.com/other");
+    });
+
+    it("normalizes malformed mailto-style URLs", async () => {
+      const html = `
+        <html>
+          <body>
+            <a href="https://contact@example.com">Malformed mailto</a>
+            <a href="https://support@company.co.uk/page">Support</a>
+          </body>
+        </html>
+      `;
+      const links = await extractLinks(html, "https://example.org/");
+      expect(links).toContain("https://example.com/");
+      expect(links).toContain("https://company.co.uk/page");
+    });
+
+    it("strips userinfo when base URL has userinfo", async () => {
+      const html = `
+        <html>
+          <body>
+            <a href="page">Relative</a>
+          </body>
+        </html>
+      `;
+      const links = await extractLinks(html, "https://user@example.org/foo/");
+      expect(links).toContain("https://example.org/foo/page");
+      expect(links).not.toContain("https://user@example.org/foo/page");
+    });
+  });
 });

--- a/apps/api/src/scraper/scrapeURL/lib/extractLinks.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractLinks.ts
@@ -1,6 +1,7 @@
 // TODO: refactor
 import { load } from "cheerio"; // rustified
 import { logger } from "../../../lib/logger";
+import { stripUrlUserInfo } from "../../../lib/url-utils";
 import {
   extractLinks as _extractLinks,
   extractBaseHref as _extractBaseHref,
@@ -28,13 +29,13 @@ function resolveUrlWithBaseHref(
 
   try {
     if (href.startsWith("http://") || href.startsWith("https://")) {
-      return href;
+      return stripUrlUserInfo(href);
     } else if (href.startsWith("mailto:")) {
       return href;
     } else if (href.startsWith("#")) {
       return "";
     } else {
-      return new URL(href, resolutionBase).href;
+      return stripUrlUserInfo(new URL(href, resolutionBase).href);
     }
   } catch (error) {
     logger.error(


### PR DESCRIPTION
FIxes: #2591 

- Add stripUrlUserInfo() to normalize http(s) URLs with userinfo
- Malformed mailto (https://email@domain.com) and basic auth (https://user:pass@domain.com) now deduplicate correctly
- Apply normalization in crawl-redis, crawler, extractLinks, worker

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate crawls by stripping userinfo (username/password) from http(s) URLs during normalization and link extraction. Basic auth and malformed mailto-style URLs now resolve to the canonical domain to avoid extra jobs.

- **Bug Fixes**
  - Added stripUrlUserInfo() in url-utils for http/https; leaves non-http schemes unchanged.
  - Applied normalization in crawl-redis (normalizeURL, generateURLPermutations), crawler link handling, extractLinks, and worker job queuing/sitemap seeding.
  - Ensures permutations and locks dedupe userinfo variants (e.g., https://user@domain.com → https://domain.com).
  - Added tests for edge cases: paths, queries, fragments, ports, punycode, and encoded credentials.

<sup>Written for commit 6ae135983ad404dab993de38833731c343285044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

