### PR TITLE
fix(sdk): add webhook parameter to startExtract method

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
@@ -1,4 +1,4 @@
-import { type ExtractResponse, type ScrapeOptions, type AgentOptions } from "../types";
+import { type ExtractResponse, type ScrapeOptions, type AgentOptions, type WebhookConfig } from "../types";
 import { HttpClient } from "../utils/httpClient";
 import { ensureValidScrapeOptions } from "../utils/validation";
 import { normalizeAxiosError, throwForBadResponse } from "../utils/errorHandler";
@@ -18,6 +18,7 @@ function prepareExtractPayload(args: {
   integration?: string;
   origin?: string;
   agent?: AgentOptions;
+  webhook?: string | WebhookConfig | null;
 }): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (args.urls) body.urls = args.urls;
@@ -37,6 +38,7 @@ function prepareExtractPayload(args: {
     ensureValidScrapeOptions(args.scrapeOptions);
     body.scrapeOptions = args.scrapeOptions;
   }
+  if (args.webhook != null) body.webhook = args.webhook;
   return body;
 }
 


### PR DESCRIPTION
The startExtract method in the Node.js SDK did not accept webhook options in its TypeScript type definitions, even though the Firecrawl API accepts webhook configuration for extract jobs. This prevented TypeScript users from properly configuring webhooks for async extraction jobs.

This fix:
- Adds webhook parameter to prepareExtractPayload function
- Imports WebhookConfig type from types
- Adds webhook to the request body when provided

The fix is consistent with how other methods (crawl, batchScrape) handle webhook configuration.

Fixes #2582

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for a `webhook` option in `startExtract` in the Node.js SDK to match the API. TypeScript users can now configure webhooks for async extract jobs.

- **Bug Fixes**
  - Added `webhook?: string | WebhookConfig | null` to `prepareExtractPayload` and included it in the request body when provided.
  - Imported `WebhookConfig` and aligned behavior with `crawl` and `batchScrape`.

<sup>Written for commit 12f79f5f8a867b966cf63f9b28cc31d428c912eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

