### PR TITLE
fix(api): correct time_taken calculation in v1 /map endpoint

### DIFF
--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -123,6 +123,7 @@ export async function getMapResults({
   headers?: Record<string, string>;
   id?: string;
 }): Promise<MapResult> {
+  const functionStartTime = Date.now();
   const id = providedId ?? uuidv7();
   let links: string[] = [url];
   let mapResults: MapDocument[] = [];
@@ -354,7 +355,7 @@ export async function getMapResults({
     mapResults: mapResults,
     scrape_id: origin?.includes("website") ? id : undefined,
     job_id: id,
-    time_taken: (new Date().getTime() - Date.now()) / 1000,
+    time_taken: (Date.now() - functionStartTime) / 1000,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #3165

The `time_taken` metric in the v1 `/map` endpoint was always returning approximately 0, regardless of actual request duration.

## Root Cause

The calculation was:
```ts
time_taken: (new Date().getTime() - Date.now()) / 1000,
```

Both `new Date().getTime()` and `Date.now()` return the current timestamp in milliseconds at the moment they are called. Since they execute on the same line within microseconds of each other, the difference is always ~0.

## Fix

Capture the start timestamp at the beginning of the `getMapResults` function and use it in the subtraction:

```ts
const functionStartTime = Date.now();
// ... function logic ...
time_taken: (Date.now() - functionStartTime) / 1000,
```

This follows the same pattern used in the v2 map endpoint (`apps/api/src/lib/map-utils.ts`).

## Testing

- The fix is straightforward and follows the existing v2 pattern
- No behavioral changes other than correct timing values

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `time_taken` in v1 `/map` to report actual request duration instead of ~0 by measuring elapsed time across the full `getMapResults` execution.

- **Bug Fixes**
  - Capture a start timestamp at `getMapResults` entry and compute `(Date.now() - start) / 1000` on return.
  - Aligns with v2 timing logic; no other behavior changes.

<sup>Written for commit 9ee9f1f68bac5851f366705a6a70370123751674. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

