### PR TITLE
fix(pdf): Fix inline image parsing in PDFs

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "3a1ada1" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "0aa4e0a" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update pdf-inspector to fix parsing of inline images in PDFs. This resolves missing or corrupted inline images during processing and improves extraction reliability.

<sup>Written for commit 11d0e48dfdff3ed1397765ab709712331a8f4b3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

