### PR TITLE
chore: bump pdf-inspector to d8bb0f5

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "cf7e6b8" }
+pdf-inspector = { git = "https://github.com/firecrawl/pdf-inspector", rev = "d8bb0f5" }
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"


### PR DESCRIPTION
## Summary

Bumps `pdf-inspector` from `cf7e6b8` to `d8bb0f5`.

## Changes

- d8bb0f5 chore: bump npm version to 0.3.6
- 1b4f1f4 fix: reduce false OCR flags for Identity-H fonts with fallback decoding
- 2455f14 chore: bump npm version to 0.3.5
- 640cdaa fix: stop counting Do operators as images in content stream scanner
- be313cd fix: require strong signal for rarity-based heading detection
- 6a9ff17 fix: simplify region text extraction to trust layout model ordering
- 0db9863 feat: lookahead-based isolated line heading detection
- 14154ee docs: update benchmark scores
- 10dd7e2 feat: XY-cut fallback for column detection on asymmetric layouts

## Test plan
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pdf-inspector` to the latest upstream to improve PDF parsing accuracy, especially for headings, columns, image counting, and OCR detection.

- **Dependencies**
  - Bumped `pdf-inspector` in Cargo to pull in recent fixes and features:
    - Reduce false OCR flags for Identity-H fonts.
    - Stop counting Do operators as images.
    - Improve heading detection (stronger rarity signal + lookahead on isolated lines).
    - Add XY-cut fallback for asymmetric column layouts; simplify region text extraction by trusting layout order.

<sup>Written for commit b5060693190f24eb07567da31ebf528f9f6545d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

