### PR TITLE
perf(pdf): check MU cache before Rust processing

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -28,6 +28,10 @@ import { scrapePDFWithParsePDF } from "./pdfParse";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
 import { comparePdfOutputs } from "./shadowComparison";
+import {
+  getPdfResultFromCache,
+  savePdfResultToCache,
+} from "../../../../lib/gcs-pdf-cache";
 
 /** Check if the PDF is eligible for Rust extraction, returning a rejection reason or null. */
 function getIneligibleReason(
@@ -135,6 +139,34 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         }
       } else {
         throw new PDFPrefetchFailed();
+      }
+    }
+
+    // Read the file to base64 once for cache lookup and MU fallback.
+    const base64Content = (await readFile(tempFilePath)).toString("base64");
+
+    // Check MU cache first, before any expensive processing.
+    if (!maxPages) {
+      try {
+        const cachedResult = await getPdfResultFromCache(base64Content);
+        if (cachedResult) {
+          meta.logger.info("Using cached MU result for PDF", {
+            tempFilePath,
+            url: meta.rewrittenUrl ?? meta.url,
+          });
+          return {
+            url: response.url ?? meta.rewrittenUrl ?? meta.url,
+            statusCode: response.status,
+            html: cachedResult.html,
+            markdown: cachedResult.markdown,
+            proxyUsed: "basic",
+          };
+        }
+      } catch (error) {
+        meta.logger.warn("Error checking PDF cache, proceeding normally", {
+          error,
+          tempFilePath,
+        });
       }
     }
 
@@ -276,8 +308,6 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     // Skipped only when Rust extraction is enabled AND mode is "fast".
     const skipOCR = rustEnabled && mode === "fast";
     if (!result && !skipOCR) {
-      const base64Content = (await readFile(tempFilePath)).toString("base64");
-
       if (
         base64Content.length < MAX_FILE_SIZE &&
         config.RUNPOD_MU_API_KEY &&
@@ -307,10 +337,16 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
               success: true,
             });
 
-          if (rustMarkdownForShadow && result?.markdown && config.PDF_SHADOW_COMPARISON_ENABLE) {
+          if (
+            rustMarkdownForShadow &&
+            result?.markdown &&
+            config.PDF_SHADOW_COMPARISON_ENABLE
+          ) {
             const shadowRust = rustMarkdownForShadow;
             const shadowMu = result.markdown;
-            const shadowLogger = meta.logger.child({ method: "scrapePDF/shadowComparison" });
+            const shadowLogger = meta.logger.child({
+              method: "scrapePDF/shadowComparison",
+            });
             const isZdr = !!meta.internalOptions.zeroDataRetention;
 
             (async () => {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
@@ -4,10 +4,7 @@ import * as marked from "marked";
 import { robustFetch } from "../../lib/fetch";
 import { z } from "zod";
 import path from "node:path";
-import {
-  getPdfResultFromCache,
-  savePdfResultToCache,
-} from "../../../../lib/gcs-pdf-cache";
+import { savePdfResultToCache } from "../../../../lib/gcs-pdf-cache";
 import type { PDFProcessorResult } from "./types";
 
 export async function scrapePDFWithRunPodMU(
@@ -20,23 +17,6 @@ export async function scrapePDFWithRunPodMU(
   meta.logger.debug("Processing PDF document with RunPod MU", {
     tempFilePath,
   });
-
-  if (!maxPages) {
-    try {
-      const cachedResult = await getPdfResultFromCache(base64Content);
-      if (cachedResult) {
-        meta.logger.info("Using cached RunPod MU result for PDF", {
-          tempFilePath,
-        });
-        return cachedResult;
-      }
-    } catch (error) {
-      meta.logger.warn("Error checking PDF cache, proceeding with RunPod MU", {
-        error,
-        tempFilePath,
-      });
-    }
-  }
 
   meta.abort.throwIfAborted();
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Check the RunPod MU PDF cache before any Rust/Parse/OCR steps to skip work and reduce latency and cost. The cache lookup now happens once at the start, and MU runs only if needed.

- **Performance**
  - Move MU cache check to pdf/index.ts before expensive processing.
  - Read base64 once and reuse for cache and MU.
  - Remove duplicate cache lookup from runpodMU.ts.
  - Keep saving MU results to cache and add lightweight logging.
  - Only check cache when maxPages is not set.

<sup>Written for commit 298a736968ec6adfc7d9e787a4ba6deaca2d7bf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

