### PR TITLE
fix(api): await logRequest in scrape controllers to prevent FK violation

### DIFF
--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -67,7 +67,7 @@ export async function scrapeController(
     account: req.account,
   });
 
-  logRequest({
+  await logRequest({
     id: jobId,
     kind: "scrape",
     api_version: "v1",
@@ -77,9 +77,7 @@ export async function scrapeController(
     target_hint: req.body.url,
     zeroDataRetention: zeroDataRetention || false,
     api_key_id: req.acuc?.api_key_id ?? null,
-  }).catch(err =>
-    logger.warn("Background request log failed", { error: err, jobId }),
-  );
+  });
 
   const origin = req.body.origin;
   const timeout = req.body.timeout;

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -126,7 +126,7 @@ export async function scrapeController(
       });
 
       if (!agentRequestId) {
-        logRequest({
+        await logRequest({
           id: jobId,
           kind: "scrape",
           api_version: "v2",
@@ -136,9 +136,7 @@ export async function scrapeController(
           target_hint: req.body.url,
           zeroDataRetention: zeroDataRetention || false,
           api_key_id: req.acuc?.api_key_id ?? null,
-        }).catch(err =>
-          logger.warn("Background request log failed", { error: err, jobId }),
-        );
+        });
       }
 
       setSpanAttributes(span, {


### PR DESCRIPTION
## Summary
- `logRequest()` was fire-and-forget (not awaited) in `v1/scrape` and `v2/scrape` controllers
- The worker's `logScrape()` inserts into `scrapes` with a foreign key to `requests`
- When the worker completes before `logRequest()` finishes, the FK constraint fails: `scrapes_request_id_fkey`
- This was causing **API-NM** (2k events, escalating) and **API-EG** (144k events, ongoing)
- All other controllers (crawl, extract, batch-scrape, etc.) already `await logRequest()` correctly
- Fix: add `await` to both scrape controllers

## Test plan
- [ ] Monitor Sentry for API-NM and API-EG — events should stop after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Awaited logRequest in v1/v2 scrape controllers to eliminate a race that caused foreign key violations when the worker logged scrapes. This stops the API-NM and API-EG error floods and brings scrape controllers in line with others.

- **Bug Fixes**
  - Added await to logRequest in v1 and v2 scrape controllers so requests rows exist before scrapes are inserted.
  - Removed fire-and-forget + catch/warn pattern; use normal error handling.

<sup>Written for commit 68747ec4b1a4111bc047e295d503b431754b6bf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

