### PR TITLE
fix(api): correct time_taken calculation in v1 /map endpoint

### DIFF
--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -122,6 +122,7 @@ export async function getMapResults({
   headers?: Record<string, string>;
   id?: string;
 }): Promise<MapResult> {
+  const functionStartTime = Date.now();
   const id = providedId ?? uuidv7();
   let links: string[] = [url];
   let mapResults: MapDocument[] = [];
@@ -353,7 +354,7 @@ export async function getMapResults({
     mapResults: mapResults,
     scrape_id: origin?.includes("website") ? id : undefined,
     job_id: id,
-    time_taken: (new Date().getTime() - Date.now()) / 1000,
+    time_taken: (Date.now() - functionStartTime) / 1000,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes the `time_taken` metric in the v1 `/map` endpoint which was always returning approximately 0.

## Problem

The original calculation was:
```ts
time_taken: (new Date().getTime() - Date.now()) / 1000,
```

Both `new Date().getTime()` and `Date.now()` return the current timestamp in milliseconds at the moment they're called. Since they execute within microseconds of each other, the difference is always ~0.

## Solution

Capture `Date.now()` at the start of `getMapResults` and use it in the final calculation:
```ts
const functionStartTime = Date.now();
// ... function body ...
time_taken: (Date.now() - functionStartTime) / 1000,
```

This is consistent with the v2 map endpoint implementation in `apps/api/src/lib/map-utils.ts`.

## Testing

- Verified the fix correctly calculates elapsed time
- Change is minimal and isolated to timing logic

Fixes #3165

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `time_taken` metric in the v1 `/map` endpoint so it reports real elapsed time instead of ~0, aligning with the v2 implementation.

- **Bug Fixes**
  - Capture `Date.now()` at `getMapResults` start and compute `time_taken` as `(Date.now() - functionStartTime) / 1000`.
  - Remove the incorrect delta between `new Date().getTime()` and `Date.now()` that always returned ~0.

<sup>Written for commit 7459bc16ea8584c132d59f0b69c83fd5a9175fa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

