### PR TITLE
fix: resolve h3 audit vulnerabilities in test-site

### DIFF
--- a/apps/test-site/package.json
+++ b/apps/test-site/package.json
@@ -27,7 +27,8 @@
     ],
     "overrides": {
       "fast-xml-parser": "^5.5.6",
-      "devalue": ">=5.6.4"
+      "devalue": ">=5.6.4",
+      "h3": ">=1.15.6"
     }
   }
 }

--- a/apps/test-site/pnpm-lock.yaml
+++ b/apps/test-site/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   fast-xml-parser: ^5.5.6
   devalue: '>=5.6.4'
+  h3: '>=1.15.6'
 
 importers:
 
@@ -1094,8 +1095,8 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
-  h3@1.15.5:
-    resolution: {integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==}
+  h3@1.15.8:
+    resolution: {integrity: sha512-iOH6Vl8mGd9nNfu9C0IZ+GuOAfJHcyf3VriQxWaSWIB76Fg4BnFuk4cxBxjmQSSxJS664+pgjP6e7VBnUzFfcg==}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -2878,7 +2879,7 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
-  h3@1.15.5:
+  h3@1.15.8:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.5
@@ -4023,7 +4024,7 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 5.0.0
       destr: 2.0.5
-      h3: 1.15.5
+      h3: 1.15.8
       lru-cache: 11.2.6
       node-fetch-native: 1.6.7
       ofetch: 1.5.1


### PR DESCRIPTION
## Summary
- Override h3 to `>=1.15.6` in test-site to fix GHSA-22cc-p3c6-wpvm and GHSA-wr4h-v87w-p3r7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `h3` to `>=1.15.6` in `apps/test-site` to resolve audit advisories GHSA-22cc-p3c6-wpvm and GHSA-wr4h-v87w-p3r7. Clears security alerts with no runtime changes expected.

- **Dependencies**
  - Added `h3: ">=1.15.6"` override in `apps/test-site/package.json`.
  - Updated lockfile to resolve `h3` to `1.15.8`.

<sup>Written for commit 9ac01b2ca3b244ad44847675d7ea4e0cada2d629. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

