### PR TITLE
chore(pdf): update pdf-inspector

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "8f652b8" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "2b5fcd7" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
## Summary

Updates `pdf-inspector` from `8f652b8` to `2b5fcd7` (4 commits).

### Changes in pdf-inspector

- **feat: detect tables from PDF line path operators (m/l/S)** — captures `m`/`l`/`h`/`S` path operators to detect ruled-line tables (IRS forms, government PDFs)
- **feat: enhance header/footer stripping with Y-band coalescing and page number normalization** — improved repeated content removal
- **fix: increase edge line count to catch form column headers as repeated content**
- **feat: strip repeated headers/footers from markdown output**

Verified against 168 PDF test suite (0 regressions).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update pdf-inspector to 2b5fcd7 to improve table detection and strip repeated headers/footers for cleaner Markdown output. Verified against 168 PDFs with no regressions.

- **Dependencies**
  - Bump pdf-inspector from 8f652b8 to 2b5fcd7.
  - Improves parsing: detects ruled-line tables via path operators and removes repeated headers/footers (Y-band coalescing, page number normalization, higher edge line count, Markdown cleanup).

<sup>Written for commit 0e3afc24b2d2955475aaed4be7ef127bde919c3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

