### PR TITLE
feat(pdf): Add ocrPageCount and ocrPageRatio to Logs

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -153,6 +153,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     let shadowConfidence: number | undefined;
     let shadowIsComplex: boolean | undefined;
     let shadowIneligibleReason: string | null | undefined;
+    let shadowPagesNeedingOcr: number[] | undefined;
 
     const rustEnabled = !!config.PDF_RUST_EXTRACT_ENABLE;
     const logger = meta.logger.child({ method: "scrapePDF/processPdf" });
@@ -282,6 +283,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           shadowConfidence = pdfResult.confidence;
           shadowIsComplex = pdfResult.isComplex;
           shadowIneligibleReason = ineligibleReason;
+          shadowPagesNeedingOcr = pdfResult.pagesNeedingOcr;
         }
 
         // In fast mode, if the PDF requires OCR, fail immediately with a
@@ -391,6 +393,14 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
                   confidence: shadowConfidence,
                   isComplex: shadowIsComplex,
                   ineligibleReason: shadowIneligibleReason,
+                  ocrPageCount: shadowPagesNeedingOcr?.length ?? 0,
+                  ocrPageRatio:
+                    effectivePageCount > 0
+                      ? Math.round(
+                          ((shadowPagesNeedingOcr?.length ?? 0) * 100) /
+                            effectivePageCount,
+                        ) / 100
+                      : 0,
                   ...metrics.overall,
                 });
               } catch (error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `ocrPageCount` and `ocrPageRatio` to PDF scrape logs to monitor OCR usage and document complexity. This improves visibility into OCR-heavy PDFs for debugging and tuning.

- **New Features**
  - Logs now include `ocrPageCount` (number of pages needing OCR) and `ocrPageRatio` (count divided by `effectivePageCount`, rounded to two decimals).
  - Values default to 0 when no pages need OCR or when the page count is unavailable.

<sup>Written for commit b609442576baf04fe82c8682f05a43c783667e9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

