### PR TITLE
chore: bump pdf-inspector to 2455f14

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "cf7e6b8" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "2455f14" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
## Summary

Bumps `pdf-inspector` from `cf7e6b8` to `2455f14`.

## Changes

- `10dd7e2` feat: XY-cut fallback for column detection on asymmetric layouts
- `14154ee` docs: update benchmark scores
- `0db9863` feat: lookahead-based isolated line heading detection
- `6a9ff17` fix: simplify region text extraction to trust layout model ordering
- `be313cd` fix: require strong signal for rarity-based heading detection
- `640cdaa` fix: stop counting Do operators as images in content stream scanner
- `2455f14` chore: bump npm version to 0.3.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pdf-inspector` to 0.3.5 to improve column and heading detection and fix image counting and text extraction accuracy.

- **New Features**
  - XY-cut fallback for asymmetric column layouts.
  - Lookahead-based detection for isolated-line headings.

- **Bug Fixes**
  - Trust layout model ordering for region text extraction.
  - Stronger signal required for rarity-based heading detection.
  - Ignore Do operators so they aren’t counted as images.

<sup>Written for commit 09fad11c8591dfc21e9be79d58671466d26b9122. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

