### PR TITLE
fix(pdf): Handle PDFs with Corrupt EOF

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "f37c911" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "3a1ada1" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates pdf-inspector to rev 3a1ada1 to handle PDFs with corrupt or missing EOF markers. This prevents parsing failures and improves stability when ingesting malformed PDFs.

<sup>Written for commit 246c7748135a19085c22abe8fa8353b39229e341. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

