### PR TITLE
chore(pdf): Log MU pagesProcessed

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -39,6 +39,7 @@ async function scrapePDFWithRunPodMU(
   tempFilePath: string,
   base64Content: string,
   maxPages?: number,
+  pagesProcessed?: number,
 ): Promise<PDFProcessorResult> {
   meta.logger.debug("Processing PDF document with RunPod MU", {
     tempFilePath,
@@ -194,6 +195,7 @@ async function scrapePDFWithRunPodMU(
     meta.logger.child({ method: "scrapePDF/MUv1" }).warn("MU v1 failed", {
       durationMs,
       url: meta.rewrittenUrl ?? meta.url,
+      ...(pagesProcessed !== undefined && { pagesProcessed }),
     });
     throw new Error("RunPod MU failed to parse PDF");
   }
@@ -203,6 +205,7 @@ async function scrapePDFWithRunPodMU(
     meta.logger.child({ method: "scrapePDF/MUv1" }).warn("MU v1 failed", {
       durationMs,
       url: meta.rewrittenUrl ?? meta.url,
+      ...(pagesProcessed !== undefined && { pagesProcessed }),
     });
     throw new Error("RunPod MU returned no result");
   }
@@ -228,6 +231,7 @@ async function scrapePDFWithRunPodMU(
     meta.logger.child({ method: "scrapePDF/MUv1" }).info("MU v1 completed", {
       durationMs,
       url: meta.rewrittenUrl ?? meta.url,
+      ...(pagesProcessed !== undefined && { pagesProcessed }),
     });
   }
 
@@ -375,6 +379,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           tempFilePath,
           base64Content,
           maxPages,
+          effectivePageCount,
         );
         const muV1DurationMs = Date.now() - muV1StartedAt;
         meta.logger


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add pagesProcessed to the RunPod MU v1 PDF scraper to track how many pages were processed. We pass effectivePageCount into scrapePDFWithRunPodMU and include pagesProcessed in MU v1 warn and info logs for better observability.

<sup>Written for commit f074493c4756ca4a1e0c72c4f5c9ae54507649a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

