### PR TITLE
chore(pdf): Update pdf-inspector: OCR detection, XObject text extraction, grid detection fixes

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "f2869ff" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "c1357e7" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
Raise text-ops threshold on pages with images for better OCR detection. Recurse into nested Form XObjects for text extraction. Fix grid detection by retrying without page-background rects and only when failed due to few non-empty rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `pdf-inspector` to improve OCR on image-heavy pages and extract text from nested Form XObjects. Also fixes grid detection by retrying without background rects when few non‑empty rows are found.

- **Dependencies**
  - Bump `pdf-inspector` to rev `c1357e7` (was `f2869ff`).

<sup>Written for commit ddeac5e327a91514c29954b76bdad736eb36923a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

