### PR TITLE
fix: use custom user-agent from headers in Playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,10 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, headers?: { [key: string]: string }) => {
+  // Extract user-agent from headers if provided, otherwise use default
+  const customUserAgent = headers?.['user-agent'];
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,7 +254,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
     if (headers) {


### PR DESCRIPTION
When calling the scrape endpoint with headers.user-agent, the value was being ignored because Playwright sets the context's user-agent first (from UserAgent package), and then when setExtraHTTPHeaders is called, Playwright ignores the user-agent header since it's already set on the context.

This fix extracts the user-agent from headers (if provided) and uses it when creating the Playwright context instead of the default random UserAgent package value.

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the incoming `user-agent` header in the scrape endpoint by setting it on the `playwright` context instead of via extra HTTP headers. Fixes #2802.

- **Bug Fixes**
  - Extract `user-agent` from request headers and use it to initialize the browser context; fall back to a generated value if missing.
  - Update `createContext` to accept `headers` and pass them from `/scrape`, preventing `setExtraHTTPHeaders` from being ignored for `user-agent`.

<sup>Written for commit e7370884e8b804bc4dd285af936c0007530fa51a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

