### PR TITLE
fix(api): handle ZodError in v2/scrape and v1/search catch blocks

### DIFF
--- a/apps/api/src/__tests__/snips/v1/lib.ts
+++ b/apps/api/src/__tests__/snips/v1/lib.ts
@@ -410,7 +410,7 @@ export async function extract(
 // Search API
 // =========================================
 
-async function searchRaw(body: SearchRequestInput, identity: Identity) {
+export async function searchRaw(body: SearchRequestInput, identity: Identity) {
   return await request(TEST_API_URL)
     .post("/v1/search")
     .set("Authorization", `Bearer ${identity.apiKey}`)

--- a/apps/api/src/__tests__/snips/v1/search.test.ts
+++ b/apps/api/src/__tests__/snips/v1/search.test.ts
@@ -1,5 +1,5 @@
 import { describeIf, HAS_PROXY, HAS_SEARCH, TEST_PRODUCTION } from "../lib";
-import { search, idmux, Identity } from "./lib";
+import { search, searchRaw, idmux, Identity } from "./lib";
 
 let identity: Identity;
 
@@ -77,6 +77,23 @@ describeIf(TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY)("Search tests", () => {
       );
       expect(res.length).toBeGreaterThan(0);
       expect(res.length).toBeLessThanOrEqual(20);
+    },
+    60000,
+  );
+
+  it.concurrent(
+    "returns 400 for limit over 100",
+    async () => {
+      const raw = await searchRaw(
+        {
+          query: "firecrawl",
+          limit: 200,
+        } as any,
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
     },
     60000,
   );

--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -139,6 +139,22 @@ describe("Scrape tests", () => {
     );
   });
 
+  it.concurrent(
+    "returns 400 for invalid URL",
+    async () => {
+      const raw = await scrapeRaw(
+        {
+          url: "not-a-valid-url",
+        } as any,
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
+    },
+    scrapeTimeout,
+  );
+
   // TEMP: domain broken
   // it.concurrent("works with Punycode domains", async () => {
   //   await scrape({

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -15,6 +15,7 @@ import { logger as _logger } from "../../lib/logger";
 import type { Logger } from "winston";
 import { ScrapeJobTimeoutError } from "../../lib/error";
 import { captureExceptionWithZdrCheck } from "../../services/sentry";
+import { z } from "zod";
 import { executeSearch } from "../../search/execute";
 import {
   DocumentWithCostTracking,
@@ -252,6 +253,15 @@ export async function searchController(
 
     return res.status(200).json(responseData);
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      logger.warn("Invalid request body", { error: error.issues });
+      return res.status(400).json({
+        success: false,
+        error: "Invalid request body",
+        details: error.issues,
+      });
+    }
+
     if (error instanceof ScrapeJobTimeoutError) {
       return res.status(408).json({
         success: false,


### PR DESCRIPTION
These controllers catch all errors and send non-TransportableError ones to Sentry, bypassing the global ZodError handler. Add ZodError checks matching the pattern already used in v2/search.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle ZodError in v1/search so invalid bodies return 400 with details and aren’t reported to Sentry. v2/scrape relies on Sentry filtering instead of a custom catch.

- **Bug Fixes**
  - Add z.ZodError check in v1/search; log a warning and return 400 with { success: false, error: "Invalid request body", details }.
  - Ignore ZodError in Sentry beforeSend; remove custom handling in v2/scrape.
  - Add tests for 400 responses: invalid URL in v2/scrape and limit > 100 in v1/search.

<sup>Written for commit 8296fc911187127ab952ed6fce3846cd334e4b37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

