### PR TITLE
chore(deps): Fix dependency audit

### DIFF
--- a/apps/test-site/package.json
+++ b/apps/test-site/package.json
@@ -26,7 +26,8 @@
       "sharp"
     ],
     "overrides": {
-      "fast-xml-parser": "^5.3.6"
+      "fast-xml-parser": "^5.3.6",
+      "devalue": "^5.6.3"
     }
   }
 }

--- a/apps/test-site/pnpm-lock.yaml
+++ b/apps/test-site/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   fast-xml-parser: ^5.3.6
+  devalue: ^5.6.3
 
 importers:
 
@@ -784,8 +785,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.6.2:
-    resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
+  devalue@5.6.3:
+    resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -2238,7 +2239,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.6.2
+      devalue: 5.6.3
       diff: 8.0.3
       dlv: 1.1.3
       dset: 3.1.4
@@ -2425,7 +2426,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.6.2: {}
+  devalue@5.6.3: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Force devalue to ^5.6.3 in apps/test-site via package.json overrides and update pnpm-lock.yaml to resolve dependency audit warnings. No app code or behavior changes.

<sup>Written for commit 88630c48f16e15c81a402edd5cc940d92c3fcece. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

