### PR TITLE
fix(nuq-postgres): set --chmod=0644 on initdb SQL so postgres user can read it

### DIFF
--- a/apps/nuq-postgres/Dockerfile
+++ b/apps/nuq-postgres/Dockerfile
@@ -17,5 +17,9 @@ RUN set -eux; \
     sed -ri "s/^#?shared_preload_libraries\s*=.*/shared_preload_libraries = 'pg_cron'/" "$conf_sample"; \
     printf "\n# Added for pg_cron\ncron.database_name = 'postgres'\n" >> "$conf_sample"
 
-# Copy nuq.sql so it is executed as part of the initdb sequence
-COPY nuq.sql /docker-entrypoint-initdb.d/010-nuq.sql
+# Copy nuq.sql so it is executed as part of the initdb sequence.
+# --chmod=0644 ensures world-readable permissions: the postgres Docker image
+# re-executes itself via `gosu postgres`, so init scripts run as the postgres
+# user, not root.  Without explicit permissions the file may be unreadable,
+# causing: "psql: error: /docker-entrypoint-initdb.d/010-nuq.sql: Permission denied"
+COPY --chmod=0644 nuq.sql /docker-entrypoint-initdb.d/010-nuq.sql


### PR DESCRIPTION
Fixes #2317

## Problem

The postgres Docker image re-executes `docker-entrypoint.sh` as the `postgres` user via `gosu postgres` before processing files in `/docker-entrypoint-initdb.d/`. The `COPY` instruction without an explicit `--chmod` flag preserves the source file's permissions from the build host. Depending on the host's umask or how git checked out the file, the resulting permissions may not include world-read, causing the init script to fail silently or with:

```
psql: error: /docker-entrypoint-initdb.d/010-nuq.sql: Permission denied
```

This prevents `nuq.sql` from running, so the `nuq` schema (tables, indexes, pg_cron jobs) is never created, which leads to errors like `relation "nuq.group_crawl" does not exist` when the API starts.

## Solution

Add `--chmod=0644` to the `COPY` instruction so `nuq.sql` is always world-readable, regardless of the build host's umask or file system permissions:

```dockerfile
COPY --chmod=0644 nuq.sql /docker-entrypoint-initdb.d/010-nuq.sql
```

This is a single-line change. `--chmod` is supported by Docker BuildKit (available since Docker 20.10, the default since Docker 23).

## Testing

- Verified that `COPY --chmod=0644` is valid Dockerfile syntax with BuildKit
- Verified that the postgres 17 Docker image entrypoint runs init scripts as the `postgres` user (via `gosu postgres`), confirming the need for world-readable permissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set explicit read permissions on the init SQL in `nuq-postgres` so Postgres can execute it on first startup. Adds `COPY --chmod=0644` for `nuq.sql`, preventing permission denied errors under `gosu postgres` and ensuring the `nuq` schema is created.

<sup>Written for commit 8a65623f0f3f4da26d2a40fb0e903280f16fa5cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

