### PR TITLE
fix: use custom user-agent from headers in playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,10 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, headers?: { [key: string]: string }) => {
+  // Use custom user-agent from headers if provided, otherwise generate a random one
+  const customUserAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,11 +254,17 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
+    // Set extra HTTP headers (excluding user-agent which is already set in context)
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      const headersWithoutUserAgent = { ...headers };
+      delete headersWithoutUserAgent['user-agent'];
+      delete headersWithoutUserAgent['User-Agent'];
+      if (Object.keys(headersWithoutUserAgent).length > 0) {
+        await page.setExtraHTTPHeaders(headersWithoutUserAgent);
+      }
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
Fixes #2802

When user-agent is provided in the headers parameter of the scrape API request, it was being ignored because playwright sets the context's user-agent before the extraHTTPHeaders are applied, and playwright ignores the user-agent key in extraHTTPHeaders when it's already set on the context.

This fix checks for user-agent in headers and uses it when creating the browser context instead of the randomly generated UserAgent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the `user-agent` from scrape API request headers when creating the `playwright` browser context, falling back to a random UA if none is provided. This fixes custom UAs being ignored and avoids duplicate UA in extra HTTP headers.

<sup>Written for commit f1bea019b6800e7f19dc515378bba7ada4fab0fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

