### PR TITLE
fix: respect user-agent header in playwright scrape requests

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -100,7 +100,7 @@ const initializeBrowser = async () => {
 };
 
 const createContext = async (skipTlsVerification: boolean = false, userAgentOverride?: string) => {
-  const userAgent = userAgentOverride || new UserAgent().toString();
+  const userAgent = userAgentOverride ?? new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {


### PR DESCRIPTION
## Summary

Fixes #2802

When scraping with a custom `user-agent` in the `headers` object, Playwright ignores it because `setExtraHTTPHeaders` does not override the context-level user agent already set by the `user-agents` package.

**Root cause:** `createContext()` always generates a random user agent via `new UserAgent().toString()` (line 103). The caller then passes the user's headers (including `user-agent`) to `page.setExtraHTTPHeaders()`, but Playwright's [documented behavior](https://playwright.dev/docs/api/class-page#page-set-extra-http-headers) is that `user-agent` in extra headers is ignored when a context-level UA is already set.

**Fix:**
1. Added an optional `userAgentOverride` parameter to `createContext()` — when provided, it's used instead of the random UA
2. At the `/scrape` call site, extract `user-agent` from the headers map (case-insensitive lookup), pass it to `createContext()`, and remove it from extra headers to avoid a redundant ignored entry

```typescript
// Before: user-agent in headers is silently ignored
requestContext = await createContext(skip_tls_verification);
page.setExtraHTTPHeaders(headers); // user-agent ignored here

// After: user-agent extracted and used at context level
const uaKey = Object.keys(headers).find(k => k.toLowerCase() === 'user-agent');
requestContext = await createContext(skip_tls_verification, headers[uaKey]);
page.setExtraHTTPHeaders(remainingHeaders);
```

## Test plan
- [ ] Deploy self-hosted, send scrape request with custom `user-agent` header
- [ ] Verify the target endpoint receives the specified user agent
- [ ] Verify requests without a custom user-agent still get a random UA from the `user-agents` package
- [ ] Verify other custom headers (e.g. `Authorization`) still work alongside a custom user-agent

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the `user-agent` header in Playwright scrape requests by setting it at the browser context level. Target sites now see the intended user agent; behavior is unchanged if none is provided.

- **Bug Fixes**
  - Added an optional userAgentOverride to createContext to set the context-level user agent.
  - Extract the `user-agent` header (case-insensitive), pass it to createContext, and remove it from extra headers.
  - Fallback to a random UA from `user-agents` only when the override is null/undefined; other headers continue to work.

<sup>Written for commit 1f5e8da13d0bbadced9646b7d8118794ee3f2eb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

