### PR TITLE
chore: update pdf-inspector to 7d73c6a

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "2b5fcd7" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "7d73c6a" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
## Summary
- Update pdf-inspector from `2b5fcd7` to `7d73c6a`

### Changes in pdf-inspector
- `7d73c6a` refactor: add PageExtraction type alias for extraction return tuples
- `f7afc0c` feat: improve rect-based table detection for wide statistical tables

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update pdf-inspector to 7d73c6a to improve rect-based table detection for wide statistical tables and adopt the new PageExtraction type alias.

- **Dependencies**
  - Bump pdf-inspector from 2b5fcd7 to 7d73c6a in apps/api/native/Cargo.toml.

<sup>Written for commit 5ee843e525236c942bf659f7f4ef52a25da556b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

