### PR TITLE
fix(api): use Chat Completions for DeepInfra OpenAI-compatible base URL

### DIFF
--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -21,6 +21,10 @@ type Provider =
   | "vertex";
 const defaultProvider: Provider = config.OLLAMA_BASE_URL ? "ollama" : "openai";
 
+function isDeepInfraOpenAIBaseURL(): boolean {
+  return (config.OPENAI_BASE_URL || "").toLowerCase().includes("deepinfra.com");
+}
+
 const providerList: Record<Provider, any> = {
   openai: createOpenAI({
     apiKey: config.OPENAI_API_KEY,
@@ -59,7 +63,10 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
   }
   const modelName = config.MODEL_NAME || name;
   // o3-mini returns empty text via the Responses API — force Chat Completions
-  if (provider === "openai" && modelName.startsWith("o3-mini")) {
+  if (
+    provider === "openai" &&
+    (modelName.startsWith("o3-mini") || isDeepInfraOpenAIBaseURL())
+  ) {
     return providerList.openai.chat(modelName);
   }
   return providerList[provider](modelName);


### PR DESCRIPTION
## Problem

When using Firecrawl Extract with an OpenAI-compatible provider via `OPENAI_BASE_URL=...deepinfra...`, the current model path may use the Responses endpoint, which is not supported by this base URL in our tested setup.
This causes extract failures even with valid API keys/models.

## Root Cause

`apps/api/src/lib/generic-ai.ts` only forced Chat Completions for `o3-mini`.
For DeepInfra OpenAI-compatible URLs, the code could still choose the Responses path.

## Fix

- Added a DeepInfra base URL detector in `generic-ai.ts`
- Forced `.chat(modelName)` for OpenAI provider when:
  - model starts with `o3-mini`, or
  - `OPENAI_BASE_URL` contains `deepinfra.com`

## Why this is safe

- Scope is minimal (single file, conditional routing only)
- Existing behavior for other providers/base URLs is unchanged
- Keeps prior `o3-mini` workaround intact

## Validation

- Confirmed request path switches to `/chat/completions` for DeepInfra base URL
- Confirmed previous `/responses` incompatibility no longer occurs for this route
- Remaining failures observed were provider-side capacity/rate limits, not endpoint mismatch

## Files changed

- `apps/api/src/lib/generic-ai.ts`

---

## Resumo em Português (complementar)

Este PR corrige a rota de chamada de LLM quando o Firecrawl usa provedor OpenAI-compatível da DeepInfra.
Antes, em alguns casos a API tentava usar o endpoint `responses`, que não estava disponível nesse cenário.
Agora, quando `OPENAI_BASE_URL` contém `deepinfra.com`, o código força o uso de `chat.completions`, mantendo o comportamento existente para `o3-mini` e sem alterar os demais provedores.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force Chat Completions when `OPENAI_BASE_URL` points to DeepInfra to stop extract failures caused by using the Responses endpoint.

- **Bug Fixes**
  - Detects `deepinfra.com` in `OPENAI_BASE_URL` and routes OpenAI calls to `.chat(model)`.
  - Keeps existing `o3-mini` Chat Completions fallback.
  - Verified requests use `/chat/completions` and no longer hit the unsupported `/responses` path.

Files updated: `apps/api/src/lib/generic-ai.ts`

<sup>Written for commit e892813c422f09f9f84fbea19a61df9f4e3ea8ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

