### PR TITLE
fix: use custom user-agent from headers in playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customUserAgent?: string) => {
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,11 +252,17 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    // Extract custom user-agent from headers if provided
+    const customUserAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+    requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
+    // Set extra HTTP headers excluding user-agent (already handled at context level)
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      const { 'user-agent': _ua, 'User-Agent': _UA, ...restHeaders } = headers;
+      if (Object.keys(restHeaders).length > 0) {
+        await page.setExtraHTTPHeaders(restHeaders);
+      }
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
When calling the scrape endpoint with a custom user-agent in the headers, the value was being ignored because Playwright sets the user-agent at the context level and then ignores the user-agent header when setExtraHTTPHeaders is called.

This fix extracts the custom user-agent from headers before setting extra headers and passes it to createContext so it can be used at the browser context level.

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect custom User-Agent on the `/scrape` endpoint by setting it at the Playwright context level and excluding it from per-page extra headers. Ensures the provided UA is used instead of being ignored. Fixes #2802.

- **Bug Fixes**
  - Extract `user-agent` from request headers and pass it to `createContext` (fallback to a generated UA when absent).
  - Remove `user-agent` from `setExtraHTTPHeaders` to avoid Playwright overriding it.

<sup>Written for commit ae4d6fb61410e563d1fd49460c10fe96588ee3d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

