### PR TITLE
fix: add webhook support to startExtract/extract methods

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
@@ -1,4 +1,4 @@
-import { type ExtractResponse, type ScrapeOptions, type AgentOptions } from "../types";
+import { type ExtractResponse, type ScrapeOptions, type AgentOptions, type WebhookConfig } from "../types";
 import { HttpClient } from "../utils/httpClient";
 import { ensureValidScrapeOptions } from "../utils/validation";
 import { normalizeAxiosError, throwForBadResponse } from "../utils/errorHandler";
@@ -18,6 +18,7 @@ function prepareExtractPayload(args: {
   integration?: string;
   origin?: string;
   agent?: AgentOptions;
+  webhook?: string | WebhookConfig | null;
 }): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (args.urls) body.urls = args.urls;
@@ -33,6 +34,7 @@ function prepareExtractPayload(args: {
   if (args.integration && args.integration.trim()) body.integration = args.integration.trim();
   if (args.origin) body.origin = args.origin;
   if (args.agent) body.agent = args.agent;
+  if (args.webhook != null) body.webhook = args.webhook;
   if (args.scrapeOptions) {
     ensureValidScrapeOptions(args.scrapeOptions);
     body.scrapeOptions = args.scrapeOptions;
@@ -103,4 +105,3 @@ export async function extract(
   if (!jobId) return started;
   return waitExtract(http, jobId, args.pollInterval ?? 2, args.timeout);
 }
-


### PR DESCRIPTION
## Summary

- Adds `webhook?: string | WebhookConfig | null` to `prepareExtractPayload` args in the JS SDK
- Forwards webhook to the API payload with `if (args.webhook != null) body.webhook = args.webhook`
- Consistent with how `crawl` and `batchScrapeUrls` already handle webhooks

Fixes #2582

## Details

The `startExtract` and `extract` methods were missing webhook support in their TypeScript type definitions, even though the Firecrawl API accepts webhook configuration for extract jobs. This caused TypeScript errors when users tried to pass `webhook` to `startExtract()`.

Changes to `apps/js-sdk/firecrawl/src/v2/methods/extract.ts`:
1. Import `WebhookConfig` from types
2. Add `webhook?: string | WebhookConfig | null` to `prepareExtractPayload` args
3. Add `if (args.webhook != null) body.webhook = args.webhook` to forward it to the payload

No changes needed in `client.ts` — it derives its types from `Parameters<typeof startExtract>`, so it automatically picks up the new parameter.

## Test plan

- [x] Verified `WebhookConfig` is already exported from `types.ts` (line 164)
- [x] Verified `crawl.ts` uses the same pattern: `if (request.webhook != null) data.webhook = request.webhook`
- [x] The `client.ts` wrapper uses `Parameters<typeof startExtract>[1]` so types propagate automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add webhook support to startExtract and extract in the JS SDK by typing and forwarding webhook to the API. This removes TypeScript errors and enables webhook callbacks for extract jobs, consistent with crawl and batchScrapeUrls.

- **Bug Fixes**
  - Added webhook?: string | WebhookConfig | null to prepareExtractPayload and forwarded it as body.webhook when provided.
  - Client types pick up the new param via Parameters<typeof startExtract>, so no wrapper changes needed.

<sup>Written for commit ff6ade79f599f519d0677c9fd0d68be7aa41802b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

