### PR TITLE
fix(python-sdk): preserve ChangeTrackingFormat and AttributesFormat options in prepare_scrape_options

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -1,5 +1,8 @@
 import pytest
-from firecrawl.v2.types import JsonFormat, ScrapeOptions, PDFParser
+from firecrawl.v2.types import (
+    JsonFormat, ScrapeOptions, PDFParser,
+    ChangeTrackingFormat, AttributesFormat, AttributeSelector,
+)
 from firecrawl.v2.utils.validation import validate_scrape_options, prepare_scrape_options
 
 
@@ -309,3 +312,57 @@ class TestPrepareScrapeOptions:
         result = prepare_scrape_options(options)
 
         assert result["parsers"][0]["maxPages"] == 5
+
+    def test_prepare_change_tracking_format_model(self):
+        """Ensure ChangeTrackingFormat model instances preserve all options."""
+        ct = ChangeTrackingFormat(
+            type="changeTracking",
+            modes=["git-diff", "json"],
+            prompt="Track price changes",
+            tag="v1",
+        )
+        options = ScrapeOptions(formats=[ct])
+        result = prepare_scrape_options(options)
+
+        assert "formats" in result
+        fmt = result["formats"][0]
+        assert isinstance(fmt, dict)
+        assert fmt["type"] == "changeTracking"
+        assert fmt["modes"] == ["git-diff", "json"]
+        assert fmt["prompt"] == "Track price changes"
+        assert fmt["tag"] == "v1"
+
+    def test_prepare_change_tracking_format_snake_case_type(self):
+        """Ensure change_tracking type string is normalised to camelCase."""
+        ct = ChangeTrackingFormat(
+            type="change_tracking",
+            modes=["json"],
+        )
+        options = ScrapeOptions(formats=[ct])
+        result = prepare_scrape_options(options)
+
+        fmt = result["formats"][0]
+        assert fmt["type"] == "changeTracking"
+        assert fmt["modes"] == ["json"]
+
+    def test_prepare_attributes_format_model(self):
+        """Ensure AttributesFormat model instances preserve selectors."""
+        af = AttributesFormat(
+            type="attributes",
+            selectors=[
+                AttributeSelector(selector=".price", attribute="data-value"),
+                AttributeSelector(selector="#title", attribute="textContent"),
+            ],
+        )
+        options = ScrapeOptions(formats=[af])
+        result = prepare_scrape_options(options)
+
+        assert "formats" in result
+        fmt = result["formats"][0]
+        assert isinstance(fmt, dict)
+        assert fmt["type"] == "attributes"
+        assert len(fmt["selectors"]) == 2
+        assert fmt["selectors"][0]["selector"] == ".price"
+        assert fmt["selectors"][0]["attribute"] == "data-value"
+        assert fmt["selectors"][1]["selector"] == "#title"
+        assert fmt["selectors"][1]["attribute"] == "textContent"

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -24,6 +24,38 @@ def _convert_format_string(format_str: str) -> str:
     return format_mapping.get(format_str, format_str)
 
 
