### PR TITLE
fix(js-sdk): convert Zod schemas in formats[].json for scrape() and batchScrape()

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -4,6 +4,8 @@ import {
   type CrawlErrorsResponse,
   type Document,
   type BatchScrapeOptions,
+  type JsonFormat,
+  type ScrapeOptions,
   type PaginationConfig,
   JobTimeoutError,
   SdkError,
@@ -12,6 +14,21 @@ import { HttpClient } from "../utils/httpClient";
 import { ensureValidScrapeOptions } from "../utils/validation";
 import { fetchAllPages } from "../utils/pagination";
 import { normalizeAxiosError, throwForBadResponse, isRetryableError } from "../utils/errorHandler";
+import { isZodSchema, zodSchemaToJsonSchema } from "../../utils/zodSchemaToJson";
+
+function convertFormatsSchemas(options: ScrapeOptions): ScrapeOptions {
+  if (!options.formats) return options;
+  const convertedFormats = options.formats.map(format => {
+    if (typeof format === "object" && format !== null && (format as JsonFormat).type === "json") {
+      const jsonFormat = format as JsonFormat;
+      if (jsonFormat.schema != null && isZodSchema(jsonFormat.schema)) {
+        return { ...jsonFormat, schema: zodSchemaToJsonSchema(jsonFormat.schema) };
+      }
+    }
+    return format;
+  });
+  return { ...options, formats: convertedFormats };
+}
 
 export async function startBatchScrape(
   http: HttpClient,
@@ -32,7 +49,7 @@ export async function startBatchScrape(
   const payload: Record<string, unknown> = { urls };
   if (options) {
     ensureValidScrapeOptions(options);
-    Object.assign(payload, options);
+    Object.assign(payload, convertFormatsSchemas(options));
   }
   if (webhook != null) payload.webhook = webhook;
   if (appendToId != null) payload.appendToId = appendToId;

--- a/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts
@@ -1,5 +1,6 @@
 import {
   type Document,
+  type JsonFormat,
   type ScrapeBrowserDeleteResponse,
   type ScrapeExecuteRequest,
   type ScrapeExecuteResponse,
@@ -8,6 +9,21 @@ import {
 import { HttpClient } from "../utils/httpClient";
 import { ensureValidScrapeOptions } from "../utils/validation";
 import { throwForBadResponse, normalizeAxiosError } from "../utils/errorHandler";
+import { isZodSchema, zodSchemaToJsonSchema } from "../../utils/zodSchemaToJson";
+
+function convertFormatsSchemas(options: ScrapeOptions): ScrapeOptions {
+  if (!options.formats) return options;
+  const convertedFormats = options.formats.map(format => {
+    if (typeof format === "object" && format !== null && (format as JsonFormat).type === "json") {
+      const jsonFormat = format as JsonFormat;
+      if (jsonFormat.schema != null && isZodSchema(jsonFormat.schema)) {
+        return { ...jsonFormat, schema: zodSchemaToJsonSchema(jsonFormat.schema) };
+      }
+    }
+    return format;
+  });
+  return { ...options, formats: convertedFormats };
+}
 
 export async function scrape(http: HttpClient, url: string, options?: ScrapeOptions): Promise<Document> {
   if (!url || !url.trim()) {
@@ -16,7 +32,7 @@ export async function scrape(http: HttpClient, url: string, options?: ScrapeOpti
   if (options) ensureValidScrapeOptions(options);
 
   const payload: Record<string, unknown> = { url: url.trim() };
-  if (options) Object.assign(payload, options);
+  if (options) Object.assign(payload, convertFormatsSchemas(options));
 
   try {
     const res = await http.post<{ success: boolean; data?: Document; error?: string }>("/v2/scrape", payload);


### PR DESCRIPTION
Fixes #3300

## Problem

The v2 `scrape()` and `startBatchScrape()` methods spread `ScrapeOptions` verbatim into the request payload using `Object.assign(payload, options)`. This means when a user passes a Zod schema in `formats: [{ type: 'json', schema: zodSchema }]`, the raw Zod object is sent to the API as-is.

The API cannot parse raw Zod objects, so `result.json` is always `undefined` even though the TypeScript types (`InferredJsonFromOptions<Opts>`) advertise that it will be populated.

## Solution

Added a `convertFormatsSchemas()` helper in both `scrape.ts` and `batch.ts` that walks the `formats` array and applies `zodSchemaToJsonSchema()` to any `{ type: 'json', schema }` entry before posting — the same pattern already used in `extract()` and `batchExtract()`.

```typescript
// Before (broken): raw Zod object sent to API → result.json === undefined
await firecrawl.scrape(url, {
  formats: [{ type: 'json', schema: z.object({ name: z.string() }) }]
});

// After (fixed): Zod schema converted to JSON Schema → result.json populated
await firecrawl.scrape(url, {
  formats: [{ type: 'json', schema: z.object({ name: z.string() }) }]
});
```

Plain JSON Schema objects are passed through unchanged (the `isZodSchema()` check is a no-op for them).

## Testing

- The fix mirrors the existing approach in `extract.ts` (`prepareExtractPayload`) which already works correctly
- `isZodSchema()` detects both Zod v3 (via `_def`) and Zod v4 (via `_zod`) markers
- Non-Zod schemas (plain JSON Schema objects) are passed through without modification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert Zod schemas in `formats[].json.schema` to JSON Schema in v2 `scrape()` and `startBatchScrape()`. This lets the API parse them and populate `result.json` as expected (fixes #3300).

- **Bug Fixes**
  - Added `convertFormatsSchemas()` to convert `{ type: 'json', schema }` via `zodSchemaToJsonSchema()`.
  - Leaves plain JSON Schema unchanged; supports Zod v3/v4 with `isZodSchema`.
  - Matches existing behavior in `extract()` and `batchExtract()`.

<sup>Written for commit 0f6c307f0def27a9f057b8676e6905b1140787ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

