### PR TITLE
fix: use custom user-agent from headers in playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customUserAgent?: string) => {
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,11 +252,16 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    const customUserAgent = headers?.['user-agent'];
+    requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      // Remove user-agent from extra headers since it's already set on the context
+      const { 'user-agent': _ua, ...extraHeaders } = headers;
+      if (Object.keys(extraHeaders).length > 0) {
+        await page.setExtraHTTPHeaders(extraHeaders);
+      }
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
## Summary

When user-agent is passed in the `headers` object to the scrape endpoint, it was being ignored because Playwright's `setExtraHTTPHeaders()` ignores the user-agent header when it's already set on the browser context.

## Root Cause

The `createContext` function was always using a random user-agent from the `user-agents` package, and then `setExtraHTTPHeaders()` was called with all headers including user-agent. However, Playwright ignores the user-agent header in `setExtraHTTPHeaders()` if it's already set on the context.

## Fix

1. Modified `createContext` to accept an optional `customUserAgent` parameter
2. Extract user-agent from headers before calling `setExtraHTTPHeaders()`
3. Pass custom user-agent to `createContext` so it's properly set on the browser context

## Testing

This fix ensures that when users specify a custom user-agent in the scrape request headers, it will be used for all requests made by Playwright.

Fixes #2802


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor custom User-Agent headers on /scrape by setting them on the Playwright browser context and omitting them from extra headers. Ensures the provided User-Agent is used for all requests and fixes #2802.

- **Bug Fixes**
  - Updated createContext to accept an optional customUserAgent and use it (fallback to `user-agents` when absent).
  - Extracted 'user-agent' from incoming headers, passed it to createContext, and sent only remaining headers via setExtraHTTPHeaders().

<sup>Written for commit beead42b21e30bda513a612a81d0b3eeeee2c405. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

