### PR TITLE
fix: pin 23 unpinned action(s),extract 1 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/deploy-go-service.yaml
+++ b/.github/workflows/deploy-go-service.yaml
@@ -23,17 +23,17 @@ jobs:
         uses: actions/checkout@main
 
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
 
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: "Build and Push Image"
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: ./apps/go-html-to-md-service
           push: true

--- a/.github/workflows/deploy-image-staging.yml
+++ b/.github/workflows/deploy-image-staging.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/checkout@main
 
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
 
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
@@ -48,7 +48,7 @@ jobs:
           echo "PLATFORM_SUFFIX=${platform//\//-}" >> $GITHUB_ENV
 
       - name: 'Build and Push Image'
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: ./apps/api
           push: true
@@ -61,7 +61,7 @@ jobs:
     needs: build
     steps:
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}

--- a/.github/workflows/deploy-nuq-postgres.yml
+++ b/.github/workflows/deploy-nuq-postgres.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}

--- a/.github/workflows/deploy-playwright.yml
+++ b/.github/workflows/deploy-playwright.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/checkout@main
 
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
 
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
@@ -48,7 +48,7 @@ jobs:
           echo "PLATFORM_SUFFIX=${platform//\//-}" >> $GITHUB_ENV
 
       - name: 'Build and Push Image'
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: ./apps/playwright-service-ts
           push: true
@@ -61,7 +61,7 @@ jobs:
     needs: build
     steps:
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}

--- a/.github/workflows/deploy-redis.yml
+++ b/.github/workflows/deploy-redis.yml
@@ -22,7 +22,7 @@ jobs:
             uses: actions/checkout@main
 
           - name: 'Login to GitHub Container Registry'
-            uses: docker/login-action@v3
+            uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
             with:
               registry: ghcr.io
               username: ${{github.actor}}

--- a/.github/workflows/ghcr-clean.yml
+++ b/.github/workflows/ghcr-clean.yml
@@ -8,7 +8,7 @@ jobs:
     name: Delete Untagged Images
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: bots-house/ghcr-delete-image-action@v1.1.0
+      - uses: bots-house/ghcr-delete-image-action@3827559c68cb4dcdf54d813ea9853be6d468d3a4 # v1.1.0
         with:
           owner: firecrawl
           name: firecrawl

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10
       

--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10
       - name: Set up Node.js
@@ -27,7 +27,9 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: './apps/js-sdk/firecrawl/pnpm-lock.yaml'
       - name: Authenticate
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish
         run: |
           pnpm install

--- a/.github/workflows/test-java-sdk.yml
+++ b/.github/workflows/test-java-sdk.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Publish test report
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc # v1
         with:
           name: Java SDK Test Report
           path: apps/java-sdk/build/test-results/test/*.xml

--- a/.github/workflows/test-js-sdk.yml
+++ b/.github/workflows/test-js-sdk.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10
       - name: Set up Node.js
@@ -27,7 +27,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: './apps/js-sdk/firecrawl/pnpm-lock.yaml'
       - name: Tailscale
-        uses: tailscale/github-action@v4
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/test-rust-sdk.yml
+++ b/.github/workflows/test-rust-sdk.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
 

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10
 

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10
 


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/deploy-go-service.yaml` | Pinned 3 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/deploy-image-staging.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/deploy-image.yml` | Pinned 4 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/deploy-nuq-postgres.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/deploy-playwright.yml` | Pinned 4 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/deploy-redis.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/ghcr-clean.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/npm-audit.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/publish-js-sdk.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/publish-js-sdk.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/test-java-sdk.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/test-js-sdk.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/test-rust-sdk.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/test-server.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/validate-lockfiles.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/scrape-evals.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/scrape-evals.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/scrape-evals.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/scrape-evals.yml` | Comment-Triggered Workflow Without Author Authorization Check |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures GitHub Actions by pinning 23 third‑party actions to commit SHAs and moving one inline NPM token to an env var. Reduces supply‑chain and injection risk without changing workflow behavior.

- **Bug Fixes**
  - Pinned actions to SHAs across 14 workflows (e.g., `docker/login-action`, `pnpm/action-setup`, `tailscale/github-action`, `useblacksmith/*`).
  - Moved `NPM_TOKEN` auth in `publish-js-sdk.yml` from `run:` to `env:` to avoid shell interpolation.

<sup>Written for commit c9fe4d51d5a2b2efbed7509d90a1c3d87f790f82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

