### PR TITLE
fix(api): handle redlock quorum error in notifications

### DIFF
--- a/apps/api/src/services/notification/email_notification.ts
+++ b/apps/api/src/services/notification/email_notification.ts
@@ -259,8 +259,8 @@ async function sendNotificationInternal(
           }
         }
 
-        console.log(
-          `Sending notification for team_id: ${team_id} and notificationType: ${notificationType}`,
+        logger.info(
+          "Sending notification for team_id: " + team_id + " and notificationType: " + notificationType,
         );
 
         if (is_ledger_enabled) {


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gracefully handle Redlock quorum failures in notification sending to stop unhandled rejections and reduce Sentry noise. If the lock can’t be acquired, we log a warning and return { success: false } instead of throwing.

- **Bug Fixes**
  - Wrapped redlock.using() in sendNotificationInternal with try/catch; on lock failure, log a warning and return { success: false }.
  - Switched console.log to logger.info when starting to send notifications.
  - Added structured warn log on ledger event failures; normal behavior unchanged when the lock succeeds.

<sup>Written for commit ba92d1179ccb52764ad379ef6002f575fb835b6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



