### PR TITLE
fix: wire up USE_RESPONSES_ENDPOINT env var for OpenAI-compatible proxies

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -195,6 +195,7 @@ const configSchema = z.object({
   MODEL_EMBEDDING_NAME: z.string().optional(),
   OLLAMA_BASE_URL: z.string().optional(),
   VERTEX_CREDENTIALS: z.string().optional(),
+  USE_RESPONSES_ENDPOINT: z.stringbool().optional(),
 
   // Rate Limiting
   RATE_LIMIT_TEST_API_KEY_SCRAPE: z.coerce.number().optional(),

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -59,7 +59,13 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
   }
   const modelName = config.MODEL_NAME || name;
   // o3-mini returns empty text via the Responses API — force Chat Completions
-  if (provider === "openai" && modelName.startsWith("o3-mini")) {
+  // When USE_RESPONSES_ENDPOINT is explicitly false, also force Chat Completions
+  // so that OpenAI-compatible proxies that only support /v1/chat/completions work.
+  if (
+    provider === "openai" &&
+    (modelName.startsWith("o3-mini") ||
+      config.USE_RESPONSES_ENDPOINT === false)
+  ) {
     return providerList.openai.chat(modelName);
   }
   return providerList[provider](modelName);


### PR DESCRIPTION
## Summary

Fixes #3169

Since `@ai-sdk/openai` v2+, calling `provider(modelName)` defaults to the OpenAI Responses API (`POST /v1/responses`). Most OpenAI-compatible providers (Azure OpenAI, LiteLLM, vLLM, etc.) only implement Chat Completions (`POST /v1/chat/completions`), causing 404 errors for all AI-powered features when self-hosting.

This PR wires up the `USE_RESPONSES_ENDPOINT` env var so self-hosted users can set `USE_RESPONSES_ENDPOINT=false` to force the Chat Completions API path.

## Changes

- **`apps/api/src/config.ts`**: Add `USE_RESPONSES_ENDPOINT` as an optional boolean env var to the config schema
- **`apps/api/src/lib/generic-ai.ts`**: When `USE_RESPONSES_ENDPOINT` is `false` and provider is `openai`, use `.chat()` (Chat Completions) instead of the default Responses API call

## Behavior

| `USE_RESPONSES_ENDPOINT` | Effect |
|---|---|
| unset / `true` | Default behavior — uses Responses API (no change) |
| `false` | Forces Chat Completions API for all OpenAI provider models |

The existing `o3-mini` special case is preserved and now shares the same `.chat()` code path.

## Test plan

- Set `USE_RESPONSES_ENDPOINT=false` with an OpenAI-compatible proxy → verify requests go to `/v1/chat/completions`
- Leave `USE_RESPONSES_ENDPOINT` unset → verify default Responses API behavior is unchanged
- Test with `o3-mini` model → verify it still uses Chat Completions regardless of env var

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wire up the `USE_RESPONSES_ENDPOINT` env var so self‑hosted deployments using OpenAI‑compatible proxies can force Chat Completions and avoid 404s caused by `@ai-sdk/openai` defaulting to the Responses API. Default behavior is unchanged and the `o3-mini` special case is preserved.

- **Bug Fixes**
  - Add `USE_RESPONSES_ENDPOINT` to config schema.
  - When provider is `openai` and `USE_RESPONSES_ENDPOINT=false`, use `.chat()` (Chat Completions); `o3-mini` continues to use `.chat()`.

- **Migration**
  - If using Azure OpenAI, LiteLLM, vLLM, or similar, set `USE_RESPONSES_ENDPOINT=false` to send requests to `/v1/chat/completions`. Leave unset to keep the Responses API.

<sup>Written for commit e2206024364c019c5ab461e3fc8ed112d301f0ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

