### PR TITLE
fix(python-sdk): add rate limit retry mechanism for 429 errors (#3114)

### DIFF
--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -98,6 +98,21 @@ class HttpClient:
                     timeout=timeout
                 )
 
+                # Handle 429 Rate Limit - parse Retry-After header and wait
+                if response.status_code == 429:
+                    if attempt < num_attempts - 1:
+                        retry_after = response.headers.get('Retry-After')
+                        if retry_after:
+                            try:
+                                wait_time = float(retry_after)
+                            except (ValueError, TypeError):
+                                wait_time = backoff_factor * (2 ** attempt)
+                        else:
+                            wait_time = backoff_factor * (2 ** attempt)
+                        time.sleep(wait_time)
+                        continue
+
+                # Handle 502 Bad Gateway - retry with backoff
                 if response.status_code == 502:
                     if attempt < num_attempts - 1:
                         time.sleep(backoff_factor * (2 ** attempt))
@@ -145,6 +160,21 @@ class HttpClient:
                     timeout=timeout
                 )
 
+                # Handle 429 Rate Limit - parse Retry-After header and wait
+                if response.status_code == 429:
+                    if attempt < num_attempts - 1:
+                        retry_after = response.headers.get('Retry-After')
+                        if retry_after:
+                            try:
+                                wait_time = float(retry_after)
+                            except (ValueError, TypeError):
+                                wait_time = backoff_factor * (2 ** attempt)
+                        else:
+                            wait_time = backoff_factor * (2 ** attempt)
+                        time.sleep(wait_time)
+                        continue
+
+                # Handle 502 Bad Gateway - retry with backoff
                 if response.status_code == 502:
                     if attempt < num_attempts - 1:
                         time.sleep(backoff_factor * (2 ** attempt))
@@ -192,6 +222,21 @@ class HttpClient:
                     timeout=timeout
                 )
 
+                # Handle 429 Rate Limit - parse Retry-After header and wait
+                if response.status_code == 429:
+                    if attempt < num_attempts - 1:
+                        retry_after = response.headers.get('Retry-After')
+                        if retry_after:
+                            try:
+                                wait_time = float(retry_after)
+                            except (ValueError, TypeError):
+                                wait_time = backoff_factor * (2 ** attempt)
+                        else:
+                            wait_time = backoff_factor * (2 ** attempt)
+                        time.sleep(wait_time)
+                        continue
+
+                # Handle 502 Bad Gateway - retry with backoff
                 if response.status_code == 502:
                     if attempt < num_attempts - 1:
                         time.sleep(backoff_factor * (2 ** attempt))


### PR DESCRIPTION
## Summary

Fixes #3114 - Concurrent scraping rate limit not properly handled causing 429 errors

## Problem

When using the Python SDK for batch scraping with high concurrency, the SDK immediately raises RateLimitError on 429 responses without any retry logic.

## Changes

- Parse Retry-After header from 429 responses
- Implement exponential backoff retry logic
- Apply to POST, GET, DELETE methods
- Default: 3 retries with 0.5s backoff factor

## Testing

Docker sandbox test passed - verified 429 handling in all HTTP methods

## Impact

- Backward compatible
- Automatic retry on 429 errors
- Respects server Retry-After header
- Configurable max_retries and backoff_factor

Fixes #3114

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic 429 rate limit retries to the Python SDK to address #3114. Prevents fast-fail during high-concurrency scraping by waiting and retrying.

- **Bug Fixes**
  - Retries 429s on POST/GET/DELETE with exponential backoff (default 3 tries, 0.5s factor).
  - Honors Retry-After when present; falls back to backoff if missing or invalid.
  - Configurable via max_retries and backoff_factor; backward compatible.

<sup>Written for commit c69dc265ed7b7fcae98fdbfe404d2a5641a7bcc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

