### PR TITLE
chore: update pdf-inspector to latest commit

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "0aa4e0a" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "8f652b8" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the pdf-inspector dependency in the native API crate to the latest commit. This pulls in upstream fixes and keeps PDF parsing current.

<sup>Written for commit aa9664c2e8eabc66cdf690fb55de9a13b18c653a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

