### PR TITLE
fix: return success for empty pages with good HTTP status code

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -433,8 +433,19 @@ async function scrapeURLLoopIter(
     // NOTE: TODO: what to do when status code is bad is tough...
     // we cannot just rely on text because error messages can be brief and not hit the limit
     // should we just use all the fallbacks and pick the one with the longest text? - mogery
-    if (isLongEnough || !isGoodStatusCode) {
-      meta.logger.info("Scrape via " + engine + " deemed successful.", {
+    
+    // If we got a successful HTTP status code, consider it a success even if content is empty.
+    // This distinguishes between actual failures (404, 500, etc.) and pages that are simply empty.
+    // Empty pages should return success with empty content, not a 500 error.
+    if (isGoodStatusCode) {
+      meta.logger.info("Scrape via " + engine + " deemed successful (good status code).", {
+        factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
+      });
+      return engineResult;
+    } else if (isLongEnough) {
+      // Fallback: if content is non-empty but status code is not 2xx, still consider it success
+      // This handles cases where servers return non-2xx status codes but still serve content
+      meta.logger.info("Scrape via " + engine + " deemed successful (content available).", {
         factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
       });
       return engineResult;


### PR DESCRIPTION
## Summary

Previously, when a webpage returned HTTP 200 but had no extractable content, Firecrawl would return a 500 error (SCRAPE_ALL_ENGINES_FAILED). This was misleading since the page was successfully accessed - it just had no content.

## Changes

This fix changes the success logic to consider a scrape successful if the HTTP status code is 2xx, even if the content is empty. Empty pages now return success with empty content instead of a 500 error.

## Fixes

Issue #2316 - Incorrect 500 Error When Scraping Empty Webpage Content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat empty pages with 2xx responses as successful scrapes to avoid misleading 500s. Empty pages now return success with empty content instead of SCRAPE_ALL_ENGINES_FAILED.

- **Bug Fixes**
  - Updated success logic in `apps/api/src/scraper/scrapeURL/index.ts`: 2xx status codes are success even if content is empty.
  - Fallback kept: if content exists but status is non-2xx, still mark as success.
  - Aligns with issue #2316: no more false 500s for empty pages.

<sup>Written for commit 41ffe9e76c736b2302de3f49bf1719c855961f02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

