### PR TITLE
fix: use custom user-agent from headers in Playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,10 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, headers?: { [key: string]: string }) => {
+  // Use custom user-agent from headers if provided, otherwise generate a random one
+  const customUserAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,11 +254,17 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
+    // Set extra HTTP headers (excluding user-agent which is already set in context)
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      const headersWithoutUserAgent = { ...headers };
+      delete headersWithoutUserAgent['user-agent'];
+      delete headersWithoutUserAgent['User-Agent'];
+      if (Object.keys(headersWithoutUserAgent).length > 0) {
+        await page.setExtraHTTPHeaders(headersWithoutUserAgent);
+      }
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
When user-agent is provided in headers, it was being ignored because playwright sets context's user-agent before extraHTTPHeaders, and playwright ignores user-agent in extraHTTPHeaders.

This fix checks for user-agent in headers and uses it when creating the browser context instead of the randomly generated one.

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use request `user-agent` header when creating the `playwright` browser context so it isn’t ignored, falling back to a generated UA if none is provided.

- **Bug Fixes**
  - Read `user-agent`/`User-Agent` from request headers and set it in the context.
  - Remove `user-agent` from `page.setExtraHTTPHeaders`; send only other headers.
  - Default to a random UA when no header is provided.

<sup>Written for commit bf61b75a0e593297db5c48a500b178937b7ecabc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

