### PR TITLE
implement search profiles management and enforcement

### DIFF
--- a/apps/api/src/controllers/v2/search-profiles.ts
+++ b/apps/api/src/controllers/v2/search-profiles.ts
@@ -1,0 +1,99 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import {
+  SearchProfileInput,
+  SearchProfileUpdateInput,
+  createSearchProfile,
+  getSearchProfile,
+  updateSearchProfile,
+} from "../../services/search-profiles";
+
+const createProfileSchema = z.strictObject({
+  profileId: z.string().max(128),
+  name: z.string().max(256),
+  allowlist: z.array(z.string()).min(1),
+  denylist: z.array(z.string()).optional(),
+  wildcardPolicy: z.enum(["none", "subdomains_only"]).optional(),
+});
+
+const updateProfileSchema = z.strictObject({
+  name: z.string().max(256).optional(),
+  allowlist: z.array(z.string()).optional(),
+  denylist: z.array(z.string()).optional(),
+  wildcardPolicy: z.enum(["none", "subdomains_only"]).optional(),
+});
+
+export async function createSearchProfileController(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const parse = createProfileSchema.safeParse(req.body);
+  if (!parse.success) {
+    res.status(400).json({
+      success: false,
+      error: "Invalid request body",
+      details: parse.error.issues,
+    });
+    return;
+  }
+
+  const input = parse.data as SearchProfileInput;
+  const profile = createSearchProfile(input);
+
+  res.status(201).json({
+    success: true,
+    profile,
+  });
+}
+
+export async function updateSearchProfileController(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const profileId = req.params.id;
+  const parse = updateProfileSchema.safeParse(req.body);
+  if (!parse.success) {
+    res.status(400).json({
+      success: false,
+      error: "Invalid request body",
+      details: parse.error.issues,
+    });
+    return;
+  }
+
+  const input = parse.data as SearchProfileUpdateInput;
+  const profile = updateSearchProfile(profileId, input);
+  if (!profile) {
+    res.status(404).json({
+      success: false,
+      error: "Search profile not found",
+    });
+    return;
+  }
+
+  res.status(200).json({
+    success: true,
+    profile,
+  });
+}
+
+export async function getSearchProfileController(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const profileId = req.params.id;
+  const profile = getSearchProfile(profileId);
+  if (!profile) {
+    res.status(404).json({
+      success: false,
+      error: "Search profile not found",
+    });
+    return;
+  }
+
+  res.status(200).json({
+    success: true,
+    profile,
+  });
+}
+

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -113,6 +113,8 @@ export async function searchController(
         enterprise: req.body.enterprise,
         scrapeOptions: req.body.scrapeOptions,
         timeout: req.body.timeout,
+        profileId: req.body.profileId,
+        overrides: req.body.overrides,
       },
       {
         teamId: req.auth.team_id,
@@ -179,11 +181,27 @@ export async function searchController(
       scrapeful: result.shouldScrape,
     });
 
