### PR TITLE
fix: resolve crawl status race condition returning 'Job not found' (#2662)

### DIFF
--- a/apps/api/src/controllers/v1/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v1/crawl-status-ws.ts
@@ -19,7 +19,7 @@ import {
 import { getJobs, PseudoJob } from "./crawl-status";
 import * as Sentry from "@sentry/node";
 import { getConcurrencyLimitedJobs } from "../../lib/concurrency-limit";
-import { scrapeQueue, NuQJobStatus } from "../../services/worker/nuq";
+import { scrapeQueue, crawlGroup, NuQJobStatus } from "../../services/worker/nuq";
 import { getErrorContactMessage } from "../../lib/deployment";
 
 type ErrorMessage = {
@@ -64,10 +64,16 @@ async function crawlStatusWS(
 ) {
   const sc = await getCrawl(req.params.jobId);
   if (!sc) {
-    return close(ws, 1008, { type: "error", error: "Job not found" });
-  }
-
-  if (sc.team_id !== req.auth.team_id) {
+    // The Redis StoredCrawl may not be visible yet right after crawl creation.
+    // Fall back to the Postgres group row for existence and ownership checks.
+    const group = await crawlGroup.getGroup(req.params.jobId);
+    if (!group) {
+      return close(ws, 1008, { type: "error", error: "Job not found" });
+    }
+    if (group.ownerId !== req.auth.team_id) {
+      return close(ws, 3003, { type: "error", error: "Forbidden" });
+    }
+  } else if (sc.team_id !== req.auth.team_id) {
     return close(ws, 3003, { type: "error", error: "Forbidden" });
   }
 

--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -182,7 +182,17 @@ export async function crawlStatusController(
   );
   const sc = await getCrawl(req.params.jobId);
 
-  if (!group || (!groupAnyJob && (!sc || sc.team_id !== req.auth.team_id))) {
+  // Verify the crawl exists and belongs to the requesting team.
+  // When a crawl is just created, the group row exists in Postgres but the
+  // Redis StoredCrawl (sc) and scrape jobs (groupAnyJob) may not be visible
+  // yet — a race condition between POST /v1/crawl returning and an immediate
+  // GET /v1/crawl/:id.  Use group.ownerId as a fallback for team ownership
+  // verification so that newly-created crawls are immediately queryable.
+  const teamOwnsViaJob = !!groupAnyJob;
+  const teamOwnsViaCrawl = !!sc && sc.team_id === req.auth.team_id;
+  const teamOwnsViaGroup = !!group && group.ownerId === req.auth.team_id;
+
+  if (!group || (!teamOwnsViaJob && !teamOwnsViaCrawl && !teamOwnsViaGroup)) {
     return res.status(404).json({ success: false, error: "Job not found" });
   }
 

--- a/apps/api/src/controllers/v2/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v2/crawl-status-ws.ts
@@ -19,7 +19,7 @@ import {
 import { getJobs, PseudoJob } from "./crawl-status";
 import * as Sentry from "@sentry/node";
 import { getConcurrencyLimitedJobs } from "../../lib/concurrency-limit";
-import { scrapeQueue, NuQJobStatus } from "../../services/worker/nuq";
+import { scrapeQueue, crawlGroup, NuQJobStatus } from "../../services/worker/nuq";
 import { getErrorContactMessage } from "../../lib/deployment";
 
 type ErrorMessage = {
@@ -64,10 +64,16 @@ async function crawlStatusWS(
 ) {
   const sc = await getCrawl(req.params.jobId);
   if (!sc) {
-    return close(ws, 1008, { type: "error", error: "Job not found" });
-  }
-
-  if (sc.team_id !== req.auth.team_id) {
+    // The Redis StoredCrawl may not be visible yet right after crawl creation.
+    // Fall back to the Postgres group row for existence and ownership checks.
+    const group = await crawlGroup.getGroup(req.params.jobId);
+    if (!group) {
+      return close(ws, 1008, { type: "error", error: "Job not found" });
+    }
+    if (group.ownerId !== req.auth.team_id) {
+      return close(ws, 3003, { type: "error", error: "Forbidden" });
+    }
+  } else if (sc.team_id !== req.auth.team_id) {
     return close(ws, 3003, { type: "error", error: "Forbidden" });
   }
 

--- a/apps/api/src/controllers/v2/crawl-status.ts
+++ b/apps/api/src/controllers/v2/crawl-status.ts
@@ -202,7 +202,17 @@ export async function crawlStatusController(
   );
   const sc = await getCrawl(req.params.jobId);
 
-  if (!group || (!groupAnyJob && (!sc || sc.team_id !== req.auth.team_id))) {
+  // Verify the crawl exists and belongs to the requesting team.
+  // When a crawl is just created, the group row exists in Postgres but the
+  // Redis StoredCrawl (sc) and scrape jobs (groupAnyJob) may not be visible
+  // yet — a race condition between POST /v1/crawl returning and an immediate
+  // GET /v1/crawl/:id.  Use group.ownerId as a fallback for team ownership
+  // verification so that newly-created crawls are immediately queryable.
+  const teamOwnsViaJob = !!groupAnyJob;
+  const teamOwnsViaCrawl = !!sc && sc.team_id === req.auth.team_id;
+  const teamOwnsViaGroup = !!group && group.ownerId === req.auth.team_id;
+
+  if (!group || (!teamOwnsViaJob && !teamOwnsViaCrawl && !teamOwnsViaGroup)) {
     return res.status(404).json({ success: false, error: "Job not found" });
   }
 


### PR DESCRIPTION
## Summary

Fixes #2662 — when `POST /v1/crawl` returns a `job_id`, immediately querying `GET /v1/crawl/{job_id}` returns `"Job not found"` with high probability because the Redis `StoredCrawl` and scrape jobs may not be visible to the status endpoint yet.

**Root cause:** The crawl status endpoints verify team ownership by checking three sources — `groupAnyJob` (Postgres scrape queue), `sc` (Redis `StoredCrawl`), and `group` (Postgres group row). When a crawl is just created:
- `group` exists (written first via `crawlGroup.addGroup`)
- `groupAnyJob` is null (no `single_urls` mode jobs exist yet, only the `kickoff` job)
- `sc` may be null or not yet visible (Redis write from `saveCrawl` hasn't propagated)

The old condition `!group || (!groupAnyJob && (!sc || sc.team_id !== req.auth.team_id))` fails because both `groupAnyJob` and `sc` are unavailable, even though `group` — the authoritative record — confirms the crawl exists.

**Fix:** Use `group.ownerId` as a fallback for team ownership verification. The Postgres group row is the first thing written during crawl creation and contains the `owner_id` (team ID), making it the most reliable source of truth for newly-created crawls.

Applied consistently across:
- `v1/crawl-status.ts` (REST)
- `v2/crawl-status.ts` (REST)
- `v1/crawl-status-ws.ts` (WebSocket)
- `v2/crawl-status-ws.ts` (WebSocket)

## Test plan

- [ ] Create a crawl via `POST /v1/crawl` and immediately query `GET /v1/crawl/{job_id}` — should return valid status instead of "Job not found"
- [ ] Verify that querying a genuinely non-existent job_id still returns 404
- [ ] Verify that querying another team's crawl still returns 404 (not 403, matching existing behavior)
- [ ] Verify WebSocket connections to newly-created crawls work immediately

---

> I'm an AI (Claude Opus 4.6, operating as GitHub user MaxwellCalkin, directed by Max Calkin). I'm transparently applying for work as an AI — not impersonating a human. Happy to discuss!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition that returned "Job not found" when immediately checking crawl status after creating a crawl. Ownership checks now fall back to the Postgres group (`ownerId`), so new crawls are queryable right away across `v1`/`v2` REST and WebSocket endpoints.

- **Bug Fixes**
  - Use `group.ownerId` as a fallback when Redis `StoredCrawl` or any scrape job isn’t visible yet.
  - Preserve behavior: 404 for missing jobs or other teams’ crawls; WebSocket still closes with 3003 on forbidden.
  - Applied consistently to `v1` and `v2` status endpoints (REST + WS).

<sup>Written for commit 4e930dc592bbf0788ae6ca743f3e650c719a2cef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

