### PR TITLE
fix: v1 /map endpoint time_taken always ~0

### DIFF
--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -123,6 +123,7 @@ export async function getMapResults({
   headers?: Record<string, string>;
   id?: string;
 }): Promise<MapResult> {
+  const startTime = Date.now();
   const id = providedId ?? uuidv7();
   let links: string[] = [url];
   let mapResults: MapDocument[] = [];
@@ -354,7 +355,7 @@ export async function getMapResults({
     mapResults: mapResults,
     scrape_id: origin?.includes("website") ? id : undefined,
     job_id: id,
-    time_taken: (new Date().getTime() - Date.now()) / 1000,
+    time_taken: (Date.now() - startTime) / 1000,
   };
 }
 


### PR DESCRIPTION
## Summary
- Fixes #3165 — v1 `/map` endpoint `time_taken` was always ~0
- Root cause: `(new Date().getTime() - Date.now()) / 1000` computes two timestamps on the same line, result is always ~0
- Fix: capture `Date.now()` at function entry into `startTime`, compute elapsed at the end
- Matches the pattern already used in the v2 map endpoint (`map-utils.ts`)

## Changes
- `apps/api/src/controllers/v1/map.ts` — 2 lines changed

## Test plan
- [x] `time_taken` now reflects actual execution time
- [x] Consistent with v2 map endpoint implementation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v1 `/map` endpoint `time_taken` always being ~0 by capturing `Date.now()` at function start and computing elapsed at return. Values now reflect real execution time and match the v2 endpoint behavior.

<sup>Written for commit fe12ea31eaa75205d553c84188a3c176503a7d0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

