### PR TITLE
fix(go): Update Go Deps

### DIFF
--- a/apps/api/sharedLibs/go-html-to-md/go.mod
+++ b/apps/api/sharedLibs/go-html-to-md/go.mod
@@ -4,15 +4,13 @@ go 1.23.0
 
 toolchain go1.24.0
 
-require (
-	github.com/PuerkitoBio/goquery v1.10.3
-	github.com/firecrawl/html-to-markdown v0.0.0-20260305014655-0ec744e89d3c
-	golang.org/x/net v0.41.0
-)
+require github.com/firecrawl/html-to-markdown v0.0.0-20260305014655-0ec744e89d3c
 
 require (
+	github.com/PuerkitoBio/goquery v1.10.3 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
+	golang.org/x/net v0.41.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/apps/api/sharedLibs/go-html-to-md/go.sum
+++ b/apps/api/sharedLibs/go-html-to-md/go.sum
@@ -3,10 +3,8 @@ github.com/PuerkitoBio/goquery v1.10.3/go.mod h1:tMUX0zDMHXYlAQk6p35XxQMqMweEKB7
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/firecrawl/html-to-markdown v0.0.0-20260203173849-25e9840a0878 h1:PsxFhBLrH0KKkYz5FXzUZefuxUQoodu5ZgDyAaDA6p8=
-github.com/firecrawl/html-to-markdown v0.0.0-20260203173849-25e9840a0878/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
-github.com/firecrawl/html-to-markdown v0.0.0-20260305014106-d5b7c1a14bb9 h1:+riTLXKteNT9WJR9sJKh3EL3BwroJxdVAEEl0JZzUTY=
-github.com/firecrawl/html-to-markdown v0.0.0-20260305014106-d5b7c1a14bb9/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
+github.com/firecrawl/html-to-markdown v0.0.0-20260305014655-0ec744e89d3c h1:EadFGDVcmkhrWfld8MVrnWFIoimCpRd9eUX/AwCiMRs=
+github.com/firecrawl/html-to-markdown v0.0.0-20260305014655-0ec744e89d3c/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated go-html-to-md dependencies: bumped html-to-markdown and marked indirect deps to keep go.mod tidy and fix go.sum.

- **Dependencies**
  - Updated github.com/firecrawl/html-to-markdown to v0.0.0-20260305014655-0ec744e89d3c.
  - Marked github.com/PuerkitoBio/goquery and golang.org/x/net as indirect; refreshed go.sum.

<sup>Written for commit 26c6da702ebde5a4bc4736aa573e8440dd705f7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

