### PR TITLE
fix(python-sdk): add missing method bindings to AsyncFirecrawl

### DIFF
--- a/apps/python-sdk/firecrawl/client.py
+++ b/apps/python-sdk/firecrawl/client.py
@@ -302,13 +302,16 @@ class AsyncFirecrawl:
         self.cancel_crawl = self._v2_client.cancel_crawl
         self.crawl = self._v2_client.crawl
         self.get_crawl_errors = self._v2_client.get_crawl_errors
+        self.get_active_crawls = self._v2_client.get_active_crawls
         self.active_crawls = self._v2_client.active_crawls
+        self.wait_crawl = self._v2_client.wait_crawl
         self.crawl_params_preview = self._v2_client.crawl_params_preview
 
         self.start_batch_scrape = self._v2_client.start_batch_scrape
         self.get_batch_scrape_status = self._v2_client.get_batch_scrape_status
         self.get_batch_scrape_status_page = self._v2_client.get_batch_scrape_status_page
         self.cancel_batch_scrape = self._v2_client.cancel_batch_scrape
+        self.wait_batch_scrape = self._v2_client.wait_batch_scrape
         self.batch_scrape = self._v2_client.batch_scrape
         self.get_batch_scrape_errors = self._v2_client.get_batch_scrape_errors
 


### PR DESCRIPTION
Fixes #3323

## What's wrong

`AsyncFirecrawl.__init__` was missing three method bindings that are present on the sync `Firecrawl` class:

- `get_active_crawls`
- `wait_crawl`
- `wait_batch_scrape`

Calling any of them directly on an `AsyncFirecrawl` instance raises `AttributeError` at runtime, even though the underlying `AsyncFirecrawlClient` implements all three and `AsyncV2Proxy` (the `.v2` accessor) binds them correctly.

## Fix

Three one-line additions to `AsyncFirecrawl.__init__` in `apps/python-sdk/firecrawl/client.py`:

```python
self.get_active_crawls = self._v2_client.get_active_crawls
self.wait_crawl = self._v2_client.wait_crawl
self.wait_batch_scrape = self._v2_client.wait_batch_scrape
```

No logic changes — purely restoring parity between the sync and async top-level clients.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind missing methods on `AsyncFirecrawl` to match the sync `Firecrawl` and prevent runtime AttributeErrors.

- **Bug Fixes**
  - Added bindings for `get_active_crawls`, `wait_crawl`, and `wait_batch_scrape` to the async top-level client.
  - These methods now work directly on `AsyncFirecrawl` (not just via `.v2`); no logic changes.

<sup>Written for commit 395d2a54e70127bc482f22eb4ec8564d7e85a76b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

