### PR TITLE
Fix user-agent header not being used by playwright

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, userAgentOverride?: string) => {
+  const userAgent = userAgentOverride || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -247,12 +247,14 @@ app.post('/scrape', async (req: Request, res: Response) => {
   }
 
   await pageSemaphore.acquire();
-  
+
   let requestContext: BrowserContext | null = null;
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    // Extract user-agent from headers if provided
+    const userAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+    requestContext = await createContext(skip_tls_verification, userAgent);
     page = await requestContext.newPage();
 
     if (headers) {


### PR DESCRIPTION
Fixes #2802. The user-agent from the scrape request headers was being ignored because Playwright does not allow overriding user-agent via setExtraHTTPHeaders when it is already set on the browser context. This fix passes the user-agent from headers directly to createContext so it is used when creating the browser context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Playwright uses the user-agent from scrape request headers by passing it into the browser context at creation time. This fixes cases where setExtraHTTPHeaders could not override the user-agent once the context was created.

- **Bug Fixes**
  - createContext now accepts an optional userAgentOverride and uses it, otherwise falls back to a generated value.
  - /scrape extracts the 'user-agent' header (case-insensitive) and passes it to createContext so the context’s UA matches the request.

<sup>Written for commit af00675fee841b219896888e02c465f5304abf97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

