### PR TITLE
fix(api): add scrape_id and team_id to branding Sentry errors, respect ZDR

### DIFF
--- a/apps/api/src/lib/branding/llm.ts
+++ b/apps/api/src/lib/branding/llm.ts
@@ -1,11 +1,11 @@
 import { generateObject } from "ai";
-import * as Sentry from "@sentry/node";
 import { logger } from "../logger";
 import { config } from "../../config";
 import { BrandingEnhancement, getBrandingEnhancementSchema } from "./schema";
 import { buildBrandingPrompt } from "./prompt";
 import { BrandingLLMInput } from "./types";
 import { getModel } from "../generic-ai";
+import { captureExceptionWithZdrCheck } from "../../services/sentry";
 
 function isDebugBrandingEnabled(input: BrandingLLMInput): boolean {
   return (
@@ -192,17 +192,21 @@ export async function enhanceBrandingWithLLM(
         },
       );
     } else {
-      Sentry.withScope(scope => {
-        scope.setTag("feature", "branding-llm");
-        scope.setTag("model", modelName);
-        scope.setContext("branding_llm", {
+      captureExceptionWithZdrCheck(error, {
+        tags: {
+          feature: "branding-llm",
+          model: modelName,
+          ...(input.scrapeId ? { scrape_id: input.scrapeId } : {}),
+          ...(input.teamId ? { team_id: input.teamId } : {}),
+        },
+        extra: {
           url: input.url,
           buttonsCount: input.buttons?.length || 0,
           logoCandidatesCount: input.logoCandidates?.length || 0,
           promptLength: prompt.length,
           hasScreenshot: !!input.screenshot,
-        });
-        Sentry.captureException(error);
+        },
+        zeroDataRetention: input.zeroDataRetention,
       });
       logger.error("LLM branding enhancement failed", {
         error,

--- a/apps/api/src/lib/branding/transformer.ts
+++ b/apps/api/src/lib/branding/transformer.ts
@@ -193,6 +193,8 @@ export async function brandingTransformer(
       ogImage: brandingProfile.images?.ogImage ?? undefined,
       heuristicLogoPick,
       teamId: meta.internalOptions.teamId,
+      scrapeId: meta.id,
+      zeroDataRetention: meta.internalOptions.zeroDataRetention,
       teamFlags: meta.internalOptions.teamFlags,
     });
 

--- a/apps/api/src/lib/branding/types.ts
+++ b/apps/api/src/lib/branding/types.ts
@@ -91,6 +91,8 @@ export interface BrandingLLMInput {
     reasoning: string;
   };
   teamId?: string;
+  scrapeId?: string;
+  zeroDataRetention?: boolean;
   teamFlags?: { debugBranding?: boolean } | null;
 }
 


### PR DESCRIPTION
Branding format Sentry errors were missing scrape_id and team_id tags, making it hard to trace failures back to specific requests. This switches the branding LLM error capture from raw `Sentry.captureException` to `captureExceptionWithZdrCheck`, threading scrape_id and team_id through as tags and respecting zero data retention so errors from ZDR-enabled teams are properly dropped instead of leaking to Sentry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route branding LLM errors through `captureExceptionWithZdrCheck` and respect zero data retention. Add `scrape_id` and `team_id` Sentry tags to trace failures per scrape and team.

- **Bug Fixes**
  - Replaced direct `@sentry/node` capture with `captureExceptionWithZdrCheck`, tagging `feature`, `model`, `scrape_id`, `team_id`, and adding extras (url, buttons/logo counts, prompt length, hasScreenshot); passes `zeroDataRetention` to drop events when enabled.
  - Threaded `scrapeId` and `zeroDataRetention` through `brandingTransformer`; extended `BrandingLLMInput` to include them.

<sup>Written for commit e73d2e587f9826b8f3241b0c345b61fdcab9ebf4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

