### PR TITLE
feat(pdf): Track MU Errors

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -220,6 +220,9 @@ async function scrapePDFWithRunPodMU(
     captureExceptionWithZdrCheck(err, {
       extra: {
         zeroDataRetention: meta.internalOptions.zeroDataRetention ?? false,
+        scrapeId: meta.id,
+        teamId: meta.internalOptions.teamId,
+        url: meta.rewrittenUrl ?? meta.url,
         runpodId: podStart.id,
         runpodError: lastRunPodError,
         durationMs,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enhanced error tracking in the PDF scraper for RunPod MU. Failures are logged with context and captured to Sentry, now including scrapeId, teamId, URL, and RunPod details; optional fields are handled safely to prevent crashes.

- **New Features**
  - Capture MU failures via captureExceptionWithZdrCheck with runpodId, scrapeId, teamId, URL, runpodError, duration, and zero-data-retention flag.
  - Throw a detailed error with the last RunPod message when MU fails.

- **Bug Fixes**
  - Treat markdown and status as optional; track and persist the last RunPod error during polling.
  - Guard against missing markdown before parsing and return a typed PDFProcessorResult.

<sup>Written for commit 90fdc15c1650b455a811b244a8d6fbbc3a7e9f3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

