### PR TITLE
fix: sync test-suite lockfile overrides with package.json

### DIFF
--- a/apps/test-suite/pnpm-lock.yaml
+++ b/apps/test-suite/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-xml-parser: ^5.3.8
+  fast-xml-parser: ^5.5.6
   minimatch@<10.2.3: '>=10.2.3'
   undici: ^7.24.1
 


### PR DESCRIPTION
The fast-xml-parser override was bumped from ^5.3.8 to ^5.5.6 in package.json but the lockfile wasn't regenerated, causing pnpm install --frozen-lockfile to fail with
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH. This has been breaking the Spring sandbox image build since March 13.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/firecrawl/firecrawl/pull/3183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