+    if (result.enforcementSummary) {
+      res.setHeader(
+        "x-search-profile-id",
+        result.enforcementSummary.appliedProfileId ?? "",
+      );
+      res.setHeader(
+        "x-search-profile-version",
+        result.enforcementSummary.profileVersion?.toString() ?? "",
+      );
+      res.setHeader(
+        "x-search-profile-effective-domains",
+        result.enforcementSummary.effectiveDomainCount.toString(),
+      );
+    }
+
     return res.status(200).json({
       success: true,
       data: result.response,
       creditsUsed: result.totalCredits,
       id: jobId,
+      enforcementSummary: result.enforcementSummary,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1619,6 +1619,13 @@ export const searchRequestSchema = z
     integration: integrationSchema.optional().transform(val => val || null),
     timeout: z.int().positive().finite().prefault(60000),
     ignoreInvalidURLs: z.boolean().optional().prefault(false),
+    profileId: z.string().max(128).optional(),
+    overrides: z
+      .object({
+        allowedDomains: z.array(z.string()).max(500).optional(),
+        blockedDomains: z.array(z.string()).max(500).optional(),
+      })
+      .optional(),
     asyncScraping: z.boolean().optional().prefault(false),
     __searchPreviewToken: z.string().optional(),
     scrapeOptions: baseScrapeOptions
@@ -1760,6 +1767,7 @@ export type SearchResponse =
       data: import("../../lib/entities").SearchV2Response;
       creditsUsed: number;
       id: string;
+      enforcementSummary?: import("../../services/search-profiles").EnforcementSummary | null;
     }
   | {
       success: true;

--- a/apps/api/src/lib/domain-utils.ts
+++ b/apps/api/src/lib/domain-utils.ts
@@ -1,0 +1,101 @@
+import { checkUrl } from "./validateUrl";
+
+export type WildcardPolicy = "none" | "subdomains_only";
+
+export function normalizeDomain(raw: string): string | null {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) return null;
+
+  let candidate = trimmed;
+  if (!/^https?:\/\//i.test(candidate)) {
+    candidate = `http://${candidate}`;
+  }
+
+  try {
+    checkUrl(candidate);
+    const url = new URL(candidate);
+    return url.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function isPrivateHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  if (
+    lower === "localhost" ||
+    lower.startsWith("127.") ||
+    lower.startsWith("10.") ||
+    /^192\.168\.\d{1,3}\.\d{1,3}$/i.test(lower) ||
+    /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/i.test(lower)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function extractHostname(url: string): string | null {
+  try {
+    const value = url.trim();
+    const candidate = /^https?:\/\//i.test(value) ? value : `http://${value}`;
+    const parsed = new URL(candidate);
+    return parsed.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function matchesWildcard(hostname: string, pattern: string): boolean {
+  if (!pattern.startsWith("*.")) return false;
+  const suffix = pattern.slice(1); // keep leading dot
+  return hostname.endsWith(suffix) && hostname !== pattern.slice(2);
+}
+
+export function domainMatches(
+  hostname: string,
+  domainPattern: string,
+  wildcardPolicy: WildcardPolicy,
+): boolean {
+  const normalizedHost = hostname.toLowerCase();
+  const normalizedPattern = domainPattern.toLowerCase();
+
+  if (normalizedPattern.startsWith("*.")) {
+    if (wildcardPolicy !== "subdomains_only") {
+      return false;
+    }
+    return matchesWildcard(normalizedHost, normalizedPattern);
+  }
+
+  return normalizedHost === normalizedPattern;
+}
+
+export interface DomainFilters {
+  allowlist: string[];
+  denylist: string[];
+  wildcardPolicy: WildcardPolicy;
+}
+
+export function shouldIncludeHostname(
+  hostname: string,
+  filters: DomainFilters,
+): boolean {
+  if (isPrivateHostname(hostname)) {
+    return false;
+  }
+
+  const { allowlist, denylist, wildcardPolicy } = filters;
+
+  const isDenied = denylist.some(pattern =>
+    domainMatches(hostname, pattern, wildcardPolicy),
+  );
+  if (isDenied) return false;
+
+  if (allowlist.length === 0) {
+    return true;
+  }
+
+  return allowlist.some(pattern =>
+    domainMatches(hostname, pattern, wildcardPolicy),
+  );
+}
+

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -3,6 +3,11 @@ import { config } from "../config";
 import { RateLimiterMode } from "../types";
 import expressWs from "express-ws";
 import { searchController } from "../controllers/v2/search";
+import {
+  createSearchProfileController,
+  getSearchProfileController,
+  updateSearchProfileController,
+} from "../controllers/v2/search-profiles";
 import { x402SearchController } from "../controllers/v2/x402-search";
 import { scrapeController } from "../controllers/v2/scrape";
 import { batchScrapeController } from "../controllers/v2/batch-scrape";
@@ -179,6 +184,24 @@ v2Router.post(
   checkCreditsMiddleware(),
   blocklistMiddleware,
   wrap(searchController),
+);
+
+v2Router.post(
+  "/search-profiles",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(createSearchProfileController),
+);
+
+v2Router.put(
+  "/search-profiles/:id",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(updateSearchProfileController),
+);
+
+v2Router.get(
+  "/search-profiles/:id",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(getSearchProfileController),
 );
 
 v2Router.post(

--- a/apps/api/src/services/search-profiles.ts
+++ b/apps/api/src/services/search-profiles.ts
@@ -1,0 +1,196 @@
+import { SearchV2Response } from "../lib/entities";
+import {
+  DomainFilters,
+  WildcardPolicy,
+  extractHostname,
+  normalizeDomain,
+  shouldIncludeHostname,
+} from "../lib/domain-utils";
+
+export interface SearchProfile {
+  profileId: string;
+  name: string;
+  allowlist: string[];
+  denylist: string[];
+  wildcardPolicy: WildcardPolicy;
+  version: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SearchProfileInput {
+  profileId: string;
+  name: string;
+  allowlist: string[];
+  denylist?: string[];
+  wildcardPolicy?: WildcardPolicy;
+}
+
+export interface SearchProfileUpdateInput {
+  name?: string;
+  allowlist?: string[];
+  denylist?: string[];
+  wildcardPolicy?: WildcardPolicy;
+}
+
+export interface DomainOverrides {
+  allowedDomains?: string[];
+  blockedDomains?: string[];
+}
+
+export interface EnforcementSummary {
+  appliedProfileId?: string;
+  profileVersion?: number;
+  effectiveDomainCount: number;
+  allowedOverrideCount: number;
+  blockedOverrideCount: number;
+}
+
+const profiles = new Map<string, SearchProfile>();
+
+export function createSearchProfile(input: SearchProfileInput): SearchProfile {
+  const now = new Date();
+  const existing = profiles.get(input.profileId);
+
+  const baseVersion = existing ? existing.version + 1 : 1;
+
+  const allowlist = (input.allowlist || [])
+    .map(normalizeDomain)
+    .filter((d): d is string => !!d);
+  const denylist = (input.denylist || [])
+    .map(normalizeDomain)
+    .filter((d): d is string => !!d);
+
+  const profile: SearchProfile = {
+    profileId: input.profileId,
+    name: input.name,
+    allowlist,
+    denylist,
+    wildcardPolicy: input.wildcardPolicy ?? "none",
+    version: baseVersion,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  };
+
+  profiles.set(profile.profileId, profile);
+  return profile;
+}
+
+export function updateSearchProfile(
+  profileId: string,
+  input: SearchProfileUpdateInput,
+): SearchProfile | null {
+  const existing = profiles.get(profileId);
+  if (!existing) return null;
+
+  const now = new Date();
+
+  const allowlist =
+    input.allowlist !== undefined
+      ? input.allowlist
+          .map(normalizeDomain)
+          .filter((d): d is string => !!d)
+      : existing.allowlist;
+
+  const denylist =
+    input.denylist !== undefined
+      ? input.denylist
+          .map(normalizeDomain)
+          .filter((d): d is string => !!d)
+      : existing.denylist;
+
+  const profile: SearchProfile = {
+    ...existing,
+    name: input.name ?? existing.name,
+    allowlist,
+    denylist,
+    wildcardPolicy: input.wildcardPolicy ?? existing.wildcardPolicy,
+    version: existing.version + 1,
+    updatedAt: now,
+  };
+
+  profiles.set(profile.profileId, profile);
+  return profile;
+}
+
+export function getSearchProfile(profileId: string): SearchProfile | null {
+  return profiles.get(profileId) ?? null;
+}
+
+function buildDomainFilters(
+  profile: SearchProfile | null,
+  overrides?: DomainOverrides,
+): { filters: DomainFilters | null; summary: EnforcementSummary | null } {
+  const allowFromProfile = profile?.allowlist ?? [];
+  const denyFromProfile = profile?.denylist ?? [];
+
+  const overrideAllowed = (overrides?.allowedDomains ?? [])
+    .map(normalizeDomain)
+    .filter((d): d is string => !!d);
+  const overrideBlocked = (overrides?.blockedDomains ?? [])
+    .map(normalizeDomain)
+    .filter((d): d is string => !!d);
+
+  const combinedAllow = Array.from(
+    new Set([...allowFromProfile, ...overrideAllowed]),
+  );
+  const combinedDeny = Array.from(
+    new Set([...denyFromProfile, ...overrideBlocked]),
+  );
+
+  if (!profile && combinedAllow.length === 0 && combinedDeny.length === 0) {
+    return { filters: null, summary: null };
+  }
+
+  const filters: DomainFilters = {
+    allowlist: combinedAllow,
+    denylist: combinedDeny,
+    wildcardPolicy: profile?.wildcardPolicy ?? "none",
+  };
+
+  const summary: EnforcementSummary = {
+    appliedProfileId: profile?.profileId,
+    profileVersion: profile?.version,
+    effectiveDomainCount: combinedAllow.length,
+    allowedOverrideCount: overrideAllowed.length,
+    blockedOverrideCount: overrideBlocked.length,
+  };
+
+  return { filters, summary };
+}
+
+export function enforceSearchProfile(
+  response: SearchV2Response,
+  profileId?: string,
+  overrides?: DomainOverrides,
+): { response: SearchV2Response; summary: EnforcementSummary | null } {
+  const profile = profileId ? getSearchProfile(profileId) : null;
+  const { filters, summary } = buildDomainFilters(profile, overrides);
+
+  if (!filters) {
+    return { response, summary: null };
+  }
+
+  const filterList = <
+    T extends { url: string } & Record<string, unknown>,
+  >(
+    items: T[] | undefined,
+  ): T[] | undefined => {
+    if (!items || items.length === 0) return items;
+    return items.filter(item => {
+      const host = extractHostname(item.url);
+      if (!host) return false;
+      return shouldIncludeHostname(host, filters);
+    });
+  };
+
+  const next: SearchV2Response = {
+    ...response,
+    web: filterList(response.web),
+    news: filterList(response.news),
+    images: filterList(response.images),
+  };
+
+  return { response: next, summary };
+}
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,10 @@
 name: firecrawl
 
 x-common-service: &common-service
-  # NOTE: If you don't want to build the service locally,
-  # comment out the build: statement and uncomment the image: statement
-  # image: ghcr.io/firecrawl/firecrawl
-  build: apps/api
+  # NOTE: Images are pulled from GitHub Container Registry (ghcr.io).
+  # To build locally instead, comment out the image: statement and uncomment the build: statement
+  image: ghcr.io/firecrawl/firecrawl:latest
+  # build: apps/api
 
   ulimits:
     nofile:
@@ -57,10 +57,10 @@ x-common-env: &common-env
 
 services:
   playwright-service:
-    # NOTE: If you don't want to build the service locally,
-    # comment out the build: statement and uncomment the image: statement
-    # image: ghcr.io/firecrawl/playwright-service:latest
-    build: apps/playwright-service-ts
+    # NOTE: Images are pulled from GitHub Container Registry (ghcr.io).
+    # To build locally instead, comment out the image: statement and uncomment the build: statement
+    image: ghcr.io/firecrawl/playwright-service:latest
+    # build: apps/playwright-service-ts
     environment:
       PORT: 3000
       PROXY_SERVER: ${PROXY_SERVER}
@@ -146,7 +146,10 @@ services:
         compress: "true"
   
   nuq-postgres:
-    build: apps/nuq-postgres
+    # NOTE: Images are pulled from GitHub Container Registry (ghcr.io).
+    # To build locally instead, comment out the image: statement and uncomment the build: statement
+    image: ghcr.io/firecrawl/nuq-postgres:latest
+    # build: apps/nuq-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}


### PR DESCRIPTION
[#2318]([Feat] Profile‑based domain allowlist for restricted /v2/search (with overrides))

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add profile-based domain enforcement to /v2/search with profile management and per-request overrides. Addresses Linear #2318 and returns an enforcement summary in the response and headers.

- **New Features**
  - Added /v2/search-profiles endpoints: POST (create), PUT (update), GET (fetch).
  - /v2/search now accepts profileId and overrides {allowedDomains, blockedDomains}.
  - Filters web/news/images results using allowlist/denylist and wildcard policy; private hosts are excluded.
  - Returns enforcementSummary and sets x-search-profile-id, x-search-profile-version, x-search-profile-effective-domains.

- **Migration**
  - Create a search profile, then pass profileId to /v2/search to enforce domains.
  - Use overrides to add or block domains per request without changing the profile.
  - Check enforcementSummary in the response to track applied profile, version, and effective domain count.
  - docker-compose now pulls GHCR images by default; switch to local builds by toggling image/build lines.

<sup>Written for commit d1726ba7c2309a4ad7fe8081005768dd0644962b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

