### PR TITLE
fix: strip userinfo from discovered URLs to prevent duplicate crawling

### DIFF
--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -297,8 +297,24 @@ export async function getCrawlQualifiedJobCount(id: string): Promise<number> {
   return await redisEvictConnection.scard("crawl:" + id + ":jobs_qualified");
 }
 
+/**
+ * Strips userinfo (username:password@) from a URL.
+ * This prevents malformed mailto links (e.g., https://user@domain.com)
+ * and HTTP basic auth URLs (e.g., https://user:pass@domain.com)
+ * from being treated as distinct URLs, which causes duplicate crawling.
+ * Modern browsers strip userinfo per the URL spec.
+ */
+export function stripURLUserinfo(url: URL): URL {
+  if (url.username || url.password) {
+    url.username = "";
+    url.password = "";
+  }
+  return url;
+}
+
 export function normalizeURL(url: string, sc: StoredCrawl): string {
   const urlO = new URL(url);
+  stripURLUserinfo(urlO);
   if (sc && sc.crawlerOptions && sc.crawlerOptions.ignoreQueryParameters) {
     urlO.search = "";
   }
@@ -328,6 +344,7 @@ export function normalizeURL(url: string, sc: StoredCrawl): string {
 // - mogery
 export function generateURLPermutations(url: string | URL): URL[] {
   const urlO = new URL(url);
+  stripURLUserinfo(urlO);
 
   // Construct two versions, one with www., one without
   const urlWithWWW = new URL(urlO);

--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -16,6 +16,7 @@ import {
 import { ScrapeJobTimeoutError } from "../../lib/error";
 import { ScrapeOptions } from "../../controllers/v2/types";
 import { filterLinks, filterUrl } from "@mendable/firecrawl-rs";
+import { stripURLUserinfo } from "../../lib/crawl-redis";
 
 export const SITEMAP_LIMIT = 25;
 const SITEMAP_MAX_AGE = 7 * 24 * 60 * 60 * 1000;
@@ -708,8 +709,9 @@ export class WebCrawler {
   }
 
   public async extractLinksFromHTML(html: string, url: string) {
+    let links: string[];
     try {
-      return [
+      links = [
         ...new Set(
           (await this.extractLinksFromHTMLRust(html, url))
             .map(x => {
@@ -731,9 +733,24 @@ export class WebCrawler {
           method: "extractMetadata",
         },
       );
+      links = await this.extractLinksFromHTMLCheerio(html, url);
     }
 
-    return await this.extractLinksFromHTMLCheerio(html, url);
+    // Strip userinfo (username:password@) from discovered URLs to prevent
+    // duplicate crawling caused by malformed mailto links or basic auth URLs.
+    // e.g., https://user@example.com/path -> https://example.com/path
+    return links.map(link => {
+      try {
+        const urlObj = new URL(link);
+        if (urlObj.username || urlObj.password) {
+          stripURLUserinfo(urlObj);
+          return urlObj.href;
+        }
+        return link;
+      } catch {
+        return link;
+      }
+    });
   }
 
   private isRobotsAllowed(


### PR DESCRIPTION
## Summary
Strips username and password (userinfo) from discovered URLs before adding them to the crawl queue. This prevents malformed mailto links and HTTP basic auth URLs from creating duplicate crawls of the same site.

Two scenarios fixed:
1. CMS-misconfigured mailto links (`mailto:user@domain.com` → `https://user@domain.com`) no longer spawn duplicate crawls
2. HTTP basic auth URLs (`https://user:pass@domain.com`) are normalized to strip credentials

This matches modern browser behavior per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication#access_using_credentials_in_the_url).

Fixes #2591

## Changes
- Added `stripURLUserinfo()` helper in `crawl-redis.ts` that strips `username` and `password` from URL objects
- Applied stripping in `normalizeURL()` — used for URL deduplication when locking URLs in the crawl queue
- Applied stripping in `generateURLPermutations()` — used for similar-URL deduplication
- Applied stripping in `extractLinksFromHTML()` — where links are discovered from scraped page content

## Test plan
- [ ] Malformed mailto URLs (e.g., `https://user@example.com/page`) are normalized to `https://example.com/page` and no longer create duplicate crawl entries
- [ ] Basic auth URLs (e.g., `https://user:pass@example.com/page`) are normalized correctly
- [ ] Normal URLs without userinfo are completely unaffected
- [ ] URL deduplication via `lockURL` correctly treats `https://user@example.com` and `https://example.com` as the same URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate crawling by stripping username/password from URLs during discovery and normalization. Fixes issues caused by malformed mailto links and basic-auth URLs.

- **Bug Fixes**
  - Remove URL userinfo so `https://user@example.com/path` is treated the same as `https://example.com/path`.
  - Added `stripURLUserinfo()` and applied it in `normalizeURL`, `generateURLPermutations`, and `extractLinksFromHTML`.
  - Normal URLs are unaffected; improves dedup behavior when locking URLs in the crawl queue.

<sup>Written for commit 5020f4dbe0adc9e9baa057b70c649a7974e041a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

