### PR TITLE
fix(js-sdk): bump axios to ^1.15.0 for critical vulnerability fix

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -26,7 +26,7 @@
   "author": "Mendable.ai",
   "license": "MIT",
   "dependencies": {
-    "axios": "1.14.0",
+    "axios": "^1.15.0",
     "firecrawl": "4.16.0",
     "typescript-event-target": "^1.1.1",
     "zod": "^3.23.8",


### PR DESCRIPTION
## Summary

Fixes #3327.

Bumps `axios` from pinned `1.14.0` to `^1.15.0` in the JS SDK. Axios 1.15.0 contains a critical security vulnerability fix. Uses caret range to allow future patch updates.

## Test plan

- [x] `npm audit` should no longer flag axios vulnerability

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `axios` in the JS SDK from 1.14.0 to `^1.15.0` to patch a critical security vulnerability and enable future patch updates.

<sup>Written for commit 6325eafb4798aac37df4e4eb054c10dbfd973296. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

