### PR TITLE
chore(native): bump pdf-inspector to 7f2995a

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "95b45d1" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "7f2995a" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
## Summary

Bumps pdf-inspector from 95b45d1 to [7f2995a](https://github.com/firecrawl/pdf-inspector/commit/7f2995a). This update fixes extraction of body text from PDFs that use uncompressed Form XObjects (e.g. those generated by pdfrw, such as Cambridge University Press excerpts) by falling back to raw bytes when lopdf's `decompressed_content()` fails on streams without a `/Filter` entry, and updates lopdf to the firecrawl fork ([edf6279](https://github.com/firecrawl/lopdf/commit/edf6279)) which also addresses this at the library level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `pdf-inspector` to fix missing body text extraction in PDFs with uncompressed Form XObjects, improving reliability on pdfrw‑generated files.

- **Bug Fixes**
  - Falls back to raw bytes when `decompressed_content()` fails on streams without a `/Filter` entry.
  - Includes the firecrawl `lopdf` fork via the updated `pdf-inspector` for better handling of uncompressed streams.

<sup>Written for commit ff628299e2f45ef5b6473f6f08aa1b874d3443f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

