### PR TITLE
fix: use custom user-agent from headers in Playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customUserAgent?: string) => {
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -251,12 +251,25 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let requestContext: BrowserContext | null = null;
   let page: Page | null = null;
 
+  // Extract user-agent from headers if present (case-insensitive)
+  let customUserAgent: string | undefined;
+  let filteredHeaders = headers;
+  if (headers) {
+    const userAgentKey = Object.keys(headers).find(key => key.toLowerCase() === 'user-agent');
+    if (userAgentKey) {
+      customUserAgent = headers[userAgentKey];
+      // Remove user-agent from headers since it's now set on the context
+      filteredHeaders = { ...headers };
+      delete filteredHeaders[userAgentKey];
+    }
+  }
+
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
-    if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+    if (filteredHeaders && Object.keys(filteredHeaders).length > 0) {
+      await page.setExtraHTTPHeaders(filteredHeaders);
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
When calling the scrape endpoint with a user-agent in the headers, the value was being ignored because Playwright only respects user-agent set on the context, not via setExtraHTTPHeaders.

This fix:
1. Extracts user-agent from headers (case-insensitive) before calling setExtraHTTPHeaders
2. Passes the custom user-agent to createContext so it's set on the browser context
3. Removes user-agent from headers passed to setExtraHTTPHeaders to avoid duplicate headers

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The scrape endpoint now respects a custom User-Agent from request headers by applying it to the `playwright` browser context. Fixes #2802.

- **Bug Fixes**
  - Extract User-Agent from headers (case-insensitive) before setting extra headers.
  - Pass the value to `createContext` so the context-level UA is used by `playwright`.
  - Remove User-Agent from `page.setExtraHTTPHeaders` to avoid duplicates.

<sup>Written for commit 8cb4df195abfbd31f9d51d821d906a22f7dc1030. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

