### PR TITLE
ci: add continue-on-error to test-reporter step

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -216,6 +216,7 @@ jobs:
 
       - name: Publish test report
         if: always()
+        continue-on-error: true
         uses: dorny/test-reporter@v1
         with:
           name: Test Report (${{ matrix.engine }}, ${{ matrix.proxy }}, ${{ matrix.search }}, ${{ matrix.ai }})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the test report step non-blocking so a failing `dorny/test-reporter@v1` run doesn’t fail the job. Adds `continue-on-error: true` to the “Publish test report” step while keeping `if: always()` to still attempt publishing.

<sup>Written for commit ad24aad1e4bb1a74021e4981c40f6f92f4014c65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