+def _normalize_format_model(fmt: Any, format_type: str) -> dict:
+    """
+    Convert a format model instance (e.g. ChangeTrackingFormat, AttributesFormat) to a dict
+    with proper camelCase keys for the API.
+
+    Args:
+        fmt: Format model instance with a model_dump() method
+        format_type: The camelCase format type string (e.g. 'changeTracking', 'attributes')
+
+    Returns:
+        Dictionary with the format type and all configuration options preserved
+    """
+    data = fmt.model_dump(exclude_none=True) if hasattr(fmt, 'model_dump') else {}
+    data['type'] = format_type
+
+    # snake_case to camelCase for known fields
+    if 'full_page' in data:
+        data['fullPage'] = data.pop('full_page')
+
+    # Normalize nested model instances (e.g. selectors with model_dump)
+    if 'selectors' in data and isinstance(data['selectors'], list):
+        normalized_selectors = []
+        for sel in data['selectors']:
+            if hasattr(sel, 'model_dump'):
+                normalized_selectors.append(sel.model_dump(exclude_none=True))
+            else:
+                normalized_selectors.append(sel)
+        data['selectors'] = normalized_selectors
+
+    return data
+
+
 def normalize_schema_for_openai(schema: Any) -> Any:
     """
     Normalize a schema for OpenAI compatibility by handling recursive references.
@@ -565,6 +597,20 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                             elif hasattr(fmt, 'type'):
                                 if fmt.type == 'json':
                                     converted_formats.append(_validate_json_format(fmt.model_dump()))
+                                elif fmt.type in ('changeTracking', 'change_tracking'):
+                                    converted_formats.append(_normalize_format_model(fmt, 'changeTracking'))
+                                elif fmt.type == 'screenshot':
+                                    normalized = {'type': 'screenshot'}
+                                    if getattr(fmt, 'full_page', None) is not None:
+                                        normalized['fullPage'] = fmt.full_page
+                                    if getattr(fmt, 'quality', None) is not None:
+                                        normalized['quality'] = fmt.quality
+                                    vp = getattr(fmt, 'viewport', None)
+                                    if vp is not None:
+                                        normalized['viewport'] = vp.model_dump(exclude_none=True) if hasattr(vp, 'model_dump') else vp
+                                    converted_formats.append(normalized)
+                                elif fmt.type == 'attributes':
+                                    converted_formats.append(_normalize_format_model(fmt, 'attributes'))
                                 else:
                                     converted_formats.append(_convert_format_string(fmt.type))
                             else:
@@ -614,6 +660,8 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                         elif hasattr(fmt, 'type'):
                             if fmt.type == 'json':
                                 converted_formats.append(_validate_json_format(fmt.model_dump()))
+                            elif fmt.type in ('changeTracking', 'change_tracking'):
+                                converted_formats.append(_normalize_format_model(fmt, 'changeTracking'))
                             elif fmt.type == 'screenshot':
                                 normalized = {'type': 'screenshot'}
                                 if getattr(fmt, 'full_page', None) is not None:
@@ -624,6 +672,8 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                                 if vp is not None:
                                     normalized['viewport'] = vp.model_dump(exclude_none=True) if hasattr(vp, 'model_dump') else vp
                                 converted_formats.append(normalized)
+                            elif fmt.type == 'attributes':
+                                converted_formats.append(_normalize_format_model(fmt, 'attributes'))
                             else:
                                 converted_formats.append(_convert_format_string(fmt.type))
                         else:


### PR DESCRIPTION
## Bug

When `ChangeTrackingFormat` or `AttributesFormat` **model instances** are passed as format options in the Python SDK, `prepare_scrape_options()` silently drops all their configuration and sends only the bare type string to the API.

For example:
```python
options = ScrapeOptions(
    formats=[
        ChangeTrackingFormat(type="changeTracking", modes=["git-diff", "json"], prompt="Track prices"),
        AttributesFormat(type="attributes", selectors=[AttributeSelector(selector=".price", attribute="data-value")]),
    ]
)
```

**Expected payload:**
```json
{"formats": [
  {"type": "changeTracking", "modes": ["git-diff", "json"], "prompt": "Track prices"},
  {"type": "attributes", "selectors": [{"selector": ".price", "attribute": "data-value"}]}
]}
```

**Actual payload (before fix):**
```json
{"formats": ["changeTracking", "attributes"]}
```

All options (`modes`, `prompt`, `tag`, `schema`, `selectors`) are lost.

## Root Cause

In `validation.py`'s `prepare_scrape_options`, the model-instance branch (`elif hasattr(fmt, 'type')`) only has explicit handling for `json` and `screenshot` format types. All other format types fall through to:
```python
converted_formats.append(_convert_format_string(fmt.type))
```
which just extracts the type string and discards the model.

Dict-based formats work correctly because they go through a different branch that preserves the entire dict.

## Fix

- Add explicit handling for `changeTracking` and `attributes` model instances in both code paths (ScrapeFormats.formats and plain list formats)
- New `_normalize_format_model()` helper that calls `model_dump()`, sets the correct camelCase type, converts snake_case keys, and normalises nested model instances (e.g. `AttributeSelector`)
- Both code paths (ScrapeFormats branch and list branch) are fixed

## Tests

3 new unit tests added to `test_validation.py`:
- `test_prepare_change_tracking_format_model` — verifies modes, prompt, tag are preserved
- `test_prepare_change_tracking_format_snake_case_type` — verifies `change_tracking` → `changeTracking` normalisation
- `test_prepare_attributes_format_model` — verifies selectors list is preserved with correct structure

All 23 validation tests pass (342 total unit tests pass; 2 pre-existing failures on Windows path separators unrelated to this change).

> **Note:** This PR was autonomously generated by an AI (Claude Opus 4.6, Anthropic).
> I am transparently seeking employment as an AI contributor.
> More context: https://www.maxcalkin.com/employee

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Python SDK serialization so `prepare_scrape_options()` preserves all options for `ChangeTrackingFormat` and `AttributesFormat` instead of sending bare type strings. Prevents loss of modes, prompt, tag, and selectors in API requests.

- **Bug Fixes**
  - Preserve model options for `ChangeTrackingFormat` and `AttributesFormat` in both `ScrapeFormats.formats` and plain list code paths.
  - Add `_normalize_format_model()` to `model_dump()` formats, convert snake_case to camelCase, and normalize nested models (e.g., `AttributeSelector`).
  - Normalize `change_tracking` to `changeTracking`.
  - Add unit tests covering change tracking, attributes, and type normalization.

<sup>Written for commit 55ea5abf5ed05dcfa51721b98e2a58441cec7b5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

