### PR TITLE
Update pdf-inspector to 967b70a

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "dcdb0a3" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "967b70a" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
## Summary
- Updates `pdf-inspector` from `dcdb0a3` to `967b70a`

## Changes included (dcdb0a3..967b70a)
- [`967b70a`](https://github.com/firecrawl/pdf-inspector/commit/967b70a) fix: suppress markdown when all pages have gid-encoded fonts
- [`587c4be`](https://github.com/firecrawl/pdf-inspector/commit/587c4be) feat(detect): flag Identity-H fonts without ToUnicode for OCR ([pdf-inspector#7](https://github.com/firecrawl/pdf-inspector/pull/7))
- [`57560f1`](https://github.com/firecrawl/pdf-inspector/commit/57560f1) feat(tables): column-based table detection for borderless layouts
- [`74d416e`](https://github.com/firecrawl/pdf-inspector/commit/74d416e) feat(detect): flag pages with gid-encoded fonts for OCR
- [`da8c27f`](https://github.com/firecrawl/pdf-inspector/commit/da8c27f) perf: cap cluster_rects component size to avoid O(n²) on vector-heavy pages ([pdf-inspector#6](https://github.com/firecrawl/pdf-inspector/pull/6))
- [`e5a048f`](https://github.com/firecrawl/pdf-inspector/commit/e5a048f) feat(tables): recover label columns for numeric-only tables
- [`e6adb29`](https://github.com/firecrawl/pdf-inspector/commit/e6adb29) feat(tables): generate hint regions from failed rect clusters