### PR TITLE
Pass scrape_id to self-hosted OCR experiment

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
@@ -56,6 +56,7 @@ export function runSelfHostedOCRExperiment(
           : undefined,
         body: {
           pdf: base64Content,
+          scrape_id: meta.id,
           ...(maxPages !== undefined && { max_pages: maxPages }),
         },
         logger,


### PR DESCRIPTION
## Summary
- Include `scrape_id` in the request body sent to the self-hosted OCR endpoint so results can be correlated back to specific scrapes.

## Test plan
- [ ] Deploy and verify OCR endpoint receives `scrape_id` in request payload

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send `scrape_id` in the self-hosted OCR request body so results can be linked to the originating scrape. The payload now includes `scrape_id` alongside `pdf` (and optional `max_pages`).

<sup>Written for commit 5797b6665c4d8a7f597cbc6051595094a30c94ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

