### PR TITLE
fix: use custom user-agent from headers in playwright

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customUserAgent?: string) => {
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,7 +252,8 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    const customUserAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+    requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
     if (headers) {


### PR DESCRIPTION
When user-agent is provided in scrape request headers, it was being ignored because Playwright's context-level user-agent takes precedence over extra HTTP headers.

This fix modifies createContext to accept an optional customUserAgent parameter. If provided in headers, it will be used instead of the auto-generated UserAgent package value.

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the user-agent from scrape request headers when creating the `playwright` context. createContext now accepts an optional customUserAgent and uses it if 'user-agent'/'User-Agent' is present; fixes #2802.

<sup>Written for commit be3c6b47d175667d0f0dfbf8224730bf140bd2ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

