### PR TITLE
fix(python-sdk): preserve format object configuration in prepare_scrape_options

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -309,3 +309,64 @@ class TestPrepareScrapeOptions:
         result = prepare_scrape_options(options)
 
         assert result["parsers"][0]["maxPages"] == 5
+
+    def test_prepare_change_tracking_format_preserves_options(self):
+        """Ensure ChangeTrackingFormat options (modes, schema, prompt, tag) are preserved."""
+        from firecrawl.v2.types import ChangeTrackingFormat
+
+        ct = ChangeTrackingFormat(
+            type="changeTracking",
+            modes=["git-diff", "json"],
+            prompt="Summarize changes",
+            tag="v2.1",
+        )
+        options = ScrapeOptions(formats=["markdown", ct])
+        result = prepare_scrape_options(options)
+
+        assert "formats" in result
+        # Find the changeTracking entry (should be a dict, not a plain string)
+        ct_entries = [f for f in result["formats"] if isinstance(f, dict) and f.get("type") == "changeTracking"]
+        assert len(ct_entries) == 1, (
+            f"Expected a dict entry for changeTracking but got: {result['formats']}"
+        )
+        ct_out = ct_entries[0]
+        assert ct_out["modes"] == ["git-diff", "json"]
+        assert ct_out["prompt"] == "Summarize changes"
+        assert ct_out["tag"] == "v2.1"
+
+    def test_prepare_attributes_format_preserves_selectors(self):
+        """Ensure AttributesFormat selectors are preserved, not collapsed to a string."""
+        from firecrawl.v2.types import AttributesFormat, AttributeSelector
+
+        attrs = AttributesFormat(
+            type="attributes",
+            selectors=[
+                AttributeSelector(selector="div.product", attribute="data-id"),
+                AttributeSelector(selector="span.price", attribute="data-value"),
+            ],
+        )
+        options = ScrapeOptions(formats=[attrs])
+        result = prepare_scrape_options(options)
+
+        assert "formats" in result
+        attr_entries = [f for f in result["formats"] if isinstance(f, dict) and f.get("type") == "attributes"]
+        assert len(attr_entries) == 1, (
+            f"Expected a dict entry for attributes but got: {result['formats']}"
+        )
+        attr_out = attr_entries[0]
+        assert "selectors" in attr_out
+        assert len(attr_out["selectors"]) == 2
+        assert attr_out["selectors"][0]["selector"] == "div.product"
+        assert attr_out["selectors"][0]["attribute"] == "data-id"
+
+    def test_prepare_simple_format_object_stays_string(self):
+        """Ensure simple Format objects (e.g. Format(type='html')) stay as strings."""
+        from firecrawl.v2.types import Format
+
+        fmt = Format(type="html")
+        options = ScrapeOptions(formats=[fmt])
+        result = prepare_scrape_options(options)
+
+        assert "formats" in result
+        # Should be collapsed to a plain string, not a dict
+        assert "html" in result["formats"]

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -9,10 +9,10 @@ from ..types import ScrapeOptions, ScrapeFormats
 def _convert_format_string(format_str: str) -> str:
     """
     Convert format string from snake_case to camelCase.
-    
+
     Args:
         format_str: Format string in snake_case
-        
+
     Returns:
         Format string in camelCase
     """
@@ -22,6 +22,43 @@ def _convert_format_string(format_str: str) -> str:
         "screenshot_full_page": "screenshot@fullPage"
     }
     return format_mapping.get(format_str, format_str)
