### PR TITLE
fix: correct time_taken calculation in v1 map endpoint

### DIFF
--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -123,6 +123,7 @@ export async function getMapResults({
   headers?: Record<string, string>;
   id?: string;
 }): Promise<MapResult> {
+  const functionStartTime = Date.now();
   const id = providedId ?? uuidv7();
   let links: string[] = [url];
   let mapResults: MapDocument[] = [];
@@ -354,7 +355,7 @@ export async function getMapResults({
     mapResults: mapResults,
     scrape_id: origin?.includes("website") ? id : undefined,
     job_id: id,
-    time_taken: (new Date().getTime() - Date.now()) / 1000,
+    time_taken: (Date.now() - functionStartTime) / 1000,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #3165

The `time_taken` metric in the v1 `/map` endpoint (`getMapResults`) was always approximately 0 because it computed:

```ts
time_taken: (new Date().getTime() - Date.now()) / 1000
```

Both `new Date().getTime()` and `Date.now()` return the current timestamp, so their difference is ~0.

## Changes

- Capture `Date.now()` at function entry as `functionStartTime`
- Replace the broken calculation with `(Date.now() - functionStartTime) / 1000`

This matches the pattern used in the v2 map endpoint (`map-utils.ts` line 365).

## 1 file changed, 2 insertions, 1 deletion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the time_taken metric in the v1 `/map` endpoint so it reports actual elapsed seconds. Capture start time at function entry and compute `(Date.now() - functionStartTime) / 1000`, matching the v2 implementation.

<sup>Written for commit 88e210d0b5f1df93ba78065861b8cf5c6fd58409. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

