### PR TITLE
fix: typo in playwright engine comment

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -37,7 +37,7 @@ export async function scrapeURLWithPlaywright(
   }
 
   return {
-    url: meta.rewrittenUrl ?? meta.url, // TODO: impove redirect following
+    url: meta.rewrittenUrl ?? meta.url, // TODO: improve redirect following
     html: response.content,
     statusCode: response.pageStatusCode,
     error: response.pageError,


### PR DESCRIPTION
## Summary
Minor typo fix in the Playwright scraper engine.

## Changes
- Fixed typo: `impove` -> `improve` in TODO comment

## Files Changed
- `apps/api/src/scraper/scrapeURL/engines/playwright/index.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in a TODO comment in the Playwright scraper engine to improve readability. Changed "impove" to "improve" in apps/api/src/scraper/scrapeURL/engines/playwright/index.ts.

<sup>Written for commit a65557cf1b1404c885700a116f4d2622e84eb87a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

