### PR TITLE
feat(api): add USE_RESPONSES_ENDPOINT env var for OpenAI-compatible proxies

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -195,6 +195,7 @@ const configSchema = z.object({
   MODEL_EMBEDDING_NAME: z.string().optional(),
   OLLAMA_BASE_URL: z.string().optional(),
   VERTEX_CREDENTIALS: z.string().optional(),
+  USE_RESPONSES_ENDPOINT: z.stringbool().default(true),
 
   // Rate Limiting
   RATE_LIMIT_TEST_API_KEY_SCRAPE: z.coerce.number().optional(),

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -59,7 +59,8 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
   }
   const modelName = config.MODEL_NAME || name;
   // o3-mini returns empty text via the Responses API — force Chat Completions
-  if (provider === "openai" && modelName.startsWith("o3-mini")) {
+  // Also use Chat Completions when USE_RESPONSES_ENDPOINT is false (for OpenAI-compatible proxies)
+  if (provider === "openai" && (modelName.startsWith("o3-mini") || !config.USE_RESPONSES_ENDPOINT)) {
     return providerList.openai.chat(modelName);
   }
   return providerList[provider](modelName);


### PR DESCRIPTION
## Summary

Fixes #3169

When self-hosting Firecrawl with OpenAI-compatible proxies (Azure OpenAI, LiteLLM, vLLM, etc.), AI features like `/extract` fail with 404 errors because these providers only implement the Chat Completions API (`/v1/chat/completions`), not the Responses API (`/v1/responses`).

## Root Cause

Since `@ai-sdk/openai` v2+ (AI SDK 5), calling `provider(modelName)` defaults to the Responses API. The existing code only had a special case for `o3-mini` models, but no way for users to opt out of the Responses API.

## Solution

Add a new `USE_RESPONSES_ENDPOINT` environment variable:
- **Default**: `true` (use Responses API, current behavior)
- **When set to `false`**: Force the OpenAI provider to use the Chat Completions API

## Usage

For self-hosted deployments with OpenAI-compatible proxies:

```bash
USE_RESPONSES_ENDPOINT=false
```

## Changes

1. **`apps/api/src/config.ts`**: Added `USE_RESPONSES_ENDPOINT` config option with `stringbool` type (defaults to `true`)
2. **`apps/api/src/lib/generic-ai.ts`**: Extended the condition in `getModel()` to use `.chat()` when `USE_RESPONSES_ENDPOINT` is false

## Testing

- Minimal, targeted change
- Backward compatible (defaults to existing behavior)
- Follows existing pattern for `o3-mini` special case

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `USE_RESPONSES_ENDPOINT` env var to switch the OpenAI provider between Responses and Chat Completions, fixing 404s with Azure OpenAI, LiteLLM, vLLM, and other OpenAI-compatible proxies. Default stays Responses; set it to false to use `/v1/chat/completions`. Fixes #3169.

- **Migration**
  - For self-hosted setups using OpenAI-compatible proxies, set USE_RESPONSES_ENDPOINT=false.

<sup>Written for commit a16b7bdc2052886501aca1e2a911412a79669b6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

