### PR TITLE
chore(deps): upgrade pdf-inspector to 4d52d7a

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "44092bc" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "4d52d7a" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
## Summary

Upgrades `pdf-inspector` from [`ad10f67`](https://github.com/firecrawl/pdf-inspector/commit/ad10f67) to [`4d52d7a`](https://github.com/firecrawl/pdf-inspector/commit/4d52d7a). Changes since last version:

- **Content stream comment parsing + CJK mojibake detection** ([#18](https://github.com/firecrawl/pdf-inspector/pull/18))
- **Borderless table detection improvements** ([#17](https://github.com/firecrawl/pdf-inspector/pull/17))
- **Struct-tree table extraction** — extract tables from tagged PDF structure tree, with 50% band coverage requirement and deduplication against rect detection ([#17](https://github.com/firecrawl/pdf-inspector/pull/17))
- **Exclude page-background rects from clustering** — prevents background rectangles from bridging unrelated table regions
- **Reject row-stripe tables with oversized cell text** ([#16](https://github.com/firecrawl/pdf-inspector/pull/16))
- **Relative valley column detection for justified text** ([#15](https://github.com/firecrawl/pdf-inspector/pull/15))
- **Recommend OCR for newspaper-style layouts** ([#14](https://github.com/firecrawl/pdf-inspector/pull/14))
- **Stop rejecting data tables with dot-leader labels as TOC** ([#13](https://github.com/firecrawl/pdf-inspector/pull/13))