### PR TITLE
Update pdf-inspector to dcdb0a3

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "442a169" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "dcdb0a3" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -23,7 +23,10 @@ import type { PDFMode } from "../../../../controllers/v2/types";
 import { processPdf, detectPdf } from "@mendable/firecrawl-rs";
 import { MAX_FILE_SIZE, MILLISECONDS_PER_PAGE } from "./types";
 import type { PDFProcessorResult } from "./types";
-import { emitNativeLogs, extractAndEmitNativeLogs } from "../../../../lib/native-logging";
+import {
+  emitNativeLogs,
+  extractAndEmitNativeLogs,
+} from "../../../../lib/native-logging";
 import { withSpan, setSpanAttributes } from "../../../../lib/otel-tracer";
 import { scrapePDFWithRunPodMU } from "./runpodMU";
 import { scrapePDFWithParsePDF } from "./pdfParse";
@@ -157,9 +160,12 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       // When PDF_RUST_EXTRACT_ENABLE is off this is the only path taken,
       // matching current prod behaviour (detectPdf → MinerU → pdfParse).
       try {
-        const nativeCtx = { scrapeId: meta.id, url: meta.rewrittenUrl ?? meta.url };
+        const nativeCtx = {
+          scrapeId: meta.id,
+          url: meta.rewrittenUrl ?? meta.url,
+        };
         const startedAt = Date.now();
-        const detection = await withSpan("native.pdf.detect", async (span) => {
+        const detection = await withSpan("native.pdf.detect", async span => {
           const result = detectPdf(tempFilePath, nativeCtx);
           setSpanAttributes(span, {
             "native.module": "pdf",
@@ -202,10 +208,17 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     } else {
       // Rust extraction enabled (fast / auto modes).
       try {
-        const nativeCtx = { scrapeId: meta.id, url: meta.rewrittenUrl ?? meta.url };
+        const nativeCtx = {
+          scrapeId: meta.id,
+          url: meta.rewrittenUrl ?? meta.url,
+        };
         const startedAt = Date.now();
-        const pdfResult = await withSpan("native.pdf.process", async (span) => {
-          const result = processPdf(tempFilePath, maxPages ?? undefined, nativeCtx);
+        const pdfResult = await withSpan("native.pdf.process", async span => {
+          const result = processPdf(
+            tempFilePath,
+            maxPages ?? undefined,
+            nativeCtx,
+          );
           setSpanAttributes(span, {
             "native.module": "pdf",
             "native.pdf_type": result.pdfType,
@@ -248,14 +261,18 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           mode,
         });
 
-        // Only shadow-compare when Rust had a real chance at extraction.
-        // Scanned/ImageBased/Mixed PDFs are expected to produce near-zero
-        // Rust output — comparing them just adds noise to the metrics.
+        // Shadow-compare when Rust produced meaningful output but wasn't
+        // eligible for direct serving. Includes:
+        // - Ineligible TextBased (complex layouts, lower confidence)
+        // - Mixed PDFs with substantial extracted text (invisible OCR layers)
+        const charsPerPage =
+          (pdfResult.markdown?.length ?? 0) / Math.max(pdfResult.pageCount, 1);
         const shadowEligible =
           !eligible &&
           pdfResult.markdown &&
           config.PDF_SHADOW_COMPARISON_ENABLE &&
-          pdfResult.pdfType === "TextBased";
+          (pdfResult.pdfType === "TextBased" ||
+            (pdfResult.pdfType === "Mixed" && charsPerPage >= 200));
 
         rustMarkdownForShadow = shadowEligible ? pdfResult.markdown : undefined;
         if (shadowEligible) {


### PR DESCRIPTION
## Summary

- Update pdf-inspector rev `442a169` → `dcdb0a3`
- Expand shadow comparison to include Mixed PDFs with substantial extracted text (≥200 chars/page)

### pdf-inspector changes since last update

- **feat: extract invisible OCR text layer from Mixed/template PDFs** — scanned PDFs with OCR text layers (rendering mode 3) now have their invisible text extracted. Two-pass approach: normal extraction first, falls back to invisible text if result is garbage/empty. 97% char similarity vs Mistral OCR on an 80-page scanned document, extracted in ~100ms vs ~7s for Mistral.

- **fix(detect): classify tiled scans with garbage OCR as Scanned** — PDFs with JBIG2/tiled image strips where no single tile exceeds the template threshold but aggregate area does (≥2M pixels) now correctly detected. Mixed PDFs with <50% alphanumeric text upgraded to Scanned.

- **fix(detect): detect images embedded in Pattern resources** — screenshot PDFs (e.g. Chrome "Save as PDF") embed images inside tiling Patterns rather than XObject images. Now traverses Pattern resources during detection.

- **fix(postprocess): collapse consecutive spaces** — OCR text layers emit trailing spaces per word. Now collapses double spaces across all output.

### Shadow comparison change

Expanded shadow eligibility to include Mixed PDFs that extract ≥200 chars/page. These are PDFs with invisible OCR layers that produce substantial text. Previously only ineligible TextBased PDFs were shadow-compared. **Eligibility gate for direct serving is unchanged** — only simple TextBased PDFs are served via Rust extraction.

## Test plan

- [ ] Verify shadow comparison fires for Mixed PDFs with OCR text layers
- [ ] Verify eligibility gate unchanged: only simple TextBased served directly
- [ ] Verify Scanned/ImageBased PDFs still throw PDFOCRRequiredError in fast mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `pdf-inspector` and expands shadow comparison to Mixed PDFs with substantial extracted text, improving OCR coverage and comparison metrics without changing direct-serve rules.

- **Dependencies**
  - Update `pdf-inspector`.
  - Extract invisible OCR text in Mixed/template PDFs when normal text is poor or empty.
  - Improve scan detection (tiled JBIG2 scans; images in Pattern resources).
  - Collapse consecutive spaces in extracted text.

- **Behavior**
  - Shadow-compare Mixed PDFs when extracted text ≥200 chars/page.
  - Direct serving unchanged: only simple TextBased PDFs use Rust output.

<sup>Written for commit 75a457b222b3e3af3dea6ec62fda4d25acedbd7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

