### PR TITLE
chore: update pdf-inspector to ad10f67

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "7f2995a" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "ad10f67" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
## Summary

Updates `pdf-inspector` from `7f2995a` to `ad10f67`.

### Changes in pdf-inspector since last update:

- **fix(fonts): CID-as-Unicode passthrough and subscript merging** — Identity-H fonts without ToUnicode maps now pass CID values through as Unicode codepoints; subscript text fragments are merged correctly
- **fix(fonts): suppress garbage CID text on OCR-flagged pages** — pages with unreadable CID-mapped text are detected and stripped to avoid mojibake in output
- **fix(layout): detect and correct rotated page text** — text on rotated pages is now unrotated before layout, fixing garbled output on landscape/rotated PDFs
- **fix(text): handle Tc/Tw character and word spacing** — respects PDF `Tc` (character spacing) and `Tw` (word spacing) operators for more accurate text extraction
- **fix: skip page extraction when operation count exceeds 1M** — prevents hangs on extremely complex pages by skipping extraction when content stream operations exceed 1M
- **chore: migrate from deprecated `load_mem_with_password` to `load_mem_with_options`** — updates to newer lopdf API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `pdf-inspector` to `ad10f67` for more accurate text extraction and improved stability on complex or rotated PDFs.

- **Dependencies**
  - Bumps `pdf-inspector` from `7f2995a` to `ad10f67`.
  - Better CID font handling: pass CIDs as Unicode and merge subscript fragments.
  - Strip unreadable CID text on OCR-flagged pages to prevent garbage output.
  - Unrotate text on rotated pages; honor `Tc` and `Tw` spacing operators.
  - Skip extraction on pages with >1M operations to avoid hangs.

<sup>Written for commit 8e6ec20fe71cfdfeb03ede28a808cf66bb39101a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

