### PR TITLE
chore(sentry): Better logging of PDF errors

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/fetch.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/fetch.ts
@@ -1,5 +1,6 @@
 import { Logger } from "winston";
 import { z, ZodError } from "zod";
+import * as Sentry from "@sentry/node";
 import { MockState, saveMock } from "./mock";
 import { fireEngineURL } from "../engines/fire-engine/scrape";
 import { fetch, Response, FormData, Agent } from "undici";
@@ -131,6 +132,7 @@ export async function robustFetch<
       if (error instanceof AbortManagerThrownError) {
         throw error;
       } else if (!ignoreFailure) {
+        Sentry.captureException(error);
         if (tryCount > 1) {
           logger.debug(
             "Request failed, trying " + (tryCount - 1) + " more times",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Sentry filters to drop operational noise and only capture actionable backend errors. PDF scraping now routes all errors through a zero-data-retention–aware capture helper with context (url, scrapeId, teamId), replacing direct Sentry calls in the PDF engine.

Ignores network fetch failures, incorrect header check, "Request sent failure status", unsupported action errors, RabbitMQ connection closing/channel closed, ZodError, and invalid UUID syntax.

<sup>Written for commit 743dd2c66aa8805da51dd03a96834621736f3d45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

