### PR TITLE
fix(api): skip shadow comparison for non-TextBased PDFs

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -224,14 +224,13 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         });
 
         // Only shadow-compare when Rust had a real chance at extraction.
-        // Scanned/ImageBased PDFs are expected to fail — comparing them
-        // just adds noise to the metrics.
+        // Scanned/ImageBased/Mixed PDFs are expected to produce near-zero
+        // Rust output — comparing them just adds noise to the metrics.
         const shadowEligible =
           !eligible &&
           pdfResult.markdown &&
           config.PDF_SHADOW_COMPARISON_ENABLE &&
-          pdfResult.pdfType !== "Scanned" &&
-          pdfResult.pdfType !== "ImageBased";
+          pdfResult.pdfType === "TextBased";
 
         rustMarkdownForShadow = shadowEligible ? pdfResult.markdown : undefined;
         if (shadowEligible) {


### PR DESCRIPTION
Only shadow-compare TextBased PDFs — Mixed/Scanned/ImageBased produce near-zero Rust output so comparisons are just noise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip shadow comparison unless the PDF is TextBased. This prevents comparing Mixed, Scanned, or ImageBased PDFs that yield near-zero Rust output, reducing noise and improving metrics accuracy.

<sup>Written for commit 58520533fefb3389ec115906e2b6e434a2c28ecb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

