### PR TITLE
browser: persistent session sdks

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -317,7 +317,7 @@ export class FirecrawlClient {
   // Browser
   /**
    * Create a new browser session.
-   * @param args Session options (ttl, activityTtl, streamWebView).
+   * @param args Session options (ttl, activityTtl, streamWebView, persistentSession).
    * @returns Session id, CDP URL, live view URL, and expiration time.
    */
   async browser(

--- a/apps/js-sdk/firecrawl/src/v2/methods/browser.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/browser.ts
@@ -13,12 +13,17 @@ export async function browser(
     ttl?: number;
     activityTtl?: number;
     streamWebView?: boolean;
+    persistentSession?: {
+      name: string;
+      writeMode?: "readonly" | "readwrite";
+    };
   } = {}
 ): Promise<BrowserCreateResponse> {
   const body: Record<string, unknown> = {};
   if (args.ttl != null) body.ttl = args.ttl;
   if (args.activityTtl != null) body.activityTtl = args.activityTtl;
   if (args.streamWebView != null) body.streamWebView = args.streamWebView;
+  if (args.persistentSession != null) body.persistentSession = args.persistentSession;
 
   try {
     const res = await http.post<BrowserCreateResponse>("/v2/browser", body);

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -984,6 +984,7 @@ class FirecrawlClient:
         ttl: Optional[int] = None,
         activity_ttl: Optional[int] = None,
         stream_web_view: Optional[bool] = None,
+        persistent_session: Optional[Dict[str, Any]] = None,
     ):
         """Create a new browser session.
 
@@ -991,6 +992,8 @@ class FirecrawlClient:
             ttl: Total time-to-live in seconds (30-3600, default 300)
             activity_ttl: Inactivity TTL in seconds (10-3600)
             stream_web_view: Whether to enable webview streaming
+            persistent_session: Persistent session config with ``name`` (str) and
+                optional ``write_mode`` (``"readonly"`` | ``"readwrite"``, default ``"readwrite"``)
 
         Returns:
             BrowserCreateResponse with session id and CDP URL
@@ -1000,6 +1003,7 @@ class FirecrawlClient:
             ttl=ttl,
             activity_ttl=activity_ttl,
             stream_web_view=stream_web_view,
+            persistent_session=persistent_session,
         )
 
     def browser_execute(

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -468,6 +468,7 @@ class AsyncFirecrawlClient:
         ttl: Optional[int] = None,
         activity_ttl: Optional[int] = None,
         stream_web_view: Optional[bool] = None,
+        persistent_session: Optional[Dict[str, Any]] = None,
     ):
         """Create a new browser session.
 
@@ -475,6 +476,8 @@ class AsyncFirecrawlClient:
             ttl: Total time-to-live in seconds (30-3600, default 300)
             activity_ttl: Inactivity TTL in seconds (10-3600)
             stream_web_view: Whether to enable webview streaming
+            persistent_session: Persistent session config with ``name`` (str) and
+                optional ``write_mode`` (``"readonly"`` | ``"readwrite"``, default ``"readwrite"``)
 
         Returns:
             BrowserCreateResponse with session id and CDP URL
@@ -484,6 +487,7 @@ class AsyncFirecrawlClient:
             ttl=ttl,
             activity_ttl=activity_ttl,
             stream_web_view=stream_web_view,
+            persistent_session=persistent_session,
         )
 
     async def browser_execute(

--- a/apps/python-sdk/firecrawl/v2/methods/aio/browser.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/browser.py
@@ -4,7 +4,7 @@ Async browser session methods for Firecrawl v2 API.
 Provides async create, execute, delete, and list operations for browser sessions.
 """
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 from ...types import (
     BrowserCreateResponse,
@@ -53,6 +53,7 @@ async def browser(
     ttl: Optional[int] = None,
     activity_ttl: Optional[int] = None,
     stream_web_view: Optional[bool] = None,
+    persistent_session: Optional[Dict[str, Any]] = None,
 ) -> BrowserCreateResponse:
     """Create a new browser session.
 
@@ -61,6 +62,8 @@ async def browser(
         ttl: Total time-to-live in seconds (30-3600, default 300)
         activity_ttl: Inactivity TTL in seconds (10-3600)
         stream_web_view: Whether to enable webview streaming
+        persistent_session: Persistent session config with ``name`` (str) and
+            optional ``write_mode`` (``"readonly"`` | ``"readwrite"``, default ``"readwrite"``)
 
     Returns:
         BrowserCreateResponse with session id and CDP URL
@@ -72,6 +75,11 @@ async def browser(
         body["activityTtl"] = activity_ttl
     if stream_web_view is not None:
         body["streamWebView"] = stream_web_view
+    if persistent_session is not None:
+        body["persistentSession"] = {
+            "name": persistent_session["name"],
+            "writeMode": persistent_session.get("write_mode", "readwrite"),
+        }
 
     resp = await client.post("/v2/browser", body)
     payload = _normalize_browser_create_response(resp.json())

--- a/apps/python-sdk/firecrawl/v2/methods/browser.py
+++ b/apps/python-sdk/firecrawl/v2/methods/browser.py
@@ -54,6 +54,7 @@ def browser(
     ttl: Optional[int] = None,
     activity_ttl: Optional[int] = None,
     stream_web_view: Optional[bool] = None,
+    persistent_session: Optional[Dict[str, Any]] = None,
 ) -> BrowserCreateResponse:
     """Create a new browser session.
 
@@ -62,6 +63,8 @@ def browser(
         ttl: Total time-to-live in seconds (30-3600, default 300)
         activity_ttl: Inactivity TTL in seconds (10-3600)
         stream_web_view: Whether to enable webview streaming
+        persistent_session: Persistent session config with ``name`` (str) and
+            optional ``write_mode`` (``"readonly"`` | ``"readwrite"``, default ``"readwrite"``)
 
     Returns:
         BrowserCreateResponse with session id and CDP URL
@@ -73,6 +76,11 @@ def browser(
         body["activityTtl"] = activity_ttl
     if stream_web_view is not None:
         body["streamWebView"] = stream_web_view
+    if persistent_session is not None:
+        body["persistentSession"] = {
+            "name": persistent_session["name"],
+            "writeMode": persistent_session.get("write_mode", "readwrite"),
+        }
 
     resp = client.post("/v2/browser", body)
     if not resp.ok:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for persistent browser sessions in the JS and Python SDKs to let users reuse session state by name and control write access.

- **New Features**
  - Added a persistentSession option to browser(...) (JS) and persistent_session to browser(...) (Python sync/async).
  - Configure name and write mode (readonly or readwrite, default readwrite); Python keys are mapped to API format.
  - Sends persistentSession in the request body alongside existing TTL and streamWebView options.

<sup>Written for commit 7056229ea1a5621cd8fc00f95828dcfec5e3f15c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

