### PR TITLE
feat(api): add agent-friendly rate limit headers for autonomous scraping workflows

### DIFF
--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -10,7 +10,7 @@ import { getRateLimiter } from "../services/rate-limiter";
 import { deleteKey, getValue, setValue } from "../services/redis";
 import { redlock } from "../services/redlock";
 import { supabase_rr_service, supabase_service } from "../services/supabase";
-import { AuthResponse, RateLimiterMode } from "../types";
+import { AuthResponse, RateLimiterMode, RateLimitInfo } from "../types";
 import { AuthCreditUsageChunk, AuthCreditUsageChunkFromTeam } from "./v1/types";
 import {
   isAutumnCheckEnabled,
@@ -513,8 +513,36 @@ async function supaAuthenticateUser(
 
   const team_endpoint_token = token === config.PREVIEW_TOKEN ? iptoken : teamId;
 
+  // Helper function to build RateLimitInfo
+  const buildRateLimitInfo = (
+    rateLimiterRes: any,
+    isLimited: boolean = false,
+  ): RateLimitInfo => {
+    const limit = rateLimiter.points ?? rateLimiter._points ?? 0;
+    const remaining = rateLimiterRes.remainingPoints ?? 0;
+    const msBeforeNext = rateLimiterRes.msBeforeNext ?? 60000;
+    const reset = Math.floor((Date.now() + msBeforeNext) / 1000);
+    
+    const info: RateLimitInfo = {
+      limit,
+      remaining,
+      reset,
+    };
+    
+    if (isLimited) {
+      info.retryAfter = Math.ceil(msBeforeNext / 1000);
+    }
+    
+    return info;
+  };
+
   try {
-    await rateLimiter.consume(team_endpoint_token);
+    const rateLimiterRes = await rateLimiter.consume(team_endpoint_token);
+    // Build rate limit info for successful request
+    const rateLimitInfo = buildRateLimitInfo(rateLimiterRes, false);
+
+    // Attach rate limit info to request for middleware to use
+    req.rateLimitInfo = rateLimitInfo;
   } catch (rateLimiterRes) {
     // logger.error(`Rate limit exceeded: ${rateLimiterRes}`, {
     //   teamId,
@@ -527,6 +555,9 @@ async function supaAuthenticateUser(
     const secs = Math.round(rateLimiterRes.msBeforeNext / 1000) || 1;
     const retryDate = new Date(Date.now() + rateLimiterRes.msBeforeNext);
 
+    // Build rate limit info for rate-limited request
+    const rateLimitInfo = buildRateLimitInfo(rateLimiterRes, true);
+
     // We can only send a rate limit email every 7 days, send notification already has the date in between checking
     // const startDate = new Date();
     // const endDate = new Date();
@@ -538,6 +569,7 @@ async function supaAuthenticateUser(
       success: false,
       error: `Rate limit exceeded. Consumed (req/min): ${rateLimiterRes.consumedPoints}, Remaining (req/min): ${rateLimiterRes.remainingPoints}. Upgrade your plan at https://firecrawl.dev/pricing for increased rate limits or please retry after ${secs}s, resets at ${retryDate}`,
       status: 429,
+      rateLimitInfo,
     };
   }
 
@@ -556,6 +588,7 @@ async function supaAuthenticateUser(
       team_id: `preview_${iptoken}`,
       org_id: null,
       chunk: null,
+      rateLimitInfo: req.rateLimitInfo,
     };
     // check the origin of the request and make sure its from firecrawl.dev
     // const origin = req.headers.origin;
@@ -595,5 +628,6 @@ async function supaAuthenticateUser(
     team_id: teamId ?? undefined,
     org_id: chunk?.org_id ?? null,
     chunk,
+    rateLimitInfo: req.rateLimitInfo,
   };
 }

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -6,7 +6,7 @@ import {
   RequestWithMaybeAuth,
   RequestWithMaybeACUC,
 } from "../controllers/v1/types";
-import { RateLimiterMode } from "../types";
+import { RateLimiterMode, RateLimitInfo } from "../types";
 import { authenticateUser } from "../controllers/auth";
 import { createIdempotencyKey } from "../services/idempotency/create";
 import { validateIdempotencyKey } from "../services/idempotency/validate";
@@ -29,6 +29,31 @@ import {
   isAutumnCheckEnabled,
   isAutumnCheckDryRun,
 } from "../services/autumn/autumn.service";
+
+/**
+ * Sets standard rate limit headers on the response following IETF draft specification.
+ * Headers set:
+ * - X-RateLimit-Limit: Maximum requests per window
+ * - X-RateLimit-Remaining: Remaining requests in current window
+ * - X-RateLimit-Reset: Unix timestamp when rate limit resets
+ * - X-RateLimit-Retry-After: Seconds until retry (only when rate limited)
+ */
+export function setRateLimitHeaders(
+  res: Response,
+  rateLimitInfo?: RateLimitInfo,
+): void {
+  if (!rateLimitInfo) {
+    return;
+  }
+
+  res.setHeader("X-RateLimit-Limit", rateLimitInfo.limit);
+  res.setHeader("X-RateLimit-Remaining", rateLimitInfo.remaining);
+  res.setHeader("X-RateLimit-Reset", rateLimitInfo.reset);
+
+  if (rateLimitInfo.retryAfter) {
+    res.setHeader("X-RateLimit-Retry-After", rateLimitInfo.retryAfter);
+  }
+}
 
 export function checkCreditsMiddleware(
   _minimum?: number,
@@ -244,6 +269,11 @@ export function authMiddleware(
       const auth = await authenticateUser(req, res, currentRateLimiterMode);
 
       if (!auth.success) {
+        // Set rate limit headers on error response if available
+        if (auth.rateLimitInfo) {
+          setRateLimitHeaders(res, auth.rateLimitInfo);
+        }
+        
         if (!res.headersSent) {
           return res
             .status(auth.status)
@@ -264,6 +294,8 @@ export function authMiddleware(
             : chunk.remaining_credits,
         };
       }
+      // Rate limit info is already set on req by authenticateUser
+      // It will be used by rateLimitHeadersMiddleware
       next();
     })().catch(err => next(err));
   };
@@ -419,6 +451,12 @@ export function requestTimingMiddleware(version: string) {
           requestTime,
           statusCode: res.statusCode,
         });
+      }
+
+      // Set rate limit headers from req.rateLimitInfo if available
+      // This ensures headers are set on all responses
+      if ((req as any).rateLimitInfo) {
+        setRateLimitHeaders(res, (req as any).rateLimitInfo);
       }
 
       return originalJson(body);

