### PR TITLE
fix(python-sdk): remove non-existent CrawlJobData from types exports

### DIFF
--- a/apps/python-sdk/firecrawl/types.py
+++ b/apps/python-sdk/firecrawl/types.py
@@ -103,7 +103,6 @@ __all__ = [
     # Crawl types
     'CrawlRequest',
     'CrawlJob',
-    'CrawlJobData',
     'CrawlResponse',
     'CrawlParamsRequest',
     'CrawlParamsData',


### PR DESCRIPTION
CrawlJobData was listed in __all__ but was never defined or imported, causing ImportError when using 'from firecrawl.types import *'

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed non-existent `CrawlJobData` from the Python SDK’s `firecrawl.types.__all__` to prevent ImportError when using `from firecrawl.types import *`. This aligns the exports with defined types and restores expected star-import behavior.

<sup>Written for commit 2902ef7e0b985a5dd58eeece9671477251508cfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

