### PR TITLE
ci: add frozen-lockfile check for test-suite

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -188,10 +188,6 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: apps/test-site
 
-      - name: Install test suite dependencies
-        run: pnpm install --frozen-lockfile
-        working-directory: apps/test-suite
-
       - name: Build + serve test site
         run: |
           pnpm build

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -1,0 +1,23 @@
+name: Validate Lockfiles
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "apps/test-suite/package.json"
+      - "apps/test-suite/pnpm-lock.yaml"
+
+jobs:
+  validate:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Validate test-suite lockfile
+        run: pnpm install --frozen-lockfile
+        working-directory: apps/test-suite


### PR DESCRIPTION
Adds `pnpm install --frozen-lockfile` for `apps/test-suite` in CI, matching what we already do for `apps/api` and `apps/test-site`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dedicated lockfile validation workflow for `apps/test-suite`. It runs `pnpm install --frozen-lockfile` on PRs that touch `apps/test-suite` to enforce lockfile sync and prevent drift, matching `apps/api` and `apps/test-site`.

<sup>Written for commit 689bce8aaccc3a55b58a3f303453b36ab6489472. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

