### PR TITLE
fix(api): handle AMQP connection closing race in NuQ.shutdown

### DIFF
--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -1482,16 +1482,24 @@ class NuQ<JobData = any, JobReturnValue = any> {
         await nl.client.query(`UNLISTEN "${this.queueName}";`);
         await nl.client.end();
       } else {
-        await nl.channel.cancel(nl.queue);
-        await nl.channel.close();
-        await nl.connection.close();
+        try {
+          await nl.channel.cancel(nl.queue);
+          await nl.channel.close();
+          await nl.connection.close();
+        } catch (_) {
+          // Connection may already be closing — safe to ignore during shutdown
+        }
       }
     }
     if (this.sender) {
       const ns = this.sender;
       this.sender = null;
-      await ns.channel.close();
-      await ns.connection.close();
+      try {
+        await ns.channel.close();
+        await ns.connection.close();
+      } catch (_) {
+        // Connection may already be closing — safe to ignore during shutdown
+      }
     }
   }
 }


### PR DESCRIPTION

## Summary by cubic
Prevent unhandled promise rejections in NuQ.shutdown by handling AMQP close races. Close calls are now wrapped in try/catch so IllegalOperationError from already-closing connections is ignored, reducing Sentry noise.

- **Bug Fixes**
  - Guard channel.cancel(), channel.close(), and connection.close() for both listener and sender paths.
  - Affects shutdown only; no change to normal processing.

<sup>Written for commit 998c2ab32517e6eba714e255e0e909068b0d9277. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

