### PR TITLE
fix: wire up USE_RESPONSES_ENDPOINT env var in generic AI provider

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -195,6 +195,7 @@ const configSchema = z.object({
   MODEL_EMBEDDING_NAME: z.string().optional(),
   OLLAMA_BASE_URL: z.string().optional(),
   VERTEX_CREDENTIALS: z.string().optional(),
+  USE_RESPONSES_ENDPOINT: z.stringbool().optional(),
 
   // Rate Limiting
   RATE_LIMIT_TEST_API_KEY_SCRAPE: z.coerce.number().optional(),

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -58,6 +58,15 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
     name = "gemini-2.5-pro";
   }
   const modelName = config.MODEL_NAME || name;
+  // Use Chat Completions endpoint when USE_RESPONSES_ENDPOINT=false.
+  // This is required for OpenAI-compatible proxies (e.g. LiteLLM, Azure OpenAI)
+  // that do not implement the Responses API.
+  if (
+    provider === "openai" &&
+    config.USE_RESPONSES_ENDPOINT === false
+  ) {
+    return providerList.openai.chat(modelName);
+  }
   // o3-mini returns empty text via the Responses API — force Chat Completions
   if (provider === "openai" && modelName.startsWith("o3-mini")) {
     return providerList.openai.chat(modelName);


### PR DESCRIPTION
## Summary

- `@ai-sdk/openai` v2 defaults to the Responses API, but OpenAI-compatible proxies (LiteLLM, Azure OpenAI) only support Chat Completions (`/v1/chat/completions`)
- Adds `USE_RESPONSES_ENDPOINT` to the config schema (boolean, optional) and checks it in `getModel()`: when set to `false`, the provider is forced to use `.chat(modelName)` targeting Chat Completions instead of Responses
- The existing `o3-mini` hard-coded override is preserved as a safety net regardless of the env var setting

### Files changed
- `apps/api/src/config.ts` — added `USE_RESPONSES_ENDPOINT` to config schema
- `apps/api/src/lib/generic-ai.ts` — conditional `.chat()` vs default provider based on env var

## Test plan

- [ ] Set `USE_RESPONSES_ENDPOINT=false` → verify requests go to `/v1/chat/completions`
- [ ] Unset the env var → verify default Responses API behavior is unchanged
- [ ] Test with LiteLLM proxy endpoint to confirm compatibility

Fixes #3169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wire up the `USE_RESPONSES_ENDPOINT` env var so the generic OpenAI provider can force Chat Completions for OpenAI‑compatible proxies. Keeps the `o3-mini` safety override to always use Chat Completions.

- **Bug Fixes**
  - Added `USE_RESPONSES_ENDPOINT` to config. When `false` and provider is `openai`, use `.chat(modelName)` to hit `/v1/chat/completions` instead of Responses (default in `@ai-sdk/openai` v2).
  - Preserved the `o3-mini` override to always use Chat Completions.

- **Migration**
  - Set `USE_RESPONSES_ENDPOINT=false` when using LiteLLM or Azure OpenAI to avoid the Responses API.

<sup>Written for commit ef94f2c7aa17bc0c3a6bbd61d9f00214d646d779. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

