### PR TITLE
fix: always include creditsUsed field in agent status response

### DIFF
--- a/apps/api/src/controllers/v2/agent-status.ts
+++ b/apps/api/src/controllers/v2/agent-status.ts
@@ -87,6 +87,6 @@ export async function agentStatusController(
       new Date(agent?.created_at ?? agentRequest.created_at).getTime() +
         1000 * 60 * 60 * 24,
     ).toISOString(),
-    creditsUsed: agent?.credits_cost,
+    creditsUsed: agent?.credits_cost ?? null,
   });
 }


### PR DESCRIPTION
When agent is still processing, credits_cost is null. Previously this would result in the creditsUsed field being omitted from the response entirely. Now we explicitly set it to null so the field is always present, matching the API documentation.

Fixes #2891

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the v2 agent status API always returns the `creditsUsed` field. When the agent is still processing, we now return `creditsUsed: null` instead of omitting the field to match the API docs and keep the response shape stable.

<sup>Written for commit 6a92bceb535d68043e1d25be36230eed008850a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

