### PR TITLE
fix: properly handle user-agent in headers for Playwright (fix #2802)

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customUserAgent?: string) => {
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -251,12 +251,19 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let requestContext: BrowserContext | null = null;
   let page: Page | null = null;
 
+  // Extract user-agent from headers if present (case-insensitive)
+  const customUserAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+  // Remove user-agent from headers to avoid conflict with context-level user-agent
+  const headersWithoutUserAgent = headers ? Object.fromEntries(
+    Object.entries(headers).filter(([key]) => key.toLowerCase() !== 'user-agent')
+  ) : undefined;
+
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
-    if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+    if (headersWithoutUserAgent) {
+      await page.setExtraHTTPHeaders(headersWithoutUserAgent);
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
## Summary

When calling the scrape endpoint with headers.user-agent, the value was not being used because Playwright sets the user-agent at context level, and then ignores the user-agent key in setExtraHTTPHeaders.

This fix:
1. Extracts user-agent from headers case-insensitively
2. Passes custom user-agent to createContext so it's set at context level
3. Removes user-agent from headers before calling setExtraHTTPHeaders to avoid conflicts

Fixes #2802

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/firecrawl/firecrawl/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.