### PR TITLE
chore(pdf): Update pdf-inspector to b126d4b

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "0dba1e6" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "b126d4b" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
Remove white text color filtering, extract all visible text. Update lopdf to latest upstream. Improve side-by-side table split detection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update pdf-inspector to b126d4b to improve PDF text extraction and side-by-side table split detection.

- **Dependencies**
  - Bump pdf-inspector to b126d4b in native API Cargo.toml.
  - Pulls upstream changes: remove white text color filtering, extract all visible text, update lopdf, improve table split detection.

<sup>Written for commit 508062f9fa70e3601457d5f55c7617843357d0a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

