### PR TITLE
fix: properly handle user-agent in headers for Playwright requests

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -256,8 +256,14 @@ app.post('/scrape', async (req: Request, res: Response) => {
     requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
-    if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+    // Filter out user-agent since it's already set at context level
+    // Setting it via setExtraHTTPHeaders is ignored by Playwright when context has userAgent
+    const headersWithoutUserAgent = headers ? Object.fromEntries(
+      Object.entries(headers).filter(([key]) => key.toLowerCase() !== 'user-agent')
+    ) : undefined;
+
+    if (headersWithoutUserAgent && Object.keys(headersWithoutUserAgent).length > 0) {
+      await page.setExtraHTTPHeaders(headersWithoutUserAgent);
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
## Description

When custom user-agent is provided in headers, it was being ignored because:

1.  extracts user-agent and sets it at context level
2.  then tries to set it again, but Playwright ignores user-agent in extra headers when context already has userAgent set

This fix filters out user-agent from headers before calling , since it's already properly applied at the context level.

## Fixes

Fixes #2802

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The fix has been verified to compile successfully with `npm run build`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor custom `user-agent` headers in `playwright` by setting them on the context and removing them from extra headers; fall back to a generated UA if none is provided. Fixes #2802.

<sup>Written for commit 7b8e129ee81025f5577a6607ed0ac44b104db32a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

