### PR TITLE
Update pdf-inspector to 442a169

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "c1357e7" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "442a169" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
## Summary
- Updates `pdf-inspector` dependency from `c1357e7` to `442a169`

## Changes between c1357e7 and 442a169
- `442a169` feat(layout): pre-mask spanning lines for multi-column pages
- `7c1ddd9` fix: merge consecutive struct-tree heading lines into single heading
- `d9c2143` feat: tagged PDF structure tree support (#4)
- `76ea526` feat(layout): detect sidebar annotations as newspaper columns
- `04aa6d4` feat(text): width-based joining for Canva single-char items
- `152de8b` feat(text): adaptive join threshold for Canva-style letter-spaced PDFs
- `80a3b81` perf(tables): remove cosmetic padding from markdown tables
- `ba1fbcb` fix(arabic): NFKC normalize presentation forms and reverse visual-order RTL text
- `7a0e074` feat(tables): detect dense narrow-column tables via gap-histogram analysis
- `f2e3d51` fix(tables): cap column alignment width at 40 chars to reduce whitespace bloat
- `f1b32b3` fix(fonts): prefer TrueType cmap over sequential remap for CJK subset fonts
- `cc92e55` fix: use lopdf fork with zlib checksum fallback for encrypted PDFs
- `e3990dc` feat(tables): add rect-guided calendar table builder and extractor improvements
- `6b8f4d0` test: add inline unit tests to postprocess, format, grid, and detect_rects
- `ea47095` feat(detector): recurse into Form XObjects for image detection and classify vector-text pages

## Test plan
- [ ] CI passes with updated dependency
- [ ] PDF extraction tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `pdf-inspector` to `442a169` to improve PDF extraction accuracy. Adds structure-tree support, better multi-column and table handling, and fixes for RTL/CJK text and some encrypted PDFs.

- **New Features**
  - Tagged PDF structure tree parsing for better headings and reading order.
  - Improved multi-column handling (pre-masked spanning lines, sidebar annotations as columns).
  - Stronger table extraction (gap-histogram for narrow columns, calendar table builder).

- **Bug Fixes**
  - Normalize Arabic presentation forms and reverse visual-order RTL text.
  - Prefer TrueType cmap for CJK subset fonts; reduce markdown table whitespace.
  - Use `lopdf` zlib checksum fallback for encrypted PDFs; recurse into Form XObjects for image detection.

<sup>Written for commit ada96048bad018286fea547c5b4a235eb22de42d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

