### PR TITLE
fix(api/scrape): billing for sites unblocked via flag

### DIFF
--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -9,9 +9,11 @@ import { CostTracking } from "./cost-tracking";
 import { hasFormatOfType } from "./format-utils";
 import { TransportableError } from "./error";
 import { FeatureFlag } from "../scraper/scrapeURL/engines";
+import { isUrlBlocked } from "../scraper/WebScraper/utils/blocklist";
 
 const creditsPerPDFPage = 1;
 const stealthProxyCostBonus = 4;
+const unblockedDomainCostBonus = 4;
 
 export async function calculateCreditsToBeBilled(
   options: ScrapeOptions,
@@ -92,6 +94,14 @@ export async function calculateCreditsToBeBilled(
     !unsupportedFeatures?.has("stealthProxy") // if stealth proxy was unsupported, don't bill for it
   ) {
     creditsToBeBilled += stealthProxyCostBonus;
+  }
+
+  const urlsToCheck = [
+    document.metadata?.url,
+    document.metadata?.sourceURL,
+  ].filter((u): u is string => !!u);
+  if (urlsToCheck.some(u => isUrlBlocked(u, null) && !isUrlBlocked(u, flags))) {
+    creditsToBeBilled += unblockedDomainCostBonus;
   }
 
   return creditsToBeBilled;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Charge an extra 4 credits when scraping domains that are normally blocked but allowed via feature flags. This aligns billing with unblock behavior and prevents undercharging.

- **Bug Fixes**
  - Apply `unblockedDomainCostBonus` (+4) when `metadata.url` or `sourceURL` is blocked by default (`isUrlBlocked(url, null)`) but unblocked with provided flags (`isUrlBlocked(url, flags)` is false).

<sup>Written for commit a654304939e039f198199c7cef8ffb90079f44be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

