### PR TITLE
fix: use user-agent from headers when provided in scrape endpoint

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -253,13 +253,17 @@ app.post('/scrape', async (req: Request, res: Response) => {
 
   try {
     // Extract user-agent from headers if provided, to set at context level
-    const customUserAgent = headers?.['user-agent'];
+    // HTTP header names are case-insensitive, so we need to find user-agent regardless of case
+    const customUserAgent = headers 
+      ? Object.entries(headers).find(([key]) => key.toLowerCase() === 'user-agent')?.[1]
+      : undefined;
     
     requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
     // Remove user-agent from headers as it's already set at context level
     // Playwright ignores user-agent in setExtraHTTPHeaders when it's set at context level
+    // Use case-insensitive matching to handle all variations like 'USER-AGENT', 'User-Agent', etc.
     const headersWithoutUserAgent = headers ? Object.fromEntries(
       Object.entries(headers).filter(([key]) => key.toLowerCase() !== 'user-agent')
     ) : null;


### PR DESCRIPTION
## Description

Previously, the user-agent header passed to the scrape endpoint was being ignored because Playwright's `setExtraHTTPHeaders` doesn't override the user-agent that's already set on the browser context.

This fix modifies `createContext` to accept headers and use the user-agent value from headers if provided, otherwise fall back to the random user-agent from the UserAgent package.

## Changes

- Modified `createContext` function to accept an optional `headers` parameter
- If headers contains a `user-agent` key, use that value for the browser context's userAgent
- Remove user-agent from extra HTTP headers since it's now handled at context creation

## Fixes

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the `user-agent` header in the `/scrape` endpoint by setting the browser context `userAgent` from request headers with case-insensitive matching. Prevents `playwright` from ignoring the header set via `page.setExtraHTTPHeaders`.

- **Bug Fixes**
  - Updated `createContext` to accept an optional `customUserAgent`; otherwise fall back to a random user agent.
  - Extracted `user-agent` from request headers in `/scrape` using case-insensitive matching and passed it to `createContext`.
  - Removed `user-agent` from extra headers with case-insensitive matching and only call `page.setExtraHTTPHeaders` when other headers remain.

<sup>Written for commit 385778a3d72ad4a8f06754b5bcf3994469b0248c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

