### PR TITLE
chore(mu): Log MU ID to Track Failures

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -195,6 +195,7 @@ async function scrapePDFWithRunPodMU(
     meta.logger.child({ method: "scrapePDF/MUv1" }).warn("MU v1 failed", {
       durationMs,
       url: meta.rewrittenUrl ?? meta.url,
+      mu_id: podStart.id,
       ...(pagesProcessed !== undefined && { pagesProcessed }),
     });
     throw new Error("RunPod MU failed to parse PDF");
@@ -205,6 +206,7 @@ async function scrapePDFWithRunPodMU(
     meta.logger.child({ method: "scrapePDF/MUv1" }).warn("MU v1 failed", {
       durationMs,
       url: meta.rewrittenUrl ?? meta.url,
+      mu_id: podStart.id,
       ...(pagesProcessed !== undefined && { pagesProcessed }),
     });
     throw new Error("RunPod MU returned no result");
@@ -231,6 +233,7 @@ async function scrapePDFWithRunPodMU(
     meta.logger.child({ method: "scrapePDF/MUv1" }).info("MU v1 completed", {
       durationMs,
       url: meta.rewrittenUrl ?? meta.url,
+      mu_id: podStart.id,
       ...(pagesProcessed !== undefined && { pagesProcessed }),
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add RunPod MU pod ID (mu_id) to PDF scraper logs to improve debugging and traceability. The ID is included in warn/info logs for MU v1 failures, no-result cases, and successful completions.

<sup>Written for commit a74f8cecfda5e3cbc934ea6c5ebeb4c287ef6a67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

