### PR TITLE
fix(pdf): update pdf-inspector to detect side-by-side tables

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "d5e03b8" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "0dba1e6" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
Updates pdf-inspector to 0dba1e6 which adds X-gap pre-splitting to detect side-by-side table layouts on the same page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated pdf-inspector to detect side-by-side tables on the same page, improving table extraction accuracy with X-gap pre-splitting.

- **Dependencies**
  - pdf-inspector: d5e03b8 -> 0dba1e6 (adds X-gap pre-splitting for side-by-side tables)

<sup>Written for commit 5430a23d930c5169f7c565542f3885cbdd5d4099. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

