### PR TITLE
chore(js-sdk): bump ver to 4.18.2

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.18.1",
+  "version": "4.18.2",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bump `@mendable/firecrawl-js` from 4.18.1 to 4.18.2. Changes since last version bump: upgraded axios to 1.15.0 to resolve GHSA-3p68-rc4w-qgx5 (#3329).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 4.18.2 of `@mendable/firecrawl-js`. Publishes the `axios` 1.15.0 upgrade to address GHSA-3p68-rc4w-qgx5.

<sup>Written for commit 240813ff83b7c6413e24c65257a517e900c4950e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

