### PR TITLE
fix(pdf): log non-PDF requests entering the PDF engine

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -126,7 +126,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     }
 
     if (!isPdfBuffer(header.subarray(0, headerBytesRead))) {
-      if (meta.pdfPrefetch !== undefined) {
+      if (meta.pdfPrefetch !== undefined || meta.featureFlags.has("pdf")) {
         meta.logger.warn(
           "Non-PDF content received in PDF engine (file path)",
           {


### PR DESCRIPTION
## Summary
- Add warning logs when the PDF engine receives content that fails the `%PDF` magic bytes check
- Logs URL, Content-Type, status code, prefetch status, and feature flag context
- Covers both code paths: in-memory buffer (`fetchFileToBuffer`) and temp file (`downloadFile`)

Follow-up to #2915.

## Test plan
- [ ] Deploy and monitor logs for `Non-PDF content received in PDF engine` warnings
- [ ] Verify logged fields are useful for diagnosing mislabeled or anti-bot responses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add warning logs only when the PDF engine receives non-PDF content from a prefetched file or when the PDF feature flag is enabled. Logs include the URL, Content-Type, status code, and PDF feature flag context to help diagnose misrouted or anti-bot responses.

<sup>Written for commit c71f038945e22c91ff26763fea141682c815de2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

