### PR TITLE
fix(test-site): resolve devalue security vulnerabilities

### DIFF
--- a/apps/test-site/package.json
+++ b/apps/test-site/package.json
@@ -24,6 +24,9 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "devalue": ">=5.6.4"
+    }
   }
 }

--- a/apps/test-site/pnpm-lock.yaml
+++ b/apps/test-site/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  devalue: '>=5.6.4'
+
 importers:
 
   .:
@@ -954,8 +957,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.6.3:
-    resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
+  devalue@5.6.4:
+    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -2495,7 +2498,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.6.3
+      devalue: 5.6.4
       diff: 8.0.3
       dlv: 1.1.3
       dset: 3.1.4
@@ -2682,7 +2685,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.6.3: {}
+  devalue@5.6.4: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Override `devalue` to `>=5.6.4` in test-site to fix GHSA-cfw5-2vxh-hr84 and GHSA-mwv9-gp5h-frr84 audit failures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `devalue` to >=5.6.4 in `apps/test-site` to patch known vulnerabilities and stop security audits from failing (GHSA-cfw5-2vxh-hr84, GHSA-mwv9-gp5h-frr4).

- **Dependencies**
  - Added override for `devalue` >=5.6.4 in `package.json`.
  - Updated lockfile to resolve `devalue@5.6.4`.

<sup>Written for commit 1e731b3805a6cde1ff7015d99ae054d538dd8a9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

