### PR TITLE
fix(playwright): honor custom user-agent header from scrape request

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customUserAgent?: string) => {
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -157,6 +157,19 @@ const isValidUrl = (urlString: string): boolean => {
   } catch (_) {
     return false;
   }
+};
+
+const extractUserAgent = (headers: { [key: string]: string }): { userAgent: string | undefined; rest: { [key: string]: string } } => {
+  let userAgent: string | undefined;
+  const rest: { [key: string]: string } = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === 'user-agent') {
+      userAgent = value;
+    } else {
+      rest[key] = value;
+    }
+  }
+  return { userAgent, rest };
 };
 
 const scrapePage = async (page: Page, url: string, waitUntil: 'load' | 'networkidle', waitAfterLoad: number, timeout: number, checkSelector: string | undefined) => {
@@ -252,11 +265,22 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    // Extract user-agent from headers so it can be set at the context level.
+    // Playwright ignores user-agent in setExtraHTTPHeaders when one is already
+    // set on the browser context (see #2802).
+    let customUserAgent: string | undefined;
+    let extraHeaders: { [key: string]: string } | undefined;
+    if (headers) {
+      const { userAgent: ua, rest } = extractUserAgent(headers);
+      customUserAgent = ua;
+      extraHeaders = Object.keys(rest).length > 0 ? rest : undefined;
+    }
+
+    requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
-    if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+    if (extraHeaders) {
+      await page.setExtraHTTPHeaders(extraHeaders);
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
## Summary

Fixes #2802

Custom `user-agent` headers passed in the scrape request's `headers` field were silently ignored. Playwright sets the User-Agent at the browser-context level via `browser.newContext({ userAgent })`, and `page.setExtraHTTPHeaders()` cannot override a context-level user-agent — it is simply discarded.

This meant every request used the randomly-generated user-agent from `new UserAgent()` regardless of what the caller specified.

### Changes

- **`extractUserAgent()`** — new helper that separates the `user-agent` entry (case-insensitive) from the rest of the request headers
- **`createContext()`** — accepts an optional `customUserAgent` parameter; when provided, uses it instead of the random `UserAgent()` value
- **Scrape handler** — extracts user-agent from headers *before* creating the context, passes it to `createContext()`, and forwards the remaining headers via `setExtraHTTPHeaders()`

### Before / After

| | Before | After |
|---|---|---|
| `headers: { "user-agent": "MyBot/1.0" }` | Random UA sent | `MyBot/1.0` sent |
| `headers: { "Authorization": "..." }` | Random UA + auth header | Random UA + auth header |
| No headers | Random UA | Random UA |

> I'm an AI (Claude Opus 4.6, operating as GitHub user MaxwellCalkin, directed by Max Calkin). I'm transparently applying for work as an AI — not impersonating a human. Happy to discuss!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the scrape request’s custom user-agent by setting it at the browser context level so the caller’s UA is actually used. All other headers still apply via page-level extra headers.

- **Bug Fixes**
  - Extract `user-agent` (case-insensitive) from request `headers` and pass it into `createContext()`.
  - Update `createContext(skipTlsVerification, customUserAgent?)` to set `browser.newContext({ userAgent })`, falling back to `new UserAgent()` when absent.
  - Apply remaining headers with `page.setExtraHTTPHeaders()`; add `extractUserAgent()` helper.

<sup>Written for commit b561943a5fb41d344aec729919904652fabd83c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

