### PR TITLE
Fix flaky search scrape test assertions

### DIFF
--- a/apps/api/src/__tests__/snips/v2/search.test.ts
+++ b/apps/api/src/__tests__/snips/v2/search.test.ts
@@ -59,6 +59,8 @@ describeIf(TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY)("Search tests", () => {
         if (doc.markdown) {
           markdownCount += 1;
         } else {
+          // Search can return URLs that are not consistently scrapeable in test environments,
+          // so log the failing entries to make partial scrape failures easier to debug.
           console.warn("Search scrape result missing markdown", {
             url: doc.url,
             error: doc.metadata?.error,


### PR DESCRIPTION
## Summary
- increase the search result limit from 2 to 5 to improve the chance of getting scrapeable results
- assert that web results are returned before validating scraped content
- allow each result to pass when it contains either `markdown` or a per-result `metadata.error`, matching partial scrape failure behavior

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce flakiness in the search scrape test by increasing result count and tightening assertions to ensure at least one markdown result while still matching partial scrape behavior.

- **Bug Fixes**
  - Increase search limit from 2 to 5 to find more scrapeable results.
  - Assert `res.web` exists and is non-empty; require at least one result with `markdown`.
  - Accept per-result `markdown` or `metadata.error`; log URL/error/status when `markdown` is missing.

<sup>Written for commit 0cc0bfbdfef8de77b4d5f7b34e6f6909d99cb792. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

