### PR TITLE
fix: filter malformed mailto and basic auth URLs during crawl link discovery

### DIFF
--- a/apps/api/native/src/crawler.rs
+++ b/apps/api/native/src/crawler.rs
@@ -396,6 +396,17 @@ pub async fn filter_links(data: FilterLinksCall) -> Result<FilterLinksResult> {
 fn _filter_url(data: FilterUrlCall) -> std::result::Result<FilterUrlResult, String> {
   let mut full_url = data.href.clone();
 
+
+  // Skip href values that look like email addresses (malformed mailto links)
+  // e.g., "email@domain.com" without mailto: prefix -- see #2591
+  if !data.href.starts_with("http") && !data.href.starts_with("/") && data.href.contains('@') {
+    return Ok(FilterUrlResult {
+      allowed: false,
+      url: None,
+      denial_reason: Some(NON_WEB_PROTOCOL.to_string()),
+    });
+  }
+
   // Handle relative URLs
   if !data.href.starts_with("http") {
     match Url::parse(&data.url) {
@@ -429,6 +440,16 @@ fn _filter_url(data: FilterUrlCall) -> std::result::Result<FilterUrlResult, Stri
       });
     }
   };
+
+
+  // Strip userinfo from URLs to prevent duplicate crawls from
+  // basic auth URLs (https://user:pass@domain.com) -- see #2591
+  let mut url = url;
+  if !url.username().is_empty() || url.password().is_some() {
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    full_url = url.to_string();
+  }
 
   let base_url = match Url::parse(&data.base_url) {
     Ok(url) => url,

--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -284,6 +284,12 @@ export class WebCrawler {
           });
           return false;
         }
+        // Strip userinfo to prevent duplicate crawls from basic auth URLs -- #2591
+        if (url.username || url.password) {
+          url.username = "";
+          url.password = "";
+        }
+
         const path = url.pathname;
 
         const urlStr = url.toString();
@@ -680,6 +686,10 @@ export class WebCrawler {
       const element = $("a")[i];
       let href = $(element).attr("href");
       if (href) {
+        // Skip malformed mailto links (email@domain.com without mailto: prefix) -- #2591
+        if (!href.startsWith("http") && !href.startsWith("/") && href.includes("@")) {
+          continue;
+        }
         if (href.match(/^https?:\/[^\/]/)) {
           href = href.replace(/^https?:\//, "$&/");
         }


### PR DESCRIPTION
## Summary

Fixes #2591

Malformed mailto links (`email@domain.com` without `mailto:` prefix) and basic auth URLs (`https://user:pass@domain.com`) cause duplicate crawls of the entire site because the userinfo portion makes URLs appear unique while pointing to the same pages.

## Problem

Two situations cause duplicate crawls:

1. **Malformed mailto**: CMS authors misconfigure a mailto link → `<a href="email@domain.com">` instead of `<a href="mailto:email@domain.com">`. The URL resolver treats this as a relative path, creating `https://example.com/email@domain.com`.

2. **Basic auth URLs**: `<a href="https://user@domain.com/path">` or `<a href="https://user:pass@domain.com/path">` — the userinfo makes every URL look unique, so the entire site gets re-crawled with the `user@` prefix.

## Fix

Changes in **both** the Rust native filter (`apps/api/native/src/crawler.rs`) and the JS fallback (`apps/api/src/scraper/WebScraper/crawler.ts`):

1. **Skip email-like href values**: Before URL resolution, detect href values that contain `@` without an `http` or `/` prefix (likely malformed mailto links) and reject them with `NON_WEB_PROTOCOL` denial reason.

2. **Strip userinfo from parsed URLs**: After URL parsing, if `username` or `password` are present, strip them. This normalizes `https://user@domain.com/path` to `https://domain.com/path`, which then deduplicates correctly against existing URLs.

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)). See [our portfolio](https://github.com/MaxwellCalkin) for more about this project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate crawls caused by malformed mailto links and basic-auth userinfo in discovered links. Skips email-like hrefs without a protocol and strips username/password from URLs before dedupe in both the Rust crawler and JS fallback.

- **Bug Fixes**
  - Skip hrefs with “@” that don’t start with `http` or `/` (treat as malformed mailto) with `NON_WEB_PROTOCOL` denial.
  - Remove `username:password@` from parsed URLs before normalization and dedup (e.g., `https://user@domain.com/path` → `https://domain.com/path`).

<sup>Written for commit f696bafc288de158d2ddc47f02742452a95aad5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

