### PR TITLE
fix(api): skip shadow comparison for scanned/image-based PDFs

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -142,6 +142,10 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     let effectivePageCount: number = 0;
     let metadataTitle: string | undefined;
     let rustMarkdownForShadow: string | undefined;
+    let shadowPdfType: string | undefined;
+    let shadowConfidence: number | undefined;
+    let shadowIsComplex: boolean | undefined;
+    let shadowIneligibleReason: string | null | undefined;
 
     const rustEnabled = !!config.PDF_RUST_EXTRACT_ENABLE;
     const logger = meta.logger.child({ method: "scrapePDF/processPdf" });
@@ -230,6 +234,12 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           pdfResult.pdfType !== "ImageBased";
 
         rustMarkdownForShadow = shadowEligible ? pdfResult.markdown : undefined;
+        if (shadowEligible) {
+          shadowPdfType = pdfResult.pdfType;
+          shadowConfidence = pdfResult.confidence;
+          shadowIsComplex = pdfResult.isComplex;
+          shadowIneligibleReason = ineligibleReason;
+        }
 
         // In fast mode, if the PDF requires OCR, fail immediately with a
         // clear error instead of returning empty content.
@@ -333,10 +343,10 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
                   scrapeId: meta.id,
                   url: isZdr ? undefined : (meta.rewrittenUrl ?? meta.url),
                   pageCount: effectivePageCount,
-                  pdfType: pdfResult.pdfType,
-                  confidence: pdfResult.confidence,
-                  isComplex: pdfResult.isComplex,
-                  ineligibleReason,
+                  pdfType: shadowPdfType,
+                  confidence: shadowConfidence,
+                  isComplex: shadowIsComplex,
+                  ineligibleReason: shadowIneligibleReason,
                   ...metrics.overall,
                 });
               } catch (error) {


### PR DESCRIPTION
Filter out scanned and image-based PDFs from shadow comparison and add pdfType metadata to logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip shadow comparison for scanned and image-based PDFs to reduce noisy metrics, and enrich shadow comparison logs with pdfType, confidence, isComplex, and ineligibleReason. Also capture these fields before MU processing so logs are accurate.

- **Bug Fixes**
  - Only run shadow comparison when Rust produced markdown, the PDF isn’t Scanned/ImageBased, and the feature flag is enabled.
  - Capture pdfResult fields before the MU scope to ensure they’re available for shadow comparison logging.

- **New Features**
  - Log pdfType, confidence, isComplex, and ineligibleReason with shadow comparison metrics.

<sup>Written for commit 64656377c5081c30f829c58ded57ab7ad15b9c00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

