### PR TITLE
chore(pdf): Update pdf-inspector to f2869ff

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "5ab92e0" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "f2869ff" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
Extract rects from filled paths for row-stripe tables. Detect vector-outlined text pages needing OCR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `pdf-inspector` to bring improved table parsing and OCR detection. It now extracts rects from filled paths in row-striped tables and detects vector-outlined text pages that need OCR.

<sup>Written for commit 039cd4cf9fd74ff6f13e1b222734ef0a9d9f9a05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