+
+
+def _serialize_format_object(fmt: Any) -> Any:
+    """
+    Serialize a Pydantic format model (ChangeTrackingFormat, AttributesFormat, etc.)
+    into a dict suitable for the API, converting snake_case keys to camelCase.
+
+    Simple format objects (e.g. Format(type="markdown")) are reduced to their type string.
+    Objects with extra configuration fields are serialized as dicts with proper key casing.
+
+    Args:
+        fmt: A Pydantic model instance with a ``type`` attribute.
+
+    Returns:
+        A string (for simple formats) or a dict (for formats with configuration).
+    """
+    data = fmt.model_dump(exclude_none=True) if hasattr(fmt, 'model_dump') else {}
+    # Normalize the type string (e.g. "change_tracking" -> "changeTracking")
+    if 'type' in data:
+        data['type'] = _convert_format_string(data['type'])
+
+    # If the only key is "type", collapse to a plain string
+    if list(data.keys()) == ['type']:
+        return data['type']
+
+    # snake_case -> camelCase for known format option keys
+    key_map = {
+        "full_page": "fullPage",
+    }
+    normalized: Dict[str, Any] = {}
+    for k, v in data.items():
+        camel = key_map.get(k, k)
+        # Recursively dump nested Pydantic models (e.g. viewport)
+        if hasattr(v, 'model_dump'):
+            v = v.model_dump(exclude_none=True)
+        normalized[camel] = v
+    return normalized
 
 
 def normalize_schema_for_openai(schema: Any) -> Any:
@@ -566,7 +603,7 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                                 if fmt.type == 'json':
                                     converted_formats.append(_validate_json_format(fmt.model_dump()))
                                 else:
-                                    converted_formats.append(_convert_format_string(fmt.type))
+                                    converted_formats.append(_serialize_format_object(fmt))
                             else:
                                 converted_formats.append(fmt)
 
@@ -625,7 +662,7 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                                     normalized['viewport'] = vp.model_dump(exclude_none=True) if hasattr(vp, 'model_dump') else vp
                                 converted_formats.append(normalized)
                             else:
-                                converted_formats.append(_convert_format_string(fmt.type))
+                                converted_formats.append(_serialize_format_object(fmt))
                         else:
                             converted_formats.append(fmt)
                 else:


### PR DESCRIPTION
## Summary

- **Bug**: When Pydantic format model instances like `ChangeTrackingFormat(modes=["git-diff", "json"], prompt="Summarize changes")` or `AttributesFormat(selectors=[...])` are passed in the `formats` list of `ScrapeOptions`, `prepare_scrape_options()` silently collapses them to plain type strings (e.g., `"changeTracking"`, `"attributes"`), **dropping all configuration fields** (modes, selectors, prompt, tag, schema, etc.)
- **Root cause**: The format serialization code in `prepare_scrape_options()` only has special handling for `json` and `screenshot` format types. All other Pydantic format model types fall through to `_convert_format_string(fmt.type)`, which returns just the type string.
- **Fix**: Add `_serialize_format_object()` helper that dumps model fields to a dict with camelCase keys, falling back to a plain string only for simple `Format` objects with no extra fields beyond `type`.
- 3 new unit tests covering `ChangeTrackingFormat`, `AttributesFormat`, and simple `Format` objects.

## Test plan

- [x] `test_prepare_change_tracking_format_preserves_options` — verifies modes, prompt, tag are preserved
- [x] `test_prepare_attributes_format_preserves_selectors` — verifies selectors list is preserved as dicts
- [x] `test_prepare_simple_format_object_stays_string` — verifies `Format(type="html")` collapses to `"html"`
- [x] All existing tests pass (2 pre-existing Windows-only test failures unrelated to this change)

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic AI), operating transparently as part of a project to demonstrate AI contributions to open-source software. A human (Max Calkin) reviews and submits all work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of format configuration in `prepare_scrape_options()` so Pydantic format models keep their options in API payloads. Ensures formats like `ChangeTrackingFormat` and `AttributesFormat` are serialized with all fields instead of being collapsed to plain strings.

- **Bug Fixes**
  - Added `_serialize_format_object()` to serialize format models to dicts with camelCase keys; falls back to a string only when `type` is the sole field.
  - Preserves options for `ChangeTrackingFormat` (modes, prompt, tag, etc.) and `AttributesFormat` (selectors).
  - Added unit tests for change tracking, attributes, and simple format cases.

<sup>Written for commit f480d16b077db7fe5938ec67fe3756610ca9bc48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

