### PR TITLE
fix: use custom user-agent from headers in Playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,10 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, headers?: { [key: string]: string }) => {
+  // Use custom user-agent if provided in headers, otherwise generate one
+  const customUserAgent = headers?.['user-agent'];
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,11 +254,16 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      // Filter out user-agent since it's now set at context level
+      const extraHeaders = { ...headers };
+      delete extraHeaders['user-agent'];
+      if (Object.keys(extraHeaders).length > 0) {
+        await page.setExtraHTTPHeaders(extraHeaders);
+      }
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
When calling the scrape endpoint with a custom user-agent in headers, the value was being ignored because Playwright sets the user-agent at the context level and then ignores the same header in setExtraHTTPHeaders.

This fix:
- Modifies createContext to accept headers parameter
- Uses custom user-agent if provided in headers  
- Filters out user-agent from extra HTTP headers to avoid conflicts

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrape endpoint now respects a custom `user-agent` by setting it on the `playwright` context and excluding it from extra headers. Fixes #2802.

- **Bug Fixes**
  - Pass request headers into `createContext`.
  - Use `headers['user-agent']` for context `userAgent`; fall back to generated value.
  - Remove `user-agent` from `page.setExtraHTTPHeaders` to avoid `playwright` conflicts.

<sup>Written for commit 335723092c81a27496b0a3d83c9b6a97509cca67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

