### PR TITLE
fix: use custom user-agent from headers in playwright service

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customUserAgent?: string) => {
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,11 +252,17 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    // Extract custom user-agent from headers if provided
+    const customUserAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+    requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
+    // Set extra HTTP headers excluding user-agent (already handled at context level)
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      const { 'user-agent': _ua, 'User-Agent': _UA, ...restHeaders } = headers;
+      if (Object.keys(restHeaders).length > 0) {
+        await page.setExtraHTTPHeaders(restHeaders);
+      }
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
When custom user-agent is provided in headers, use it at the context level instead of letting setExtraHTTPHeaders ignore it. This fixes the bug where the user-agent value from scrape API headers was not being used.

Issue: #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the scrape API respects a provided custom user-agent by setting it at the Playwright context level. Prevents the header-based user-agent from being ignored and improves site compatibility.

- **Bug Fixes**
  - Read `user-agent`/`User-Agent` from request headers and pass it to `createContext`.
  - Exclude `user-agent` from `page.setExtraHTTPHeaders` since it’s handled by the context.
  - Fallback to a generated user-agent when none is provided.

<sup>Written for commit a3cb18c6e29c52bec4363d47e3ac46b2f6b67b3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

