### PR TITLE
fix: strip FirePDF base64 payload from robustFetch logs

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -66,46 +66,15 @@ export async function scrapePDFWithFirePDF(
   const durationMs = Date.now() - startedAt;
   const pages = resp.pages_processed ?? pagesProcessed;
 
-  const allPagesFailed =
-    resp.failed_pages &&
-    resp.failed_pages.length > 0 &&
-    pages !== undefined &&
-    resp.failed_pages.length >= pages;
-
-  if (allPagesFailed) {
-    logger.error("FirePDF failed: all pages failed", {
-      scrapeId: meta.id,
-      url: meta.rewrittenUrl ?? meta.url,
-      durationMs,
-      failedPages: resp.failed_pages,
-      pagesProcessed: pages,
-    });
-    throw new Error(
-      `FirePDF: all ${resp.failed_pages!.length} pages failed`,
-    );
-  }
-
-  if (resp.failed_pages && resp.failed_pages.length > 0) {
-    logger.warn("FirePDF completed with failed pages", {
-      scrapeId: meta.id,
-      url: meta.rewrittenUrl ?? meta.url,
-      durationMs,
-      markdownLength: resp.markdown.length,
-      failedPages: resp.failed_pages,
-      pagesProcessed: pages,
-      perPageMs: pages ? Math.round(durationMs / pages) : undefined,
-    });
-  } else {
-    logger.info("FirePDF completed", {
-      scrapeId: meta.id,
-      url: meta.rewrittenUrl ?? meta.url,
-      durationMs,
-      markdownLength: resp.markdown.length,
-      failedPages: resp.failed_pages,
-      pagesProcessed: pages,
-      perPageMs: pages ? Math.round(durationMs / pages) : undefined,
-    });
-  }
+  logger.info("FirePDF completed", {
+    scrapeId: meta.id,
+    url: meta.rewrittenUrl ?? meta.url,
+    durationMs,
+    markdownLength: resp.markdown.length,
+    failedPages: resp.failed_pages,
+    pagesProcessed: pages,
+    perPageMs: pages ? Math.round(durationMs / pages) : undefined,
+  });
 
   const processorResult = {
     markdown: resp.markdown,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -66,15 +66,46 @@ export async function scrapePDFWithFirePDF(
   const durationMs = Date.now() - startedAt;
   const pages = resp.pages_processed ?? pagesProcessed;
 
-  logger.info("FirePDF completed", {
-    scrapeId: meta.id,
-    url: meta.rewrittenUrl ?? meta.url,
-    durationMs,
-    markdownLength: resp.markdown.length,
-    failedPages: resp.failed_pages,
-    pagesProcessed: pages,
-    perPageMs: pages ? Math.round(durationMs / pages) : undefined,
-  });
+  const allPagesFailed =
+    resp.failed_pages &&
+    resp.failed_pages.length > 0 &&
+    pages !== undefined &&
+    resp.failed_pages.length >= pages;
+
+  if (allPagesFailed) {
+    logger.error("FirePDF failed: all pages failed", {
+      scrapeId: meta.id,
+      url: meta.rewrittenUrl ?? meta.url,
+      durationMs,
+      failedPages: resp.failed_pages,
+      pagesProcessed: pages,
+    });
+    throw new Error(
+      `FirePDF: all ${resp.failed_pages!.length} pages failed`,
+    );
+  }
+
+  if (resp.failed_pages && resp.failed_pages.length > 0) {
+    logger.warn("FirePDF completed with failed pages", {
+      scrapeId: meta.id,
+      url: meta.rewrittenUrl ?? meta.url,
+      durationMs,
+      markdownLength: resp.markdown.length,
+      failedPages: resp.failed_pages,
+      pagesProcessed: pages,
+      perPageMs: pages ? Math.round(durationMs / pages) : undefined,
+    });
+  } else {
+    logger.info("FirePDF completed", {
+      scrapeId: meta.id,
+      url: meta.rewrittenUrl ?? meta.url,
+      durationMs,
+      markdownLength: resp.markdown.length,
+      failedPages: resp.failed_pages,
+      pagesProcessed: pages,
+      perPageMs: pages ? Math.round(durationMs / pages) : undefined,
+    });
+  }
 
   const processorResult = {
     markdown: resp.markdown,

--- a/apps/api/src/scraper/scrapeURL/lib/fetch.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/fetch.ts
@@ -91,7 +91,12 @@ export async function robustFetch<
             file_content: undefined,
           },
         }
-      : body,
+      : body?.pdf
+        ? {
+            ...body,
+            pdf: undefined,
+          }
+        : body,
     logger: undefined,
   };
 


### PR DESCRIPTION
Strips the base64 PDF payload from robustFetch log params for FirePDF requests, matching the existing filtering for MinerU's file_content field. This prevents flooding logs with encoded file content on failures.