### PR TITLE
add stealth mode support for Playwright engine

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -31,6 +31,7 @@ export type Engine =
   | "fire-engine;tlsclient"
   | "fire-engine;tlsclient;stealth"
   | "playwright"
+  | "playwright;stealth"
   | "fetch"
   | "pdf"
   | "document"
@@ -58,7 +59,7 @@ const engines: Engine[] = [
         "fire-engine;tlsclient;stealth" as const,
       ]
     : []),
-  ...(usePlaywright ? ["playwright" as const] : []),
+  ...(usePlaywright ? ["playwright" as const, "playwright;stealth" as const] : []),
   "fetch",
   "pdf",
   "document",
@@ -154,6 +155,7 @@ const engineHandlers: {
   "fire-engine;tlsclient": scrapeURLWithFireEngineTLSClient,
   "fire-engine;tlsclient;stealth": scrapeURLWithFireEngineTLSClient,
   playwright: scrapeURLWithPlaywright,
+  "playwright;stealth": scrapeURLWithPlaywright,
   fetch: scrapeURLWithFetch,
   pdf: scrapePDF,
   document: scrapeDocument,
@@ -181,6 +183,7 @@ const engineMRTs: {
   "fire-engine;tlsclient;stealth": meta =>
     fireEngineMaxReasonableTime(meta, "tlsclient"),
   playwright: playwrightMaxReasonableTime,
+  "playwright;stealth": playwrightMaxReasonableTime,
   fetch: fetchMaxReasonableTime,
   pdf: pdfMaxReasonableTime,
   document: documentMaxReasonableTime,
@@ -366,6 +369,25 @@ const engineOptions: {
       disableAdblock: false,
     },
     quality: 20,
+  },
+  "playwright;stealth": {
+    features: {
+      actions: false,
+      waitFor: true,
+      screenshot: false,
+      "screenshot@fullScreen": false,
+      pdf: false,
+      document: false,
+      atsv: false,
+      location: false,
+      mobile: false,
+      skipTlsVerification: true,
+      useFastMode: false,
+      stealthProxy: true,
+      branding: false,
+      disableAdblock: false,
+    },
+    quality: -12, // Negative quality for stealth variant (between playwright;stealth -10 from fire-engine and tlsclient;stealth -15)
   },
   "fire-engine;tlsclient": {
     features: {

--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -8,6 +8,9 @@ import { getInnerJson } from "@mendable/firecrawl-rs";
 export async function scrapeURLWithPlaywright(
   meta: Meta,
 ): Promise<EngineScrapeResult> {
+  // Check if stealth mode is enabled via feature flags (set by engine selection)
+  const useStealth = meta.featureFlags.has("stealthProxy");
+
   const response = await robustFetch({
     url: config.PLAYWRIGHT_MICROSERVICE_URL!,
     headers: {
@@ -19,6 +22,7 @@ export async function scrapeURLWithPlaywright(
       timeout: meta.abort.scrapeTimeout(),
       headers: meta.options.headers,
       skip_tls_verification: meta.options.skipTlsVerification,
+      stealth: useStealth,
     },
     method: "POST",
     logger: meta.logger.child("scrapeURLWithPlaywright/robustFetch"),
@@ -43,7 +47,7 @@ export async function scrapeURLWithPlaywright(
     error: response.pageError,
     contentType: response.contentType,
 
-    proxyUsed: "basic",
+    proxyUsed: useStealth ? "stealth" : "basic",
   };
 }
 


### PR DESCRIPTION
[#2257]([Self-Host] Firecrawl fails on sites with strong anti-bot measures where Browserless.io succeeds on the same host)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stealth mode variant for the Playwright engine to reduce bot detection and improve success on hard-protected sites. Implements “playwright;stealth” and updates the microservice to support stealth features, addressing Linear #2257.

- **New Features**
  - New engine: "playwright;stealth" (same MRT as standard Playwright, lower quality score to prefer only on tough sites).
  - Passes a stealth flag from API to the Playwright microservice and reports proxyUsed as "stealth".
  - Stealth mode adds CSP bypass, realistic headers, hides navigator.webdriver, fakes plugins, adjusts permissions, exposes chrome object, and adds light canvas noise.
  - Keeps TLS-skip support and existing media blocking; engine registered and feature-flagged via stealthProxy.

- **Migration**
  - Use engine=playwright;stealth to enable stealth via the API.
  - If calling the microservice directly, include "stealth: true" in the POST body (optional).

<sup>Written for commit 65f2a1daa606938702d644c8e413cedbabadaf68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

