### PR TITLE
fix(js-sdk): add missing webhook parameter to startExtract method

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
@@ -1,4 +1,4 @@
-import { type ExtractResponse, type ScrapeOptions, type AgentOptions } from "../types";
+import { type ExtractResponse, type ScrapeOptions, type AgentOptions, type WebhookConfig } from "../types";
 import { HttpClient } from "../utils/httpClient";
 import { ensureValidScrapeOptions } from "../utils/validation";
 import { normalizeAxiosError, throwForBadResponse } from "../utils/errorHandler";
@@ -18,6 +18,7 @@ function prepareExtractPayload(args: {
   integration?: string;
   origin?: string;
   agent?: AgentOptions;
+  webhook?: string | WebhookConfig | null;
 }): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (args.urls) body.urls = args.urls;
@@ -33,6 +34,7 @@ function prepareExtractPayload(args: {
   if (args.integration && args.integration.trim()) body.integration = args.integration.trim();
   if (args.origin) body.origin = args.origin;
   if (args.agent) body.agent = args.agent;
+  if (args.webhook != null) body.webhook = args.webhook;
   if (args.scrapeOptions) {
     ensureValidScrapeOptions(args.scrapeOptions);
     body.scrapeOptions = args.scrapeOptions;


### PR DESCRIPTION
## Summary

The `startExtract` method in the Node.js SDK does not accept `webhook` options in its TypeScript type definitions, even though the Firecrawl API supports webhook configuration for extract jobs. This causes a TypeScript error when users try to pass webhook options:

```
Property 'webhook' does not exist on type '{ urls?: string[]; prompt?: string; schema?: ... }'
```

This PR adds `webhook?: string | WebhookConfig | null` to the extract payload type and forwards it to the API request body, consistent with how `crawl` and `batchScrapeUrls` already handle webhooks.

## Changes

- Import `WebhookConfig` type in `extract.ts`
- Add `webhook` to the `prepareExtractPayload` args type
- Forward `webhook` to the API request payload

Fixes #2582

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the `webhook` option in `startExtract` so TypeScript users can configure webhooks for extract jobs without errors. Aligns the extract API with existing webhook support in `crawl` and `batchScrapeUrls`.

- **Bug Fixes**
  - Added `webhook?: string | WebhookConfig | null` to the extract payload type in `extract.ts`.
  - Forwarded `webhook` to the API request body.
  - Matches behavior in `crawl` and `batchScrapeUrls`.

<sup>Written for commit 94ae5185b5d752813036d23640636d6cb550abbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

