### PR TITLE
fix: use custom user-agent from headers in playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,9 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, headers?: Record<string, string>) => {
+  const customUserAgent = headers?.['user-agent'];
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,7 +253,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
     if (headers) {


### PR DESCRIPTION
## Description

When calling the scrape endpoint with `headers.user-agent`, the value was not being used because `setExtraHTTPHeaders` doesn't override the user-agent set at the context level.

## Fix

This fix modifies `createContext` to accept headers parameter and prioritize custom user-agent from headers over the auto-generated one from the UserAgent package.

## Changes

- Modified `createContext` function to accept optional `headers` parameter
- Added logic to check for custom user-agent in headers before falling back to auto-generated one
- Updated the `/scrape` endpoint to pass headers to `createContext`

## Testing

The fix has been tested by:
1. Calling the scrape endpoint with custom user-agent in headers
2. Verifying that the requests now use the specified user-agent

## Related Issue

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the custom user-agent from request headers in the Playwright context for the `/scrape` endpoint. This ensures requests use the caller’s user-agent instead of the auto-generated one.

- **Bug Fixes**
  - `createContext` accepts optional `headers` and uses `headers['user-agent']` when present.
  - `/scrape` passes request headers to `createContext`.
  - Falls back to the auto-generated user-agent from `user-agents` if none is provided.

<sup>Written for commit 0de9b2b5e577589348aaed74f81e9778c1dc87eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

