### PR TITLE
fix(sdk): add webhook parameter to startExtract method

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
@@ -1,4 +1,4 @@
-import { type ExtractResponse, type ScrapeOptions, type AgentOptions } from "../types";
+import { type ExtractResponse, type ScrapeOptions, type AgentOptions, type WebhookConfig } from "../types";
 import { HttpClient } from "../utils/httpClient";
 import { ensureValidScrapeOptions } from "../utils/validation";
 import { normalizeAxiosError, throwForBadResponse } from "../utils/errorHandler";
@@ -18,6 +18,7 @@ function prepareExtractPayload(args: {
   integration?: string;
   origin?: string;
   agent?: AgentOptions;
+  webhook?: string | WebhookConfig | null;
 }): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (args.urls) body.urls = args.urls;
@@ -37,6 +38,7 @@ function prepareExtractPayload(args: {
     ensureValidScrapeOptions(args.scrapeOptions);
     body.scrapeOptions = args.scrapeOptions;
   }
+  if (args.webhook != null) body.webhook = args.webhook;
   return body;
 }
 


### PR DESCRIPTION
## Summary

Adds webhook parameter support to the `startExtract` method in the Node.js SDK.

## Changes

- Added `webhook` parameter to the `prepareExtractPayload` function type
- Added webhook to the payload body when provided
- Imported `WebhookConfig` type from types module

## Testing

- TypeScript types are correctly updated
- The change is consistent with other async job methods (crawl, batchScrape) that already support webhook options

## Related Issue

Fixes #2582

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] TypeScript types are correctly updated
- [x] No breaking changes (webhook is optional)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional webhook support to `startExtract` in the Node.js SDK, accepting a `string` or `WebhookConfig` and sending it in the payload when provided. Aligns extract jobs with existing async methods (`crawl`, `batchScrape`) and fixes #2582.

<sup>Written for commit 8149895f1a256aaba7c04c5e075bff3f8501349d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

