### PR TITLE
fix: remove www prefix from URL in map search query

### DIFF
--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -198,7 +198,7 @@ export async function getMapResults({
         ? `${search} ${urlWithoutWww}`
         : search
           ? `${search} site:${urlWithoutWww}`
-          : `site:${url}`;
+          : `site:${urlWithoutWww}`;
 
     const resultsPerPage = 100;
     const maxPages = Math.ceil(


### PR DESCRIPTION
When calling the map endpoint with a URL that starts with 'www.', the search query was incorrectly using the original URL instead of the URL without 'www.'. This caused the map function to return empty results for URLs like 'https://www.example.com' because the search engine would look for 'site:https://www.example.com' instead of 'site:example.com'.

Fixes #2580

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the URL without the "www." prefix for site: queries in the map endpoint, so domains like https://www.example.com return results. The fallback branch now uses the normalized domain (fixes #2580).

<sup>Written for commit 4d2efda3e00435986d1da1b5dcc632deac4b4a16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

