### PR TITLE
feat: add custom http headers support to node.js sdk

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -80,6 +80,8 @@ export interface FirecrawlClientOptions {
   maxRetries?: number;
   /** Exponential backoff factor for retries (optional). */
   backoffFactor?: number;
+  /** Custom HTTP headers for self-hosted instances (optional). */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -111,6 +113,7 @@ export class FirecrawlClient {
       timeoutMs: options.timeoutMs,
       maxRetries: options.maxRetries,
       backoffFactor: options.backoffFactor,
+      headers: options.headers,
     });
   }
 

--- a/apps/js-sdk/firecrawl/src/v2/utils/httpClient.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/httpClient.ts
@@ -7,6 +7,7 @@ export interface HttpClientOptions {
   timeoutMs?: number;
   maxRetries?: number;
   backoffFactor?: number; // seconds factor for 0.5, 1, 2...
+  headers?: Record<string, string>; // custom headers for self-hosted instances
 }
 
 export class HttpClient {
@@ -27,6 +28,7 @@ export class HttpClient {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.apiKey}`,
+        ...(options.headers || {}), // merge custom headers
       },
       transitional: { clarifyTimeoutError: true },
     });


### PR DESCRIPTION
Closes #2814

## Summary
This PR adds support for custom HTTP headers in the Node.js SDK (), enabling users of self-hosted Firecrawl instances behind reverse proxies to pass authentication headers.

## Changes
- Added `headers` option to `FirecrawlClientOptions` interface
- Added `headers` option to `HttpClientOptions` interface  
- Updated `HttpClient` constructor to merge custom headers with default headers
- Updated `FirecrawlClient` constructor to pass headers to `HttpClient`

## Use Case
This feature enables self-hosted Firecrawl users to handle:
- **Cloudflare Access protection:** Pass `CF-Access-Client-Id` and `CF-Access-Client-Secret` headers
- **Custom authorization schemes:** Support non-Bearer token auth or additional auth headers
- **Reverse proxy authentication:** Work with nginx auth, Traefik forward auth, etc.
- **Custom tracking headers:** Add request IDs, tenant identifiers, or metadata headers

## Example Usage
```typescript
const firecrawl = new Firecrawl({
  apiUrl: 'https://firecrawl.my-company.com',
  headers: {
    'CF-Access-Client-Id': process.env.CF_ACCESS_CLIENT_ID,
    'CF-Access-Client-Secret': process.env.CF_ACCESS_CLIENT_SECRET
  }
});

// All SDK methods now work through Cloudflare Access
const result = await firecrawl.scrape('https://example.com');
```

## Backwards Compatibility
✅ Fully backwards-compatible - existing code continues to work unchanged. The `headers` option is optional and defaults to an empty object if not provided.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds custom HTTP headers support to the Node.js SDK so self-hosted Firecrawl behind reverse proxies can pass auth or metadata headers. Fully backwards-compatible; behavior is unchanged if no headers are provided.

- **New Features**
  - Added headers option to FirecrawlClientOptions and HttpClientOptions.
  - HttpClient merges custom headers with default Content-Type and Authorization.
  - FirecrawlClient passes headers through to HttpClient.

<sup>Written for commit dd986c2875d434df90067f7d2daea3828154af2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

