### PR TITLE
Add time comparison to selfHostedOCR logs

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
@@ -73,7 +73,7 @@ export function runSelfHostedOCRExperiment(
       const similarity = wordSimilarity(resp.markdown, muV1Result.markdown);
       const pages = resp.pages_processed ?? pagesProcessed;
       const timeDiffMs = muV1Result.durationMs - ocrDurationMs;
-      const speedup = muV1Result.durationMs > 0
+      const speedup = muV1Result.durationMs > 0 && ocrDurationMs > 0
         ? Math.round((muV1Result.durationMs / ocrDurationMs) * 100) / 100
         : undefined;
 


### PR DESCRIPTION
Adds `timeDiffMs` (positive = self-hosted is faster) and `speedup` (muV1 duration / self-hosted duration, >1 means self-hosted wins) fields to the self-hosted OCR experiment log so we can easily query and track how our self-hosted OCR performance compares to muV1 over time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `timeDiffMs` and `speedup` to self-hosted OCR experiment logs to compare performance against muV1 and make trend tracking easier.

- **New Features**
  - `timeDiffMs = muV1DurationMs - ocrDurationMs` (positive means self-hosted is faster).
  - `speedup = muV1DurationMs / ocrDurationMs`, rounded to 2 decimals; only set when both durations > 0 to avoid division by zero.

<sup>Written for commit d48ab99fe767dc963e488f0ff7005b22862d41cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

