### PR TITLE
fix: use custom user-agent from headers in Playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,9 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customHeaders?: Record<string, string>) => {
+  // Use custom user-agent from headers if provided, otherwise generate a random one
+  const userAgent = customHeaders?.['user-agent'] || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,11 +253,17 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
+    // Only set extra headers if there are headers other than user-agent
+    // (user-agent is already set at context level)
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      const headersWithoutUserAgent = { ...headers };
+      delete headersWithoutUserAgent['user-agent'];
+      if (Object.keys(headersWithoutUserAgent).length > 0) {
+        await page.setExtraHTTPHeaders(headersWithoutUserAgent);
+      }
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
When calling the scrape endpoint with headers.user-agent, the value was not being used because Playwright first sets the user-agent at context level, then ignores the user-agent key when setExtraHTTPHeaders is called.

This fix:
1. Passes headers to createContext so custom user-agent can be used at context creation time
2. Removes user-agent from headers before calling setExtraHTTPHeaders since it's already set at context level

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure custom User-Agent from `headers.user-agent` is applied in Playwright by setting it during context creation, not via extra headers. This makes the `/scrape` endpoint honor the caller’s UA. Fixes #2802.

- **Bug Fixes**
  - Pass `headers` into `createContext` and use `headers['user-agent']` if provided; fallback to a generated UA.
  - Remove `user-agent` before `page.setExtraHTTPHeaders`; only set extra headers when others are present.

<sup>Written for commit 327290dec7f6ac5d80fa455e7199b670f3e82b42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

