### PR TITLE
Add pages processed and per-page latency to selfHostedOCR logs

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
@@ -216,6 +216,7 @@ export async function scrapePDFWithRunPodMU(
         base64Content,
         { markdown: result.markdown, durationMs },
         maxPages,
+        pagesProcessed,
       );
     }
   }

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
@@ -35,6 +35,7 @@ export function runSelfHostedOCRExperiment(
   base64Content: string,
   muV1Result: { markdown: string; durationMs: number },
   maxPages?: number,
+  pagesProcessed?: number,
 ): void {
   if (
     !config.PDF_OCR_EXPERIMENT_ENABLE ||
@@ -63,12 +64,14 @@ export function runSelfHostedOCRExperiment(
         schema: z.object({
           markdown: z.string(),
           failed_pages: z.array(z.number()).nullable(),
+          pages_processed: z.number().optional(),
         }),
         mock: meta.mock,
         abort: meta.abort.asSignal(),
       });
       const ocrDurationMs = Date.now() - startedAt;
       const similarity = wordSimilarity(resp.markdown, muV1Result.markdown);
+      const pages = resp.pages_processed ?? pagesProcessed;
 
       logger.info("Self-hosted OCR experiment completed", {
         scrapeId: meta.id,
@@ -79,6 +82,9 @@ export function runSelfHostedOCRExperiment(
         muV1MarkdownLength: muV1Result.markdown.length,
         wordSimilarity: Math.round(similarity * 1000) / 1000,
         failedPages: resp.failed_pages,
+        pagesProcessed: pages,
+        ocrPerPageMs: pages ? Math.round(ocrDurationMs / pages) : undefined,
+        muV1PerPageMs: pages ? Math.round(muV1Result.durationMs / pages) : undefined,
       });
     } catch {
       // Non-blocking: instance may be down at any time, silently skip


### PR DESCRIPTION
Log pages processed count and per-page latency for both the self-hosted OCR provider and MU v1 in the selfHostedOCR experiment, making it easier to compare provider performance on a per-page basis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pages processed and per-page latency to the self-hosted OCR experiment logs to enable apples-to-apples performance comparisons with MU v1. Pages count is passed through and used to compute per-page timings for both providers.

- **New Features**
  - Log `pagesProcessed`, `ocrPerPageMs`, and `muV1PerPageMs` in `runSelfHostedOCRExperiment`.
  - Accept optional `pages_processed` in the OCR response schema; fallback to the passed `pagesProcessed`.
  - Pass `pagesProcessed` from `scrapePDFWithRunPodMU` into `runSelfHostedOCRExperiment`.

<sup>Written for commit 843b03c6b9e262b32787bac87a21de56a2da2247. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

