### PR TITLE
chore(api): update semaphore hold duration buckets

### DIFF
--- a/apps/api/src/services/worker/team-semaphore.ts
+++ b/apps/api/src/services/worker/team-semaphore.ts
@@ -23,7 +23,7 @@ const semaphoreHoldDuration = new Histogram({
   name: "noq_semaphore_hold_duration_seconds",
   help: "Semaphore hold time",
   buckets: [
-    0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 180, 240, 300, 600,
+    0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 10, 15, 20, 30, 60, 120, 300,
   ],
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Prometheus histogram buckets for semaphore hold duration to better reflect typical waits and improve metric accuracy. Adds tighter granularity from 0.5–8s, keeps coverage up to 5 minutes, and removes sub-0.5s and >300s buckets to reduce noise.

<sup>Written for commit 643f84633939b118119b6f6473770be0946a7eae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

