### PR TITLE
Use saveChanges instead of writeMode for profiles

### DIFF
--- a/apps/api/src/controllers/v2/browser.ts
+++ b/apps/api/src/controllers/v2/browser.ts
@@ -43,7 +43,7 @@ const browserCreateRequestSchema = z.object({
   streamWebView: z.boolean().default(true),
   profile: z.object({
     name: z.string().min(1).max(128),
-    writeMode: z.enum(["readonly", "readwrite"]).default("readwrite"),
+    saveChanges: z.boolean().default(true),
   }).optional(),
 });
 
@@ -260,7 +260,7 @@ export async function browserCreateController(
       .slice(0, 16);
     persistentStorage = {
       uniqueId: `${teamHash}_${profile.name}`,
-      write: profile.writeMode === "readwrite",
+      write: profile.saveChanges !== false,
     };
   }
 
@@ -285,7 +285,7 @@ export async function browserCreateController(
         });
         return res.status(409).json({
           success: false,
-          error: "Another session is currently writing to this profile. Only one writer is allowed at a time. You can still access it with writeMode \"readonly\", or try again later.",
+          error: "Another session is currently writing to this profile. Only one writer is allowed at a time. You can still access it with saveChanges: false, or try again later.",
         });
       }
 

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.14.1",
+  "version": "4.15.0",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/v2/methods/browser.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/browser.ts
@@ -15,7 +15,7 @@ export async function browser(
     streamWebView?: boolean;
     profile?: {
       name: string;
-      writeMode?: "readonly" | "readwrite";
+      saveChanges?: boolean;
     };
   } = {}
 ): Promise<BrowserCreateResponse> {

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.17.2"
+__version__ = "4.18.0"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -993,7 +993,7 @@ class FirecrawlClient:
             activity_ttl: Inactivity TTL in seconds (10-3600)
             stream_web_view: Whether to enable webview streaming
             profile: Profile config with ``name`` (str) and
-                optional ``write_mode`` (``"readonly"`` | ``"readwrite"``, default ``"readwrite"``)
+                optional ``save_changes`` (bool, default ``True``)
 
         Returns:
             BrowserCreateResponse with session id and CDP URL

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -477,7 +477,7 @@ class AsyncFirecrawlClient:
             activity_ttl: Inactivity TTL in seconds (10-3600)
             stream_web_view: Whether to enable webview streaming
             profile: Profile config with ``name`` (str) and
-                optional ``write_mode`` (``"readonly"`` | ``"readwrite"``, default ``"readwrite"``)
+                optional ``save_changes`` (bool, default ``True``)
 
         Returns:
             BrowserCreateResponse with session id and CDP URL

--- a/apps/python-sdk/firecrawl/v2/methods/aio/browser.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/browser.py
@@ -63,7 +63,7 @@ async def browser(
         activity_ttl: Inactivity TTL in seconds (10-3600)
         stream_web_view: Whether to enable webview streaming
         profile: Profile config with ``name`` (str) and
-            optional ``write_mode`` (``"readonly"`` | ``"readwrite"``, default ``"readwrite"``)
+            optional ``save_changes`` (bool, default ``True``)
 
     Returns:
         BrowserCreateResponse with session id and CDP URL
@@ -78,7 +78,7 @@ async def browser(
     if profile is not None:
         body["profile"] = {
             "name": profile["name"],
-            "writeMode": profile.get("write_mode", "readwrite"),
+            "saveChanges": profile.get("save_changes", True),
         }
 
     resp = await client.post("/v2/browser", body)

--- a/apps/python-sdk/firecrawl/v2/methods/browser.py
+++ b/apps/python-sdk/firecrawl/v2/methods/browser.py
@@ -64,7 +64,7 @@ def browser(
         activity_ttl: Inactivity TTL in seconds (10-3600)
         stream_web_view: Whether to enable webview streaming
         profile: Profile config with ``name`` (str) and
-            optional ``write_mode`` (``"readonly"`` | ``"readwrite"``, default ``"readwrite"``)
+            optional ``save_changes`` (bool, default ``True``)
 
     Returns:
         BrowserCreateResponse with session id and CDP URL
@@ -79,7 +79,7 @@ def browser(
     if profile is not None:
         body["profile"] = {
             "name": profile["name"],
-            "writeMode": profile.get("write_mode", "readwrite"),
+            "saveChanges": profile.get("save_changes", True),
         }
 
     resp = client.post("/v2/browser", body)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced profile.writeMode with profile.saveChanges across the v2 browser endpoint and SDKs. This keeps the same default behavior and makes the API simpler and clearer.

- **Migration**
  - Use profile.saveChanges (boolean) instead of profile.writeMode.
  - Mapping: "readwrite" -> true, "readonly" -> false.
  - JS/TS: profile.saveChanges; Python: profile["save_changes"].
  - Default remains true; set false for read-only. Error messages now reference saveChanges: false.

- **Dependencies**
  - JS SDK: 4.15.0
  - Python SDK: 4.18.0

<sup>Written for commit 802b14f82c36be768084cec6a11330f8b0be948a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

