### PR TITLE
fix: use user-agent from headers in playwright context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,10 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, headers?: { [key: string]: string }) => {
+  // Use user-agent from headers if provided, otherwise generate a random one
+  const userAgentFromHeaders = headers?.['user-agent'] || headers?.['User-Agent'];
+  const userAgent = userAgentFromHeaders || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,11 +254,15 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      // Remove user-agent from headers since it's already set at context level
+      const { 'user-agent': _, 'User-Agent': __, ...filteredHeaders } = headers;
+      if (Object.keys(filteredHeaders).length > 0) {
+        await page.setExtraHTTPHeaders(filteredHeaders);
+      }
     }
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);


### PR DESCRIPTION
When calling the scrape endpoint with headers.user-agent, the value was
ignored because Playwright sets the user-agent at context level before
setExtraHTTPHeaders is called, which causes it to be ignored.

This fix:
1. Extracts user-agent from headers if provided
2. Uses it in the context creation instead of a random UserAgent
3. Filters out user-agent from extraHTTPHeaders since it's already set
   at context level

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the request’s user-agent by setting it at the Playwright context level and filtering it from extra headers. Fixes #2802.

- **Bug Fixes**
  - Read `user-agent`/`User-Agent` from request headers and apply it when creating the context.
  - Remove the user-agent from `page.setExtraHTTPHeaders` since it’s already set in the context.
  - Fallback to a generated user-agent when none is provided.

<sup>Written for commit a2fe353f5142e2811b9d4c51a36aed56b8863607. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

