### PR TITLE
feat(pdf): add self-hosted OCR live traffic routing

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -164,6 +164,10 @@ const configSchema = z.object({
   PDF_OCR_BASE_URL: z.string().optional(),
   PDF_OCR_API_KEY: z.string().optional(),
 
+  // Self-Hosted OCR Live Traffic
+  PDF_OCR_LIVE_ENABLE: z.stringbool().optional(),
+  PDF_OCR_LIVE_PERCENT: z.coerce.number().min(0).max(100).default(0),
+
   // RunPod
   RUNPOD_MU_API_KEY: z.string().optional(),
   RUNPOD_MU_POD_ID: z.string().optional(),

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -33,6 +33,7 @@ import { scrapePDFWithParsePDF } from "./pdfParse";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
 import { comparePdfOutputs } from "./shadowComparison";
+import { scrapePDFWithSelfHostedOCR } from "./selfHostedOCR";
 
 /** Check if the PDF is eligible for Rust extraction, returning a rejection reason or null. */
 function getIneligibleReason(
@@ -339,7 +340,43 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     if (!result && !skipOCR) {
       const base64Content = (await readFile(tempFilePath)).toString("base64");
 
+      // Self-hosted OCR live routing: route a percentage of traffic
+      // to the self-hosted OCR service. Falls back to MU on failure.
+      const useSelfHostedOCR =
+        config.PDF_OCR_LIVE_ENABLE &&
+        config.PDF_OCR_BASE_URL &&
+        base64Content.length < MAX_FILE_SIZE &&
+        Math.random() * 100 < config.PDF_OCR_LIVE_PERCENT;
+
+      if (useSelfHostedOCR) {
+        try {
+          result = await scrapePDFWithSelfHostedOCR(
+            {
+              ...meta,
+              logger: meta.logger.child({
+                method: "scrapePDF/selfHostedOCRLive",
+              }),
+            },
+            base64Content,
+            maxPages,
+            effectivePageCount,
+          );
+        } catch (error) {
+          if (
+            error instanceof RemoveFeatureError ||
+            error instanceof AbortManagerThrownError
+          ) {
+            throw error;
+          }
+          meta.logger.warn(
+            "Self-hosted OCR failed, falling back to MU/pdfParse",
+            { error },
+          );
+        }
+      }
+
       if (
+        !result &&
         base64Content.length < MAX_FILE_SIZE &&
         config.RUNPOD_MU_API_KEY &&
         config.RUNPOD_MU_POD_ID

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/selfHostedOCR.ts
@@ -2,6 +2,8 @@ import { Meta } from "../..";
 import { config } from "../../../../config";
 import { robustFetch } from "../../lib/fetch";
 import { z } from "zod";
+import * as marked from "marked";
+import type { PDFProcessorResult } from "./types";
 
 /**
  * Compute word-level Jaccard similarity between two texts.
@@ -96,4 +98,62 @@ export function runSelfHostedOCRExperiment(
       // Non-blocking: instance may be down at any time, silently skip
     }
   })();
+}
+
+const selfHostedOCRResponseSchema = z.object({
+  markdown: z.string(),
+  failed_pages: z.array(z.number()).nullable(),
+  pages_processed: z.number().optional(),
+});
+
+export async function scrapePDFWithSelfHostedOCR(
+  meta: Meta,
+  base64Content: string,
+  maxPages?: number,
+  pagesProcessed?: number,
+): Promise<PDFProcessorResult> {
+  const startedAt = Date.now();
+  const logger = meta.logger.child({ method: "scrapePDF/selfHostedOCRLive" });
+
+  logger.info("Self-hosted OCR live started", {
+    scrapeId: meta.id,
+    url: meta.rewrittenUrl ?? meta.url,
+    maxPages,
+    pagesProcessed,
+  });
+
+  const resp = await robustFetch({
+    url: `${config.PDF_OCR_BASE_URL}/ocr`,
+    method: "POST",
+    headers: config.PDF_OCR_API_KEY
+      ? { Authorization: `Bearer ${config.PDF_OCR_API_KEY}` }
+      : undefined,
+    body: {
+      pdf: base64Content,
+      scrape_id: meta.id,
+      ...(maxPages !== undefined && { max_pages: maxPages }),
+    },
+    logger,
+    schema: selfHostedOCRResponseSchema,
+    mock: meta.mock,
+    abort: meta.abort.asSignal(),
+  });
+
+  const durationMs = Date.now() - startedAt;
+  const pages = resp.pages_processed ?? pagesProcessed;
+
+  logger.info("Self-hosted OCR live completed", {
+    scrapeId: meta.id,
+    url: meta.rewrittenUrl ?? meta.url,
+    durationMs,
+    markdownLength: resp.markdown.length,
+    failedPages: resp.failed_pages,
+    pagesProcessed: pages,
+    perPageMs: pages ? Math.round(durationMs / pages) : undefined,
+  });
+
+  return {
+    markdown: resp.markdown,
+    html: await marked.parse(resp.markdown, { async: true }),
+  };
 }


### PR DESCRIPTION
## Summary
- Route a configurable percentage of PDF OCR traffic to self-hosted OCR service
- New env vars: `PDF_OCR_LIVE_ENABLE` (toggle) and `PDF_OCR_LIVE_PERCENT` (0-100, default 0)
- Reuses existing `PDF_OCR_BASE_URL` and `PDF_OCR_API_KEY` config
- Falls back to MU on failure, then pdfParse as final fallback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds percentage-based routing of PDF OCR traffic to a self-hosted service, controlled by env vars. On failure, falls back to MU and then `pdfParse`.

- **New Features**
  - `PDF_OCR_LIVE_ENABLE` and `PDF_OCR_LIVE_PERCENT` (0–100, default 0) to control live routing.
  - Uses `PDF_OCR_BASE_URL` and optional `PDF_OCR_API_KEY` for self-hosted OCR.
  - Returns markdown and HTML (rendered via `marked`) with basic timing/page metrics.

- **Migration**
  - No change by default.
  - To enable: set `PDF_OCR_LIVE_ENABLE=true`, `PDF_OCR_LIVE_PERCENT=<0-100>`, and `PDF_OCR_BASE_URL` (plus `PDF_OCR_API_KEY` if required).

<sup>Written for commit 38afde9bfa8df4254a9e4b45d473a32178dfab08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

