### PR TITLE
fix: catch marked.js stack overflow on large PDF markdown

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -76,9 +76,18 @@ export async function scrapePDFWithFirePDF(
     perPageMs: pages ? Math.round(durationMs / pages) : undefined,
   });
 
+  let html: string;
+  try {
+    html = await marked.parse(resp.markdown, { async: true });
+  } catch {
+    // marked.js can blow the stack on very large/complex markdown.
+    // Fall back to wrapping raw markdown in a <pre> block.
+    html = `<pre>${resp.markdown}</pre>`;
+  }
+
   const processorResult = {
     markdown: resp.markdown,
-    html: await marked.parse(resp.markdown, { async: true }),
+    html,
   };
 
   if (!maxPages && !meta.internalOptions.zeroDataRetention) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -79,10 +79,13 @@ export async function scrapePDFWithFirePDF(
   let html: string;
   try {
     html = await marked.parse(resp.markdown, { async: true });
-  } catch {
-    // marked.js can blow the stack on very large/complex markdown.
-    // Fall back to wrapping raw markdown in a <pre> block.
-    html = `<pre>${resp.markdown}</pre>`;
+  } catch (e) {
+    logger.warn("marked.parse failed, falling back to <pre> wrapper", {
+      error: e,
+      scrapeId: meta.id,
+      markdownLength: resp.markdown.length,
+    });
+    html = `<pre>${resp.markdown.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")}</pre>`;
   }
 
   const processorResult = {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
@@ -186,9 +186,16 @@ export async function scrapePDFWithRunPodMU(
     throw new Error("RunPod MU returned no result");
   }
 
+  let html: string;
+  try {
+    html = await marked.parse(result.markdown, { async: true });
+  } catch {
+    html = `<pre>${result.markdown}</pre>`;
+  }
+
   const processorResult = {
     markdown: result.markdown,
-    html: await marked.parse(result.markdown, { async: true }),
+    html,
   };
 
   if (!meta.internalOptions.zeroDataRetention) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
@@ -189,8 +189,13 @@ export async function scrapePDFWithRunPodMU(
   let html: string;
   try {
     html = await marked.parse(result.markdown, { async: true });
-  } catch {
-    html = `<pre>${result.markdown}</pre>`;
+  } catch (e) {
+    meta.logger.warn("marked.parse failed, falling back to <pre> wrapper", {
+      error: e,
+      scrapeId: meta.id,
+      markdownLength: result.markdown.length,
+    });
+    html = `<pre>${result.markdown.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")}</pre>`;
   }
 
   const processorResult = {


### PR DESCRIPTION
## Summary
- `marked.parse()` throws `Maximum call stack size exceeded` on complex markdown from large PDFs (seen on 119-page French thesis, 190KB markdown)
- Causes FirePDF path to throw, falling back to MinerU unnecessarily
- Same vulnerability exists in MinerU/RunPod path

## Fix
- Wrap `marked.parse()` in try/catch in both `firePDF.ts` and `runpodMU.ts`
- Falls back to `<pre>` wrapped raw markdown on failure — preserves the markdown output (primary format) while providing valid HTML

## Test plan
- [ ] Deploy and monitor for `marked.parse` failures on large PDFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `marked` stack overflows on large/complex PDF markdown. On failure we now log a warning and return HTML-escaped `<pre>` HTML instead of crashing or cascading fallbacks.

- **Bug Fixes**
  - Wrapped `marked.parse()` in try/catch in `apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts` and `apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts`.
  - On error, fall back to HTML-escaped `<pre>` with the raw markdown; markdown output remains unchanged.
  - Added warn logs with `scrapeId` and `markdownLength`; prevents unnecessary FirePDF → MinerU fallback and protects the MinerU path.

<sup>Written for commit 9fa7fa6c08ca729d7005c3dc577ff91a98aa8bfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

