### PR TITLE
(feat/interact) Share the same number of concurrent browser

### DIFF
--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -353,7 +353,13 @@ export async function scrapeStopInteractiveBrowserController(
   const claimed = await claimBrowserSessionDestroyed(session.id);
 
   invalidateActiveBrowserSessionCount(session.team_id).catch(() => {});
-  removeConcurrencyLimitActiveJob(session.team_id, session.id).catch(() => {});
+  removeConcurrencyLimitActiveJob(session.team_id, session.id).catch(error => {
+    logger.error("Failed to remove concurrency limiter entry for browser session", {
+      error,
+      sessionId: session.id,
+      teamId: session.team_id,
+    });
+  });
 
   if (!claimed) {
     logger.info("Session already destroyed by another path, skipping billing", {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Interactive browser sessions now use the same team-wide concurrency pool as scrape/crawl jobs. This keeps limits consistent and blocks bypassing concurrent job caps.

- **Refactors**
  - Enforce shared concurrency via `getConcurrencyLimitActiveJobsCount` and `req.acuc?.concurrency` (default 2).
  - Register on create and clean up on destroy in the limiter (TTL), with errors logged on failed removal.
  - Update 429 message to reference concurrent jobs and suggest waiting or destroying sessions.

<sup>Written for commit be5e1a10ff05b0150a1f4e5bee2af3da1b110085. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

