### PR TITLE
fix: handle empty webpage content without 500 error

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -436,10 +436,25 @@ async function scrapeURLLoopIter(
     // NOTE: TODO: what to do when status code is bad is tough...
     // we cannot just rely on text because error messages can be brief and not hit the limit
     // should we just use all the fallbacks and pick the one with the longest text? - mogery
-    if (isLongEnough || !isGoodStatusCode) {
-      meta.logger.info("Scrape via " + engine + " deemed successful.", {
-        factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
-      });
+    //
+    // When the page returns a good status code but has no content, this is a
+    // valid empty page — not an engine failure. We accept the result so the
+    // caller gets a 200 with empty content instead of a misleading 500
+    // SCRAPE_ALL_ENGINES_FAILED error. (fixes #2316)
+    if (isLongEnough || !isGoodStatusCode || (isGoodStatusCode && hasNoPageError)) {
+      if (!isLongEnough && isGoodStatusCode && hasNoPageError) {
+        meta.logger.info(
+          "Scrape via " + engine + " returned empty content with a good status code. Treating as successful empty page.",
+          {
+            factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
+            statusCode: engineResult.statusCode,
+          },
+        );
+      } else {
+        meta.logger.info("Scrape via " + engine + " deemed successful.", {
+          factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
+        });
+      }
       return engineResult;
     } else {
       meta.logger.warn("Scrape via " + engine + " deemed unsuccessful.", {


### PR DESCRIPTION
## Summary

- When scraping a valid but content-empty webpage (HTTP 200, no page errors, but no extractable text), the scraper now returns a successful response with empty content instead of throwing a misleading `500 SCRAPE_ALL_ENGINES_FAILED` error.
- The fix adds a third condition to the engine success check in `scrapeURLLoopIter`: if the status code is good (2xx/304) and there is no page-level error, treat the scrape as successful even when content is empty.
- Existing behavior for pages with content, bad status codes, or page-level errors is unchanged.

Fixes #2316

## Test plan

- [ ] Scrape a valid but empty HTML page (e.g., `<html><body></body></html>`) — should return 200 with empty markdown, not 500
- [ ] Scrape a normal page with content — should still return 200 with content (no regression)
- [ ] Scrape a page that returns a 4xx/5xx status code — should still attempt fallback engines as before
- [ ] Scrape a page where the engine reports a page-level error but status is 200 — should still try fallback engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 200 with empty content for valid webpages that have no extractable text, instead of a 500 `SCRAPE_ALL_ENGINES_FAILED`.
Adds a success condition in `scrapeURLLoopIter` for good status (2xx/304) with no page-level error; fallback behavior for bad status or page-level errors is unchanged (fixes #2316).

<sup>Written for commit 1aadaa81338196eecfdb53e209cdf46501d3eba8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

