### PR TITLE
chore(pdf): Update pdf-inspector to c54e29f

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "b126d4b" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "c54e29f" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
Detect image-dominated PDFs with minimal text as needing OCR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update pdf-inspector to include detection for image-heavy PDFs with little text and mark them for OCR. Improves handling of scanned documents by routing them to OCR when needed.

<sup>Written for commit b782ed3021cc7f3088d67359da2baaf007e3a4d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

