### PR TITLE
chore(native): bump pdf-inspector to 95b45d1

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "967b70a" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "95b45d1" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
Bumps pdf-inspector from `967b70a` to `95b45d1`.

Changes:
- fix(fonts): fall back to raw stream for uncompressed ToUnicode CMaps
- feat(detect): flag Type3-only pages without ToUnicode for OCR
- fix(preprocess): keep first occurrence of repeated headers/footers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `pdf-inspector` to pick up fixes and a new detection feature. Improves text extraction reliability and flags pages that need OCR.

- **Dependencies**
  - Fix: fallback to raw stream for uncompressed ToUnicode CMaps
  - Fix: keep first occurrence of repeated headers/footers
  - Feature: flag Type3-only pages without ToUnicode for OCR

<sup>Written for commit 3c86ff31fbd81f3179a9a30d558049b3ff73c403. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

