### PR TITLE
fix: use custom user-agent from headers in playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -257,7 +257,12 @@ app.post('/scrape', async (req: Request, res: Response) => {
     page = await requestContext.newPage();
 
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      // Filter out user-agent from headers since it's already set at context level
+      // and Playwright ignores user-agent in setExtraHTTPHeaders when set at context level
+      const filteredHeaders = { ...headers };
+      delete filteredHeaders['user-agent'];
+      delete filteredHeaders['User-Agent'];
+      await page.setExtraHTTPHeaders(filteredHeaders);
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
The user-agent specified in headers was being ignored because Playwright's
setExtraHTTPHeaders doesn't override user-agent when it's already set at
context level. This fix filters out user-agent from the extra headers
when a custom user-agent is provided, ensuring it's used correctly
at the context level.

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respects the custom `user-agent` from request headers by setting it on the `playwright` context and stripping it from extra headers so it isn’t ignored (fixes #2802). Ensures target sites see the intended user agent.

- **Bug Fixes**
  - Pass the header’s user agent into context creation (fallback to generated UA if none).
  - Remove `user-agent` from `page.setExtraHTTPHeaders` to avoid context-level override conflicts.

<sup>Written for commit 12884b91481d358197fdcaa8bb65617fe92fece0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

