### PR TITLE
chore(pdf): Update pdf-inspector to 5ab92e0

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "c54e29f" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "5ab92e0" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
Eliminate double-pass over content streams in detector. Detect tables from clip-path rects via merged-cluster fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update pdf-inspector to 5ab92e0 to speed up PDF parsing and improve table detection. The detector now avoids a double pass over content streams and uses clip-path rects with a merged-cluster fallback to identify tables.

- **Dependencies**
  - pdf-inspector: c54e29f → 5ab92e0

<sup>Written for commit a37981f1fb1eccc03cefa864176589543edd3417. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

