### PR TITLE
[test] Use self-hosted OCR as primary PDF OCR engine

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -28,7 +28,7 @@ import {
   extractAndEmitNativeLogs,
 } from "../../../../lib/native-logging";
 import { withSpan, setSpanAttributes } from "../../../../lib/otel-tracer";
-import { scrapePDFWithRunPodMU } from "./runpodMU";
+import { scrapePDFWithSelfHostedOCR } from "./selfHostedOCR";
 import { scrapePDFWithParsePDF } from "./pdfParse";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
@@ -331,36 +331,30 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       );
     }
 
-    // OCR / MU fallback.
+    // OCR fallback (self-hosted OCR primary, MinerU as experiment).
     // Skipped only when Rust extraction is enabled AND mode is "fast".
     const skipOCR = rustEnabled && mode === "fast";
     if (!result && !skipOCR) {
       const base64Content = (await readFile(tempFilePath)).toString("base64");
 
-      if (
-        base64Content.length < MAX_FILE_SIZE &&
-        config.RUNPOD_MU_API_KEY &&
-        config.RUNPOD_MU_POD_ID
-      ) {
-        const muV1StartedAt = Date.now();
+      if (base64Content.length < MAX_FILE_SIZE && config.PDF_OCR_BASE_URL) {
+        const ocrStartedAt = Date.now();
         try {
-          result = await scrapePDFWithRunPodMU(
+          result = await scrapePDFWithSelfHostedOCR(
             {
               ...meta,
               logger: meta.logger.child({
-                method: "scrapePDF/scrapePDFWithRunPodMU",
+                method: "scrapePDF/scrapePDFWithSelfHostedOCR",
               }),
             },
-            tempFilePath,
             base64Content,
             maxPages,
-            effectivePageCount,
           );
-          const muV1DurationMs = Date.now() - muV1StartedAt;
+          const ocrDurationMs = Date.now() - ocrStartedAt;
           meta.logger
-            .child({ method: "scrapePDF/MUv1Experiment" })
-            .info("MU v1 completed", {
-              durationMs: muV1DurationMs,
+            .child({ method: "scrapePDF/selfHostedOCR" })
+            .info("Self-hosted OCR completed", {
+              durationMs: ocrDurationMs,
               url: meta.rewrittenUrl ?? meta.url,
               pages: effectivePageCount,
               success: true,
@@ -372,7 +366,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             config.PDF_SHADOW_COMPARISON_ENABLE
           ) {
             const shadowRust = rustMarkdownForShadow;
-            const shadowMu = result.markdown;
+            const shadowOcr = result.markdown;
             const shadowLogger = meta.logger.child({
               method: "scrapePDF/shadowComparison",
             });
@@ -380,7 +374,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
 
             (async () => {
               try {
-                const metrics = comparePdfOutputs(shadowRust, shadowMu);
+                const metrics = comparePdfOutputs(shadowRust, shadowOcr);
                 shadowLogger.info("shadow comparison complete", {
                   scrapeId: meta.id,
                   url: isZdr ? undefined : (meta.rewrittenUrl ?? meta.url),
@@ -404,7 +398,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             throw error;
           }
           meta.logger.warn(
-            "RunPod MU failed to parse PDF (could be due to timeout) -- falling back to parse-pdf",
+            "Self-hosted OCR failed to parse PDF -- falling back to MinerU/parse-pdf",
             { error },
           );
           captureExceptionWithZdrCheck(error, {
@@ -416,17 +410,18 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
               url: meta.rewrittenUrl ?? meta.url,
             },
           });
-          const muV1DurationMs = Date.now() - muV1StartedAt;
+          const ocrDurationMs = Date.now() - ocrStartedAt;
           meta.logger
-            .child({ method: "scrapePDF/MUv1Experiment" })
-            .info("MU v1 failed", {
-              durationMs: muV1DurationMs,
+            .child({ method: "scrapePDF/selfHostedOCR" })
+            .info("Self-hosted OCR failed", {
+              durationMs: ocrDurationMs,
               url: meta.rewrittenUrl ?? meta.url,
               pages: effectivePageCount,
               success: false,
             });
         }
       }
+
     }
 
     // Final fallback to PdfParse.

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
@@ -4,7 +4,6 @@ import * as marked from "marked";
 import { robustFetch } from "../../lib/fetch";
 import { z } from "zod";
 import path from "node:path";
-import { runSelfHostedOCRExperiment } from "./selfHostedOCR";
 import {
   getPdfResultFromCache,
   savePdfResultToCache,
@@ -210,15 +209,6 @@ export async function scrapePDFWithRunPodMU(
       url: meta.rewrittenUrl ?? meta.url,
       pagesProcessed,
     });
-    if (!meta.internalOptions.zeroDataRetention) {
-      runSelfHostedOCRExperiment(
-        meta,
-        base64Content,
-        { markdown: result.markdown, durationMs },
-        maxPages,
-        pagesProcessed,
-      );
-    }
   }
 
   return processorResult;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
@@ -2,98 +2,43 @@ import { Meta } from "../..";
 import { config } from "../../../../config";
 import { robustFetch } from "../../lib/fetch";
 import { z } from "zod";
+import * as marked from "marked";
+import type { PDFProcessorResult } from "./types";
 
-/**
- * Compute word-level Jaccard similarity between two texts.
- * Strips markdown syntax and normalises whitespace so we compare
- * the underlying data, not formatting differences.
- */
-function wordSimilarity(a: string, b: string): number {
-  const normalise = (s: string) =>
-    s
-      .replace(/[#*_`\[\]()>|~\-]/g, " ")
-      .replace(/\s+/g, " ")
-      .trim()
-      .toLowerCase();
+const ocrResponseSchema = z.object({
+  markdown: z.string(),
+  failed_pages: z.array(z.number()).nullable(),
+  pages_processed: z.number().optional(),
+});
 
-  const wordsA = new Set(normalise(a).split(" ").filter(Boolean));
-  const wordsB = new Set(normalise(b).split(" ").filter(Boolean));
-
-  if (wordsA.size === 0 && wordsB.size === 0) return 1;
-  if (wordsA.size === 0 || wordsB.size === 0) return 0;
-
-  let intersection = 0;
-  for (const w of wordsA) {
-    if (wordsB.has(w)) intersection++;
-  }
-
-  return intersection / (wordsA.size + wordsB.size - intersection);
-}
-
-export function runSelfHostedOCRExperiment(
+export async function scrapePDFWithSelfHostedOCR(
   meta: Meta,
   base64Content: string,
-  muV1Result: { markdown: string; durationMs: number },
   maxPages?: number,
-  pagesProcessed?: number,
-): void {
-  if (
-    !config.PDF_OCR_EXPERIMENT_ENABLE ||
-    !config.PDF_OCR_BASE_URL ||
-    Math.random() * 100 >= config.PDF_OCR_EXPERIMENT_PERCENT
-  ) {
-    return;
-  }
+): Promise<PDFProcessorResult> {
+  const logger = meta.logger.child({ method: "scrapePDF/selfHostedOCR" });
 
-  (async () => {
-    const startedAt = Date.now();
-    const logger = meta.logger.child({ method: "scrapePDF/selfHostedOCR" });
-    try {
-      const resp = await robustFetch({
-        url: `${config.PDF_OCR_BASE_URL}/ocr`,
-        method: "POST",
-        headers: config.PDF_OCR_API_KEY
-          ? { Authorization: `Bearer ${config.PDF_OCR_API_KEY}` }
-          : undefined,
-        body: {
-          pdf: base64Content,
-          scrape_id: meta.id,
-          ...(maxPages !== undefined && { max_pages: maxPages }),
-        },
-        logger,
-        schema: z.object({
-          markdown: z.string(),
-          failed_pages: z.array(z.number()).nullable(),
-          pages_processed: z.number().optional(),
-        }),
-        mock: meta.mock,
-        abort: meta.abort.asSignal(),
-      });
-      const ocrDurationMs = Date.now() - startedAt;
-      const similarity = wordSimilarity(resp.markdown, muV1Result.markdown);
-      const pages = resp.pages_processed ?? pagesProcessed;
-      const timeDiffMs = muV1Result.durationMs - ocrDurationMs;
-      const speedup = muV1Result.durationMs > 0 && ocrDurationMs > 0
-        ? Math.round((muV1Result.durationMs / ocrDurationMs) * 100) / 100
-        : undefined;
+  logger.debug("Processing PDF document with self-hosted OCR");
 
-      logger.info("Self-hosted OCR experiment completed", {
-        scrapeId: meta.id,
-        url: meta.rewrittenUrl ?? meta.url,
-        ocrDurationMs,
-        muV1DurationMs: muV1Result.durationMs,
-        timeDiffMs,
-        speedup,
-        ocrMarkdownLength: resp.markdown.length,
-        muV1MarkdownLength: muV1Result.markdown.length,
-        wordSimilarity: Math.round(similarity * 1000) / 1000,
-        failedPages: resp.failed_pages,
-        pagesProcessed: pages,
-        ocrPerPageMs: pages ? Math.round(ocrDurationMs / pages) : undefined,
-        muV1PerPageMs: pages ? Math.round(muV1Result.durationMs / pages) : undefined,
-      });
-    } catch {
-      // Non-blocking: instance may be down at any time, silently skip
-    }
-  })();
+  const resp = await robustFetch({
+    url: `${config.PDF_OCR_BASE_URL}/ocr`,
+    method: "POST",
+    headers: config.PDF_OCR_API_KEY
+      ? { Authorization: `Bearer ${config.PDF_OCR_API_KEY}` }
+      : undefined,
+    body: {
+      pdf: base64Content,
+      scrape_id: meta.id,
+      ...(maxPages !== undefined && { max_pages: maxPages }),
+    },
+    logger,
+    schema: ocrResponseSchema,
+    mock: meta.mock,
+    abort: meta.abort.asSignal(),
+  });
+
+  return {
+    markdown: resp.markdown,
+    html: await marked.parse(resp.markdown, { async: true }),
+  };
 }


### PR DESCRIPTION
Switches the PDF engine's OCR path from MinerU (RunPod) to self-hosted OCR as the primary processor. The selfHostedOCR module is no longer a background experiment — it now returns results directly. MinerU fallback is removed for now so we can fully evaluate the self-hosted model in production.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the self-hosted OCR service the primary PDF OCR engine and remove MinerU fallback so we can evaluate the self-hosted model in production. The OCR path now returns parsed markdown and HTML directly.

- **Refactors**
  - Replaced `scrapePDFWithRunPodMU` with `scrapePDFWithSelfHostedOCR` in `scrapePDF`.
  - Promoted `selfHostedOCR` from experiment to primary: returns `PDFProcessorResult` (`markdown` + `html` via `marked`).
  - Removed the self-hosted OCR experiment code and similarity metrics; stripped experiment hook from `runpodMU`.
  - Updated logging to report self-hosted OCR completion/failure with durations.
  - MinerU fallback disabled; final fallback remains `parse-pdf`.

- **Migration**
  - Set `PDF_OCR_BASE_URL` (required) and `PDF_OCR_API_KEY` (optional) for the self-hosted service.
  - `RUNPOD_MU_API_KEY` and `RUNPOD_MU_POD_ID` are no longer used in the OCR path.
  - `PDF_OCR_EXPERIMENT_ENABLE` and `PDF_OCR_EXPERIMENT_PERCENT` are ignored.

<sup>Written for commit 09605ac5a6158c5bc6ef82e7ad115119e343cae9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

