### PR TITLE
chore(docker): add notes for building nuq-postgres image locally

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -148,6 +148,9 @@ services:
         compress: "true"
   
   nuq-postgres:
+    # NOTE: If you don't want to build the image locally,
+    # comment out the build: statement and uncomment the image: statement
+    # image: ghcr.io/firecrawl/nuq-postgres:latest
     build: apps/nuq-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}


### PR DESCRIPTION
Aligns the nuq-postgres service with api and playwright-service by adding a short note and a commented-out image: ghcr.io/firecrawl/nuq-postgres:latest, so self-hosters can use the published image instead of building locally.

The [image](https://github.com/firecrawl/firecrawl/pkgs/container/nuq-postgres) is already built and pushed in CI; the compose file did not mention it, which was inconsistent and easy to miss.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a note and a commented `image` line for the `nuq-postgres` service in docker-compose. This lets self-hosters use the published image `ghcr.io/firecrawl/nuq-postgres:latest` instead of building locally, matching `api` and `playwright-service`.

<sup>Written for commit 0c5c8b61059a00adccbf0d2e88a93c92c3d9f0ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

