### PR TITLE
fix(billing): don't use bullmq

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,7 +9,6 @@ import cors from "cors";
 import {
   getGenerateLlmsTxtQueue,
   getDeepResearchQueue,
-  getBillingQueue,
   getPrecrawlQueue,
 } from "./services/queue-service";
 import { v0Router } from "./routes/v0";
@@ -82,7 +81,6 @@ const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
   queues: [
     new BullMQAdapter(getGenerateLlmsTxtQueue()),
     new BullMQAdapter(getDeepResearchQueue()),
-    new BullMQAdapter(getBillingQueue()),
     new BullMQAdapter(getPrecrawlQueue()),
   ],
   serverAdapter: serverAdapter,

--- a/apps/api/src/services/queue-service.ts
+++ b/apps/api/src/services/queue-service.ts
@@ -9,7 +9,6 @@ let loggingQueue: Queue;
 let indexQueue: Queue;
 let deepResearchQueue: Queue;
 let generateLlmsTxtQueue: Queue;
-let billingQueue: Queue;
 let precrawlQueue: Queue;
 let redisConnection: IORedis;
 
@@ -27,7 +26,6 @@ export function getRedisConnection(): IORedis {
 
 const generateLlmsTxtQueueName = "{generateLlmsTxtQueue}";
 const deepResearchQueueName = "{deepResearchQueue}";
-const billingQueueName = "{billingQueue}";
 export const precrawlQueueName = "{precrawlQueue}";
 
 export async function addExtractJobToQueue(
@@ -72,23 +70,6 @@ export function getDeepResearchQueue() {
     );
   }
   return deepResearchQueue;
-}
-
-export function getBillingQueue() {
-  if (!billingQueue) {
-    billingQueue = new Queue(billingQueueName, {
-      connection: getRedisConnection(),
-      defaultJobOptions: {
-        removeOnComplete: {
-          age: 60, // 1 minute
-        },
-        removeOnFail: {
-          age: 3600, // 1 hour
-        },
-      },
-    });
-  }
-  return billingQueue;
 }
 
 export function getPrecrawlQueue() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed BullMQ from billing. Billing now writes directly to the Redis-backed batch processor, simplifying workers and improving reliability.

- **Refactors**
  - Removed the billing BullMQ queue, worker, and Bull Board entry.
  - scrape-worker now calls queueBillingOperation(...) instead of enqueuing a BullMQ job.
  - Kept startBillingBatchProcessing() to run the batch processor without BullMQ.

<sup>Written for commit 0aed440086bd36dd021d187f0127d7279d1ac91d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