--- a/apps/api/src/routes/v0.ts
+++ b/apps/api/src/routes/v0.ts
@@ -7,8 +7,12 @@ import { crawlCancelController } from "../../src/controllers/v0/crawl-cancel";
 import { keyAuthController } from "../../src/controllers/v0/keyAuth";
 import { livenessController } from "../controllers/v0/liveness";
 import { readinessController } from "../controllers/v0/readiness";
+import { requestTimingMiddleware } from "./shared";
 
 export const v0Router = express.Router();
+
+// Add timing middleware to all v0 routes (includes rate limit headers)
+v0Router.use(requestTimingMiddleware("v0"));
 
 v0Router.post("/v0/scrape", scrapeController);
 v0Router.post("/v0/crawl", crawlController);

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -147,6 +147,13 @@ export enum RateLimiterMode {
   BrowserExecute = "browserExecute",
 }
 
+export type RateLimitInfo = {
+  limit: number;
+  remaining: number;
+  reset: number; // Unix timestamp in seconds when the rate limit resets
+  retryAfter?: number; // Seconds until retry (only set when rate limited)
+};
+
 export type AuthResponse =
   | {
       success: true;
@@ -154,11 +161,13 @@ export type AuthResponse =
       org_id?: string | null;
       api_key?: string;
       chunk: AuthCreditUsageChunk | null;
+      rateLimitInfo?: RateLimitInfo;
     }
   | {
       success: false;
       error: string;
       status: number;
+      rateLimitInfo?: RateLimitInfo;
     };
 
 export enum NotificationType {


### PR DESCRIPTION
## Problem

When autonomous agents use the Firecrawl API for scraping, they lack visibility into rate limit information. This makes it difficult for agents to properly handle rate limits and implement appropriate retry logic.

## Solution

This PR adds standard rate limit response headers following the IETF RateLimit header fields draft specification.

### Headers Added

All API responses now include:
- `X-RateLimit-Limit`: Maximum requests per window
- `X-RateLimit-Remaining`: Remaining requests in current window  
- `X-RateLimit-Reset`: Unix timestamp when rate limit resets

On 429 (rate limited) responses:
- `X-RateLimit-Retry-After`: Seconds until retry

### Changes

- Add `RateLimitInfo` type to `types.ts`
- Modify `auth.ts` to capture rate limit info after `consume()`
- Add `setRateLimitHeaders` helper function in `shared.ts`
- Modify `authMiddleware` to set headers on error responses
- Modify `requestTimingMiddleware` to set headers on all responses
- Add `requestTimingMiddleware` to v0 routes

### Benefits

This enables autonomous agents to:
- Monitor their rate limit usage proactively
- Implement intelligent retry strategies
- Avoid unnecessary 429 errors

Closes #3150

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds standard rate limit headers to all API responses so agents can monitor usage and retry intelligently. Follows the IETF RateLimit header fields draft and includes retry hints on 429s.

- **New Features**
  - Headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`; plus `X-RateLimit-Retry-After` on 429.
  - Middleware: `requestTimingMiddleware` now sets headers on all responses; enabled for `v0` routes.
  - Auth flow: captures `RateLimitInfo` after `consume()` and attaches it to both success and error responses; `authMiddleware` sets headers on error responses.
  - Types/Utils: added `RateLimitInfo` and `setRateLimitHeaders` helper.

<sup>Written for commit 5c0dac57b4f62a13f740d22e3857b9dc4347af41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

