### PR TITLE
fix: forward user-agent header to playwright browser context

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -197,8 +197,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false): Promise<{ context: BrowserContext; securityState: ContextSecurityState }> => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customUserAgent?: string): Promise<{ context: BrowserContext; securityState: ContextSecurityState }> => {
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
   const securityState: ContextSecurityState = {
     blockedNavigationRequestUrl: null,
@@ -401,13 +401,27 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    const contextBundle = await createContext(skip_tls_verification);
+    // Extract user-agent from headers (case-insensitive) to set at context level,
+    // since Playwright ignores user-agent in setExtraHTTPHeaders when the context
+    // already has a userAgent set.
+    const customUserAgent = headers
+      ? Object.entries(headers).find(([key]) => key.toLowerCase() === 'user-agent')?.[1]
+      : undefined;
+
+    const contextBundle = await createContext(skip_tls_verification, customUserAgent);
     requestContext = contextBundle.context;
     securityState = contextBundle.securityState;
     page = await requestContext.newPage();
 
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      // Remove user-agent from extra headers since it's already set at context level.
+      // Playwright ignores user-agent in setExtraHTTPHeaders when context userAgent is set.
+      const filteredHeaders = Object.fromEntries(
+        Object.entries(headers).filter(([key]) => key.toLowerCase() !== 'user-agent')
+      );
+      if (Object.keys(filteredHeaders).length > 0) {
+        await page.setExtraHTTPHeaders(filteredHeaders);
+      }
     }
 
     const result = await scrapePage(


### PR DESCRIPTION
## Summary
- When users set a custom `user-agent` in scrape request headers, Playwright ignored it because `setExtraHTTPHeaders` does not override the context-level `userAgent` that was already set via the `UserAgent` package
- This fix extracts the `user-agent` from request headers (case-insensitive) and passes it to `createContext()` so it is set at the browser context level where Playwright respects it
- The `user-agent` key is also filtered out of `setExtraHTTPHeaders` to avoid redundancy and potential conflicts

## Test plan
- [ ] Deploy self-hosted instance with this fix
- [ ] POST to `/v2/scrape` with `headers: { "user-agent": "MyCustomAgent/1.0" }` targeting a request-logging endpoint (e.g. webhook.site)
- [ ] Verify the logged request shows `MyCustomAgent/1.0` as the user-agent (not Playwright's default or a random user-agent)
- [ ] POST to `/v2/scrape` without a custom user-agent header and verify a random user-agent is still generated (backward compatibility)
- [ ] POST to `/v2/scrape` with other custom headers (e.g. `Accept-Language`) and verify they are still forwarded correctly
- [ ] Verify mixed case `User-Agent` / `USER-AGENT` keys are handled correctly

Fixes #2802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure custom User-Agent headers on scrape requests are respected by setting them at the `playwright` browser context level instead of only via extra HTTP headers. Fixes cases where the header was ignored due to an existing context-level userAgent.

- **Bug Fixes**
  - Extract `user-agent` (case-insensitive) from request headers and pass it to `createContext()` to set the context `userAgent`.
  - Remove `user-agent` from `page.setExtraHTTPHeaders` to prevent conflicts with the context.
  - Default to a random user agent when no custom header is provided (unchanged behavior).

<sup>Written for commit ca6882e6bf5414dfe008face7b54ca73bc9023c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

