### PR TITLE
fix(sdk): add webhook parameter to startExtract method (fix #2582)

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
@@ -1,4 +1,4 @@
-import { type ExtractResponse, type ScrapeOptions, type AgentOptions } from "../types";
+import { type ExtractResponse, type ScrapeOptions, type AgentOptions, type WebhookConfig } from "../types";
 import { HttpClient } from "../utils/httpClient";
 import { ensureValidScrapeOptions } from "../utils/validation";
 import { normalizeAxiosError, throwForBadResponse } from "../utils/errorHandler";
@@ -18,6 +18,7 @@ function prepareExtractPayload(args: {
   integration?: string;
   origin?: string;
   agent?: AgentOptions;
+  webhook?: string | WebhookConfig | null;
 }): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (args.urls) body.urls = args.urls;
@@ -37,6 +38,7 @@ function prepareExtractPayload(args: {
     ensureValidScrapeOptions(args.scrapeOptions);
     body.scrapeOptions = args.scrapeOptions;
   }
+  if (args.webhook != null) body.webhook = args.webhook;
   return body;
 }
 


### PR DESCRIPTION
## Summary

The `startExtract` method in the Node.js SDK was missing the `webhook` parameter in its TypeScript type definitions, even though the Firecrawl API accepts webhook configuration for extract jobs. This prevented TypeScript users from properly configuring webhooks for async extraction jobs.

## Fix

This fix adds the `webhook?: string | WebhookConfig | null` parameter to the `prepareExtractPayload` function in `apps/js-sdk/firecrawl/src/v2/methods/extract.ts`, making it consistent with other async job methods in the SDK like `crawl` and `batchScrapeUrls`.

## Changes

- Added `webhook?: string | WebhookConfig | null` to the `prepareExtractPayload` function parameter type
- Added import for `WebhookConfig` type from `../types`
- Added handling to include webhook in the request body when provided

## Testing

The SDK builds successfully with these changes.

---

**Related Issue:** #2582

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add webhook support to `startExtract` in the Node.js SDK so TypeScript users can configure webhooks for async extract jobs. Aligns the method with the API and other async job methods.

- **Bug Fixes**
  - Added `webhook?: string | WebhookConfig | null` to `prepareExtractPayload`.
  - Imported `WebhookConfig` type.
  - Included `webhook` in the request body when provided.

<sup>Written for commit 477ffc63e916584cf57f4249cb3fe8f8499591a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

