### PR TITLE
feat(pdf): add success/failure logging to pdfParse

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -491,13 +491,9 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     // Final fallback to PdfParse (skipped when Fire PDF is forced).
     if (!result && !forceFirePDF) {
       result = await scrapePDFWithParsePDF(
-        {
-          ...meta,
-          logger: meta.logger.child({
-            method: "scrapePDF/scrapePDFWithParsePDF",
-          }),
-        },
+        meta,
         tempFilePath,
+        "scrapePDF/scrapePDFWithParsePDF",
       );
     }
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -491,9 +491,13 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     // Final fallback to PdfParse (skipped when Fire PDF is forced).
     if (!result && !forceFirePDF) {
       result = await scrapePDFWithParsePDF(
-        meta,
+        {
+          ...meta,
+          logger: meta.logger.child({
+            method: "scrapePDF/scrapePDFWithParsePDF",
+          }),
+        },
         tempFilePath,
-        "scrapePDF/scrapePDFWithParsePDF",
       );
     }
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/pdfParse.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/pdfParse.ts
@@ -7,10 +7,8 @@ import type { PDFProcessorResult } from "./types";
 export async function scrapePDFWithParsePDF(
   meta: Meta,
   tempFilePath: string,
-  method?: string,
 ): Promise<PDFProcessorResult> {
-  const logger = meta.logger.child({ method: method ?? "scrapePDFWithParsePDF" });
-  logger.debug("Processing PDF document with parse-pdf", { tempFilePath });
+  meta.logger.debug("Processing PDF document with parse-pdf", { tempFilePath });
 
   try {
     const startedAt = Date.now();
@@ -18,7 +16,7 @@ export async function scrapePDFWithParsePDF(
     const durationMs = Date.now() - startedAt;
     const escaped = escapeHtml(result.text);
 
-    logger.info("pdfParse succeeded", {
+    meta.logger.info("pdfParse succeeded", {
       durationMs,
       markdownLength: escaped.length,
       numPages: result.numpages,
@@ -29,7 +27,7 @@ export async function scrapePDFWithParsePDF(
       html: escaped,
     };
   } catch (error) {
-    logger.error("pdfParse failed", { error });
+    meta.logger.error("pdfParse failed", { error });
     throw error;
   }
 }

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/pdfParse.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/pdfParse.ts
@@ -7,14 +7,29 @@ import type { PDFProcessorResult } from "./types";
 export async function scrapePDFWithParsePDF(
   meta: Meta,
   tempFilePath: string,
+  method?: string,
 ): Promise<PDFProcessorResult> {
-  meta.logger.debug("Processing PDF document with parse-pdf", { tempFilePath });
+  const logger = meta.logger.child({ method: method ?? "scrapePDFWithParsePDF" });
+  logger.debug("Processing PDF document with parse-pdf", { tempFilePath });
 
-  const result = await PdfParse(await readFile(tempFilePath));
-  const escaped = escapeHtml(result.text);
+  try {
+    const startedAt = Date.now();
+    const result = await PdfParse(await readFile(tempFilePath));
+    const durationMs = Date.now() - startedAt;
+    const escaped = escapeHtml(result.text);
 
-  return {
-    markdown: escaped,
-    html: escaped,
-  };
+    logger.info("pdfParse succeeded", {
+      durationMs,
+      markdownLength: escaped.length,
+      numPages: result.numpages,
+    });
+
+    return {
+      markdown: escaped,
+      html: escaped,
+    };
+  } catch (error) {
+    logger.error("pdfParse failed", { error });
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary
- Add info-level log on successful PDF parsing (duration, markdown length, page count)
- Add error-level log on pdfParse failure
- Accept optional `method` param for caller-specific logger context

## Test plan
- [ ] Verify logs appear in dev when pdfParse succeeds
- [ ] Verify error log appears when pdfParse throws

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured logging to PDF parsing for better observability. Records success metrics and errors, and keeps the original logger pass pattern (no new params).

- **New Features**
  - Info log on success with `durationMs`, `markdownLength`, and `numPages`.
  - Error log on failure with error payload.

- **Bug Fixes**
  - Restored original logger pass pattern; removed `method` param (no API change).

<sup>Written for commit 81cc08b6d2e5a7b1db90515527b7de52c4776d8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

