### PR TITLE
fix: properly handle user-agent in scrape headers (Issue #2802)

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -256,7 +256,9 @@ app.post('/scrape', async (req: Request, res: Response) => {
     page = await requestContext.newPage();
 
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      // Filter out user-agent since it's already set at context level in createContext
+      const { 'user-agent': _, ...headersWithoutUserAgent } = headers;
+      await page.setExtraHTTPHeaders(headersWithoutUserAgent);
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
## Description

The user-agent header was being ignored because Playwright filters out user-agent from `setExtraHTTPHeaders` when it's already set at the context level (in `createContext`). 

## Fix

This fix filters out user-agent from the headers passed to `setExtraHTTPHeaders` since it's already handled in `createContext`.

## Changes

- In `apps/playwright-service-ts/api.ts`, when calling `setExtraHTTPHeaders`, we now filter out the user-agent header since it's already set at the browser context level.

## Testing

- TypeScript compiles without errors
- This fix addresses issue #2802

---
Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ignored User-Agent on scrape requests by removing `user-agent` from headers passed to `page.setExtraHTTPHeaders`, since it’s already set in `createContext`. Ensures the context-defined User-Agent is applied consistently and fixes #2802.

<sup>Written for commit 1c1242c277d93d9183a0af42ec6af1596b23e57a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

