### PR TITLE
feat(sdk): Add pdf parser options to JS and Python SDKS

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.13.2",
+  "version": "4.14.0",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -145,7 +145,7 @@ export interface ScrapeOptions {
   timeout?: number;
   waitFor?: number;
   mobile?: boolean;
-  parsers?: Array<string | { type: 'pdf'; maxPages?: number }>;
+  parsers?: Array<string | { type: 'pdf'; mode?: 'fast' | 'auto' | 'ocr'; maxPages?: number }>;
   actions?: ActionOption[];
   location?: LocationConfig;
   skipTlsVerification?: boolean;

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.16.3"
+__version__ = "4.17.0"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1015,9 +1015,10 @@ class PDFAction(BaseModel):
 
 
 class PDFParser(BaseModel):
-    """PDF parser configuration with optional page limit."""
+    """PDF parser configuration with optional page limit and processing mode."""
 
     type: Literal["pdf"] = "pdf"
+    mode: Optional[Literal["fast", "auto", "ocr"]] = None
     max_pages: Optional[int] = None
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds PDF parser mode support to the JS and Python SDKs so you can choose fast, auto, or ocr for PDF extraction.

- **New Features**
  - JS: ScrapeOptions.parsers accepts { type: 'pdf', mode: 'fast' | 'auto' | 'ocr', maxPages? }.
  - Python: PDFParser adds mode ('fast' | 'auto' | 'ocr'); max_pages remains optional.

- **Dependencies**
  - JS SDK version: 4.14.0
  - Python SDK version: 4.17.0

<sup>Written for commit 503bac2c41664f1478cf575839ef9782c5991442. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

