### PR TITLE
fix(playwright): honour caller-supplied user-agent header in scrape requests

### DIFF
--- a/apps/playwright-service-ts/__tests__/user-agent.test.ts
+++ b/apps/playwright-service-ts/__tests__/user-agent.test.ts
@@ -1,0 +1,84 @@
+import express from "express";
+import type { Server } from "http";
+
+/**
+ * End-to-end test that verifies the scrape endpoint honours a caller-supplied
+ * user-agent header instead of silently replacing it with a random one.
+ *
+ * The test starts two HTTP servers:
+ *   1. A tiny "echo" server that records the User-Agent it receives.
+ *   2. The playwright-service itself (imported from ../api.ts).
+ *
+ * We then POST to /scrape with headers.user-agent set and assert the echo
+ * server saw the exact value we asked for.
+ */
+
+let echoServer: Server;
+let echoPort: number;
+let receivedUserAgent: string | undefined;
+
+// We need the playwright service running — import triggers listen().
+// Override PORT so it picks a free one.
+const PW_PORT = 13377;
+process.env.PORT = String(PW_PORT);
+
+beforeAll(async () => {
+  // 1. Start echo server
+  const echoApp = express();
+  await new Promise<void>((resolve) => {
+    echoServer = echoApp.get("/ua-echo", (req, res) => {
+      receivedUserAgent = req.headers["user-agent"];
+      res.send("ok");
+    }).listen(0, () => {
+      echoPort = (echoServer.address() as any).port;
+      resolve();
+    });
+  });
+
+  // 2. Start playwright service (gives it time to launch browser)
+  await import("../api");
+  // Wait for browser init
+  await new Promise((r) => setTimeout(r, 3000));
+}, 30_000);
+
+afterAll(async () => {
+  echoServer?.close();
+});
+
+it("uses custom user-agent from headers when provided", async () => {
+  const customUA = "MyCustomAgent/1.0 (firecrawl-test)";
+  receivedUserAgent = undefined;
+
+  const res = await fetch(`http://localhost:${PW_PORT}/scrape`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      url: `http://localhost:${echoPort}/ua-echo`,
+      headers: { "user-agent": customUA },
+      timeout: 10000,
+    }),
+  });
+
+  expect(res.status).toBe(200);
+  expect(receivedUserAgent).toBe(customUA);
+}, 20_000);
+
+it("falls back to random user-agent when none supplied", async () => {
+  receivedUserAgent = undefined;
+
+  const res = await fetch(`http://localhost:${PW_PORT}/scrape`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      url: `http://localhost:${echoPort}/ua-echo`,
+      timeout: 10000,
+    }),
+  });
+
+  expect(res.status).toBe(200);
+  // Should be a real browser-like UA, not empty or undefined
+  expect(receivedUserAgent).toBeDefined();
+  expect(receivedUserAgent!.length).toBeGreaterThan(10);
+  // Should NOT be our custom one
+  expect(receivedUserAgent).not.toBe("MyCustomAgent/1.0 (firecrawl-test)");
+}, 20_000);

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,12 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, headers?: { [key: string]: string }) => {
+  // If the caller supplied a user-agent header, honour it instead of a random one.
+  const userAgentHeader = headers
+    ? Object.entries(headers).find(([k]) => k.toLowerCase() === 'user-agent')?.[1]
+    : undefined;
+  const userAgent = userAgentHeader ?? new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,7 +256,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
     if (headers) {

--- a/apps/playwright-service-ts/jest.config.js
+++ b/apps/playwright-service-ts/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/__tests__/**/*.test.ts"],
+};

--- a/apps/playwright-service-ts/package.json
+++ b/apps/playwright-service-ts/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node dist/api.js",
     "build": "tsc",
-    "dev": "tsx api.ts"
+    "dev": "tsx api.ts",
+    "test": "jest"
   },
   "keywords": [],
   "author": "Jeff Pereira",
@@ -22,6 +23,9 @@
     "@types/node": "^22.15.30",
     "@types/user-agents": "^1.0.4",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.4",
+    "@types/jest": "^29.5.14"
   }
 }


### PR DESCRIPTION
## Summary
- Playwright's `setExtraHTTPHeaders` cannot override the `userAgent` set at context level — it's silently ignored
- When callers pass a custom `user-agent` in scrape request headers, the playwright service currently replaces it with a random UA
- This fix extracts the user-agent from request headers (case-insensitive match) and passes it to `createContext()` so it's set at the browser context level where Playwright actually respects it
- Remaining headers are still applied via `setExtraHTTPHeaders` as before
- Falls back to the existing random UA behavior when no user-agent header is provided

## Changes
- `createContext()` now accepts an optional `customUserAgent` parameter
- Case-insensitive extraction of `user-agent` key from headers before context creation
- Added 2 tests covering custom UA passthrough and default random UA fallback

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the caller’s User-Agent in scrape requests by setting it at the Playwright context level. Prevents Playwright from replacing a supplied UA with a random one.

- **Bug Fixes**
  - Extract user-agent from request headers (case-insensitive) and set it when creating the browser context; fallback to a random UA when none is provided.
  - Keep applying remaining headers via setExtraHTTPHeaders.
  - Added end-to-end tests for custom UA passthrough and fallback behavior.

- **Dependencies**
  - Added Jest and ts-jest with basic config and a test script.

<sup>Written for commit 63c12b7438d296b36e8bf71952433291d2c62f0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

