### PR TITLE
fix: filter out mailto and basic auth URLs during crawl discovery

### DIFF
--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -307,6 +307,19 @@ export class WebCrawler {
           return false;
         }
 
+        // Filter out URLs with userinfo (basic auth credentials or malformed mailto)
+        // e.g. https://user:pass@example.com or https://email@example.com
+        if (url.username || url.password) {
+          if (config.FIRECRAWL_DEBUG_FILTER_LINKS) {
+            this.logger.debug(`${link} USERINFO FAIL`);
+          }
+          denialReasons.set(
+            link,
+            "This URL contains embedded credentials (userinfo) in the format user:pass@host or user@host. These are typically malformed mailto links or basic auth URLs that should not be crawled. Modern browsers strip this information from URLs.",
+          );
+          return false;
+        }
+
         const depth = getURLDepth(url.toString());
 
         // Check if the link exceeds the maximum depth allowed
@@ -667,6 +680,14 @@ export class WebCrawler {
     const links = await extractLinks(html);
     const filteredLinks: string[] = [];
     for (const link of links) {
+      // Skip non-http protocols and URLs with userinfo (basic auth / malformed mailto)
+      if (link.startsWith("mailto:") || link.startsWith("tel:")) continue;
+      try {
+        const parsed = new URL(link, url);
+        if (parsed.username || parsed.password) continue;
+      } catch {
+        continue;
+      }
       const filterResult = await this.filterURL(link, url);
       if (filterResult.allowed && filterResult.url) {
         filteredLinks.push(filterResult.url);
@@ -683,8 +704,17 @@ export class WebCrawler {
       const element = $("a")[i];
       let href = $(element).attr("href");
       if (href) {
+        // Skip non-http protocols (mailto, tel, etc.)
+        if (href.startsWith("mailto:") || href.startsWith("tel:") || href.startsWith("ftp:") || href.startsWith("ssh:") || href.startsWith("file:") || href.startsWith("telnet:")) continue;
         if (href.match(/^https?:\/[^\/]/)) {
           href = href.replace(/^https?:\//, "$&/");
+        }
+        // Skip URLs with userinfo (basic auth credentials or malformed mailto)
+        try {
+          const parsed = new URL(href, url);
+          if (parsed.username || parsed.password) continue;
+        } catch {
+          // If URL can't be parsed, filterURL will handle it
         }
         const filterResult = await this.filterURL(href, url);
         if (filterResult.allowed && filterResult.url) {
@@ -717,7 +747,10 @@ export class WebCrawler {
           (await this.extractLinksFromHTMLRust(html, url))
             .map(x => {
               try {
-                return new URL(x, url).href;
+                const parsed = new URL(x, url);
+                // Final safety check: reject URLs with userinfo
+                if (parsed.username || parsed.password) return null;
+                return parsed.href;
               } catch (e) {
                 return null;
               }

--- a/apps/api/src/scraper/scrapeURL/lib/__tests__/extractLinks.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/__tests__/extractLinks.test.ts
@@ -61,4 +61,77 @@ describe("extractLinks integration", () => {
     const links = await extractLinks(html, "https://example.org/foo/bar");
     expect(links).toContain("https://example.org/foo/page.php");
   });
+
+  it("should filter out mailto: links", async () => {
+    const html = `
+      <html>
+        <body>
+          <a href="mailto:test@example.com">Email</a>
+          <a href="https://example.com/page">Page</a>
+        </body>
+      </html>
+    `;
+    const links = await extractLinks(html, "https://example.com");
+    expect(links).not.toContain("mailto:test@example.com");
+    expect(links).toContain("https://example.com/page");
+  });
+
+  it("should filter out tel: links", async () => {
+    const html = `
+      <html>
+        <body>
+          <a href="tel:+1234567890">Call</a>
+          <a href="https://example.com/page">Page</a>
+        </body>
+      </html>
+    `;
+    const links = await extractLinks(html, "https://example.com");
+    expect(links).not.toContain("tel:+1234567890");
+    expect(links).toContain("https://example.com/page");
+  });
+
+  it("should filter out URLs with basic auth credentials (user:pass@host)", async () => {
+    const html = `
+      <html>
+        <body>
+          <a href="https://user:pass@example.com/page">Auth Link</a>
+          <a href="https://example.com/page">Normal Link</a>
+        </body>
+      </html>
+    `;
+    const links = await extractLinks(html, "https://example.com");
+    expect(links).not.toContain("https://user:pass@example.com/page");
+    expect(links).toContain("https://example.com/page");
+  });
+
+  it("should filter out URLs with userinfo (email@host pattern)", async () => {
+    const html = `
+      <html>
+        <body>
+          <a href="https://email@example.com">Malformed mailto</a>
+          <a href="https://example.com/contact">Contact</a>
+        </body>
+      </html>
+    `;
+    const links = await extractLinks(html, "https://example.com");
+    expect(links).not.toContain("https://email@example.com");
+    expect(links).not.toContain("https://email@example.com/");
+    expect(links).toContain("https://example.com/contact");
+  });
+
+  it("should keep valid https URLs without userinfo", async () => {
+    const html = `
+      <html>
+        <body>
+          <a href="https://example.com">Home</a>
+          <a href="https://sub.example.com/path?q=1">Query</a>
+          <a href="http://example.com/page#section">Section</a>
+        </body>
+      </html>
+    `;
+    const links = await extractLinks(html, "https://example.com");
+    expect(links).toContain("https://example.com");
+    expect(links).toContain("https://sub.example.com/path?q=1");
+    // Note: fragment links to same page are filtered as section links
+  });
 });

--- a/apps/api/src/scraper/scrapeURL/lib/extractLinks.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractLinks.ts
@@ -6,6 +6,32 @@ import {
   extractBaseHref as _extractBaseHref,
 } from "@mendable/firecrawl-rs";
 
+/**
+ * Checks whether a resolved URL is valid for crawling.
+ * Filters out:
+ * - Non-HTTP(S) protocols (mailto:, tel:, ftp:, etc.)
+ * - URLs containing userinfo / basic auth credentials (user:pass@host)
+ */
+function isValidCrawlUrl(url: string): boolean {
+  // Only allow http and https protocols
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    // Reject URLs with userinfo (basic auth credentials or email-like patterns)
+    // e.g. https://user:pass@example.com or https://user@example.com
+    if (parsed.username || parsed.password) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  return true;
+}
+
 function resolveUrlWithBaseHref(
   href: string,
   baseUrl: string,
@@ -29,8 +55,8 @@ function resolveUrlWithBaseHref(
   try {
     if (href.startsWith("http://") || href.startsWith("https://")) {
       return href;
-    } else if (href.startsWith("mailto:")) {
-      return href;
+    } else if (href.startsWith("mailto:") || href.startsWith("tel:")) {
+      return "";
     } else if (href.startsWith("#")) {
       return "";
     } else {
@@ -56,7 +82,7 @@ async function extractLinksRust(
   hrefs.forEach(href => {
     href = href.trim();
     const resolvedUrl = resolveUrlWithBaseHref(href, baseUrl, baseHref);
-    if (resolvedUrl) {
+    if (resolvedUrl && isValidCrawlUrl(resolvedUrl)) {
       links.push(resolvedUrl);
     }
   });
@@ -87,7 +113,7 @@ export async function extractLinks(
     if (href) {
       href = href.trim();
       const resolvedUrl = resolveUrlWithBaseHref(href, baseUrl, baseHref);
-      if (resolvedUrl) {
+      if (resolvedUrl && isValidCrawlUrl(resolvedUrl)) {
         links.push(resolvedUrl);
       }
     }


### PR DESCRIPTION
## Summary

- Adds `isValidCrawlUrl()` guard in link extraction to reject non-HTTP protocols and URLs with userinfo (basic auth credentials like `user:pass@host` or malformed mailto like `email@host`)
- Fixes `resolveUrlWithBaseHref` to return empty string for `mailto:` and `tel:` hrefs instead of passing them through to the crawl queue
- Adds userinfo checks in the crawler's JS fallback `filterLinks`, `extractLinksFromHTMLRust`, `extractLinksFromHTMLCheerio`, and `extractLinksFromHTML` methods for defense in depth
- Adds unit tests covering mailto, tel, basic auth, and userinfo URL filtering

## Test plan

- [ ] Existing `extractLinks` integration tests continue to pass (relative links, base href, absolute base href, fallback)
- [ ] New tests verify `mailto:` links are excluded from extracted links
- [ ] New tests verify `tel:` links are excluded from extracted links
- [ ] New tests verify `https://user:pass@example.com` URLs are excluded
- [ ] New tests verify `https://email@example.com` (malformed mailto) URLs are excluded
- [ ] New tests verify valid `https://` URLs without userinfo are preserved
- [ ] E2E crawl test `filters out non-web protocol links` continues to pass

Fixes #2591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent malformed `mailto:` and basic-auth URLs from entering the crawl queue to stop duplicate recrawls and bad targets, fixing #2591. Adds a central URL validator with defense-in-depth checks across extractors.

- **Bug Fixes**
  - Added `isValidCrawlUrl()` to allow only `http/https` and block userinfo (`user:pass@host`, `user@host`).
  - `resolveUrlWithBaseHref()` now returns empty for `mailto:` and `tel:`.
  - Early protocol/userinfo filtering in crawler paths: JS fallback `filterLinks`, `extractLinksFromHTMLRust`, `extractLinksFromHTMLCheerio`, and `extractLinksFromHTML`.
  - Tests added for `mailto:`, `tel:`, basic auth, and userinfo; existing integration/E2E tests remain green.

<sup>Written for commit 45a3fd07ac7bfb11118ab5b305620b3c2929b16d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

