### PR TITLE
fix: return creditsUsed during agent job lifecycle

### DIFF
--- a/apps/api/src/controllers/v2/agent-status.ts
+++ b/apps/api/src/controllers/v2/agent-status.ts
@@ -26,6 +26,8 @@ export async function agentStatusController(
   const agent = await supabaseGetAgentByIdDirect(req.params.jobId);
 
   let model: "spark-1-pro" | "spark-1-mini";
+  let creditsUsed: number | undefined = agent?.credits_cost ?? undefined;
+
   if (agent) {
     model = (agent.options?.model ?? "spark-1-pro") as
       | "spark-1-pro"
@@ -53,9 +55,14 @@ export async function agentStatusController(
         });
         model = "spark-1-pro"; // fall back to this value
       } else {
-        model = ((await optionsRequest.json()).model ?? "spark-1-pro") as
+        const optionsData = await optionsRequest.json();
+        model = (optionsData.model ?? "spark-1-pro") as
           | "spark-1-pro"
           | "spark-1-mini";
+        // Get credits from external service if available
+        if (optionsData.creditsUsed !== undefined) {
+          creditsUsed = optionsData.creditsUsed;
+        }
       }
     } catch (error) {
       logger.warn("Failed to get agent request details", {
@@ -65,6 +72,37 @@ export async function agentStatusController(
         extractId: req.params.jobId,
       });
       model = "spark-1-pro"; // fall back to this value
+    }
+  }
+
+  // If agent exists but credits_cost is not set, try to get credits from external service
+  if (agent && creditsUsed === undefined && config.EXTRACT_V3_BETA_URL) {
+    try {
+      const optionsRequest = await fetch(
+        config.EXTRACT_V3_BETA_URL +
+          "/v2/extract/" +
+          req.params.jobId +
+          "/options",
+        {
+          headers: {
+            Authorization: `Bearer ${config.AGENT_INTEROP_SECRET}`,
+          },
+        },
+      );
+
+      if (optionsRequest.status === 200) {
+        const optionsData = await optionsRequest.json();
+        if (optionsData.creditsUsed !== undefined) {
+          creditsUsed = optionsData.creditsUsed;
+        }
+      }
+    } catch (error) {
+      logger.warn("Failed to get credits from external service", {
+        error,
+        method: "agentStatusController",
+        module: "api/v2",
+        extractId: req.params.jobId,
+      });
     }
   }
 
@@ -87,6 +125,6 @@ export async function agentStatusController(
       new Date(agent?.created_at ?? agentRequest.created_at).getTime() +
         1000 * 60 * 60 * 24,
     ).toISOString(),
-    creditsUsed: agent?.credits_cost,
+    creditsUsed,
   });
 }

--- a/apps/api/src/controllers/v2/extract-status.ts
+++ b/apps/api/src/controllers/v2/extract-status.ts
@@ -53,6 +53,40 @@ export async function extractStatusController(
         data = await getJobFromGCS(agent.id);
       }
 
+      let creditsUsed: number | undefined = agent?.credits_cost ?? undefined;
+
+      // If agent exists but credits_cost is not set, or agent doesn't exist,
+      // try to get credits from external service
+      if (creditsUsed === undefined && config.EXTRACT_V3_BETA_URL) {
+        try {
+          const optionsRequest = await fetch(
+            config.EXTRACT_V3_BETA_URL +
+              "/v2/extract/" +
+              req.params.jobId +
+              "/options",
+            {
+              headers: {
+                Authorization: `Bearer ${config.AGENT_INTEROP_SECRET}`,
+              },
+            },
+          );
+
+          if (optionsRequest.status === 200) {
+            const optionsData = await optionsRequest.json();
+            if (optionsData.creditsUsed !== undefined) {
+              creditsUsed = optionsData.creditsUsed;
+            }
+          }
+        } catch (error) {
+          _logger.warn("Failed to get credits from external service", {
+            error,
+            method: "extractStatusController",
+            module: "api/v2",
+            extractId: req.params.jobId,
+          });
+        }
+      }
+
       return res.status(200).json({
         success: true,
         status: !agent
@@ -66,7 +100,7 @@ export async function extractStatusController(
           new Date(agent?.created_at ?? extractRequest.created_at).getTime() +
             1000 * 60 * 60 * 24,
         ).toISOString(),
-        creditsUsed: agent?.credits_cost,
+        creditsUsed,
       });
     }
   }


### PR DESCRIPTION
## Summary

Fixes the agent status endpoint to return `creditsUsed` at all stages of the job lifecycle, not just when complete.

## Changes

- Updated `agent-status.ts` to query the external agent service for credits when the agent is processing
- Updated `extract-status.ts` to also query for credits when handling agent jobs
- Both endpoints now attempt to get `creditsUsed` from the external service options endpoint when the database value is not available

## Problem

When polling the Get Agent Status endpoint (GET /v1/agent/{agentId}) while an agent job is in progress, the `creditsUsed` attribute was never included in the response. It only appeared once the agent job reached status=complete.

## Solution

The fix queries the external agent service for credits when:
1. The agent record does not exist yet (job is processing)
2. The agent record exists but `credits_cost` is not set

The external service is queried via the `/v2/extract/{id}/options` endpoint, which already returns model information. This PR extends it to also check for `creditsUsed` in the response.

## Testing

- Verified the fix returns creditsUsed at all job stages
- Maintains backward compatibility - if the external service does not provide credits, the behavior is unchanged

Fixes firecrawl/firecrawl#2891

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return creditsUsed across the entire agent job lifecycle by fetching it from the external extract options endpoint when the database value is missing. Applies to both agent status and extract status responses.

- **Bug Fixes**
  - Both `agent-status` and `extract-status` query `/v2/extract/{id}/options` for `creditsUsed` when `credits_cost` is absent or the agent record isn’t created yet.
  - Responses now include `creditsUsed` for queued, processing, and completed jobs; falls back gracefully if the external service doesn’t return credits.
  - Adds warning logs on fetch failures; existing model fallback behavior remains unchanged.

<sup>Written for commit 219d86f46a5312019f3e0dc0740329fa40b3a841. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

