### PR TITLE
fix(pdf): catch marked.parse stack overflow in PDF pipeline

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/markdownToHtml.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/markdownToHtml.test.ts
@@ -5,8 +5,8 @@ const noopLogger = {
 } as any;
 
 describe("safeMarkdownToHtml", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("converts simple markdown to HTML", async () => {
@@ -15,35 +15,26 @@ describe("safeMarkdownToHtml", () => {
     expect(html).toContain("Hello");
   });
 
-  it("does not throw on pathologically deep markdown and returns <pre> fallback", async () => {
-    // 50,000 nested blockquotes — enough to blow the call stack in marked's recursive parser
+  it("does not throw on pathologically deep or large markdown", async () => {
+    // 50,000 nested blockquotes
     const deep = "> ".repeat(50_000) + "content";
-    const html = await safeMarkdownToHtml(deep, noopLogger, "test-deep");
-    // Should not throw — either marked handles it or we fall back
-    expect(typeof html).toBe("string");
-    expect(html.length).toBeGreaterThan(0);
+    const htmlDeep = await safeMarkdownToHtml(deep, noopLogger, "test-deep");
+    expect(typeof htmlDeep).toBe("string");
+    expect(htmlDeep.length).toBeGreaterThan(0);
 
-    // If marked blew up, we should get the <pre> fallback
-    if (html.startsWith("<pre>")) {
-      expect(html).toContain("content");
-      expect(noopLogger.warn).toHaveBeenCalled();
-    }
-  });
-
-  it("does not throw on a large table and returns <pre> fallback", async () => {
     // ~200KB markdown table
     const row = "| " + "cell | ".repeat(10) + "\n";
     const header = row + "| " + "--- | ".repeat(10) + "\n";
     const table = header + row.repeat(5_000);
     expect(table.length).toBeGreaterThan(200_000);
 
-    const html = await safeMarkdownToHtml(table, noopLogger, "test-table");
-    expect(typeof html).toBe("string");
-    expect(html.length).toBeGreaterThan(0);
+    const htmlTable = await safeMarkdownToHtml(table, noopLogger, "test-table");
+    expect(typeof htmlTable).toBe("string");
+    expect(htmlTable.length).toBeGreaterThan(0);
   });
 
-  it("escapes HTML entities in the <pre> fallback", async () => {
-    // Force the fallback by mocking marked
+  it("falls back to escaped <pre> and logs a warning when marked.parse throws", async () => {
+    // monkey-patch required since marked exports are non-configurable (can't use jest.spyOn)
     const markedModule = require("marked");
     const originalParse = markedModule.parse;
     markedModule.parse = () => {
@@ -53,34 +44,23 @@ describe("safeMarkdownToHtml", () => {
     try {
       const input = '<script>alert("xss")</script> & "quotes" \'apos\'';
       const html = await safeMarkdownToHtml(input, noopLogger, "test-escape");
-      expect(html).toStartWith("<pre>");
+
+      expect(html.startsWith("<pre>")).toBe(true);
       expect(html).toContain("&lt;script&gt;");
       expect(html).toContain("&amp;");
       expect(html).toContain("&quot;quotes&quot;");
       expect(html).toContain("&#39;apos&#39;");
       expect(html).not.toContain("<script>");
+
+      expect(noopLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("marked.parse failed"),
+        expect.objectContaining({
+          scrapeId: "test-escape",
+          markdownLength: expect.any(Number),
+        }),
+      );
     } finally {
       markedModule.parse = originalParse;
     }
   });
 });
-
-// Custom matcher
-expect.extend({
-  toStartWith(received: string, expected: string) {
-    const pass = typeof received === "string" && received.startsWith(expected);
-    return {
-      pass,
-      message: () =>
-        `expected ${JSON.stringify(received.slice(0, 50))}... to start with ${JSON.stringify(expected)}`,
-    };
-  },
-});
-
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toStartWith(expected: string): R;
-    }
-  }
-}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/markdownToHtml.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/markdownToHtml.test.ts
@@ -7,6 +7,7 @@ const noopLogger = {
 describe("safeMarkdownToHtml", () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    noopLogger.warn.mockClear();
   });
 
   it("converts simple markdown to HTML", async () => {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/markdownToHtml.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/markdownToHtml.test.ts
@@ -1,0 +1,86 @@
+import { safeMarkdownToHtml } from "../markdownToHtml";
+
+const noopLogger = {
+  warn: jest.fn(),
+} as any;
+
+describe("safeMarkdownToHtml", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("converts simple markdown to HTML", async () => {
+    const html = await safeMarkdownToHtml("# Hello", noopLogger, "test-1");
+    expect(html).toContain("<h1>");
+    expect(html).toContain("Hello");
+  });
+
+  it("does not throw on pathologically deep markdown and returns <pre> fallback", async () => {
+    // 50,000 nested blockquotes — enough to blow the call stack in marked's recursive parser
+    const deep = "> ".repeat(50_000) + "content";
+    const html = await safeMarkdownToHtml(deep, noopLogger, "test-deep");
+    // Should not throw — either marked handles it or we fall back
+    expect(typeof html).toBe("string");
+    expect(html.length).toBeGreaterThan(0);
+
+    // If marked blew up, we should get the <pre> fallback
+    if (html.startsWith("<pre>")) {
+      expect(html).toContain("content");
+      expect(noopLogger.warn).toHaveBeenCalled();
+    }
+  });
+
+  it("does not throw on a large table and returns <pre> fallback", async () => {
+    // ~200KB markdown table
+    const row = "| " + "cell | ".repeat(10) + "\n";
+    const header = row + "| " + "--- | ".repeat(10) + "\n";
+    const table = header + row.repeat(5_000);
+    expect(table.length).toBeGreaterThan(200_000);
+
+    const html = await safeMarkdownToHtml(table, noopLogger, "test-table");
+    expect(typeof html).toBe("string");
+    expect(html.length).toBeGreaterThan(0);
+  });
+
+  it("escapes HTML entities in the <pre> fallback", async () => {
+    // Force the fallback by mocking marked
+    const markedModule = require("marked");
+    const originalParse = markedModule.parse;
+    markedModule.parse = () => {
+      throw new RangeError("Maximum call stack size exceeded");
+    };
+
+    try {
+      const input = '<script>alert("xss")</script> & "quotes" \'apos\'';
+      const html = await safeMarkdownToHtml(input, noopLogger, "test-escape");
+      expect(html).toStartWith("<pre>");
+      expect(html).toContain("&lt;script&gt;");
+      expect(html).toContain("&amp;");
+      expect(html).toContain("&quot;quotes&quot;");
+      expect(html).toContain("&#39;apos&#39;");
+      expect(html).not.toContain("<script>");
+    } finally {
+      markedModule.parse = originalParse;
+    }
+  });
+});
+
+// Custom matcher
+expect.extend({
+  toStartWith(received: string, expected: string) {
+    const pass = typeof received === "string" && received.startsWith(expected);
+    return {
+      pass,
+      message: () =>
+        `expected ${JSON.stringify(received.slice(0, 50))}... to start with ${JSON.stringify(expected)}`,
+    };
+  },
+});
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toStartWith(expected: string): R;
+    }
+  }
+}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -2,8 +2,8 @@ import { Meta } from "../..";
 import { config } from "../../../../config";
 import { robustFetch } from "../../lib/fetch";
 import { z } from "zod";
-import * as marked from "marked";
 import type { PDFProcessorResult } from "./types";
+import { safeMarkdownToHtml } from "./markdownToHtml";
 import {
   getPdfResultFromCache,
   savePdfResultToCache,
@@ -78,7 +78,7 @@ export async function scrapePDFWithFirePDF(
 
   const processorResult = {
     markdown: resp.markdown,
-    html: await marked.parse(resp.markdown, { async: true }),
+    html: await safeMarkdownToHtml(resp.markdown, logger, meta.id),
   };
 
   if (!maxPages && !meta.internalOptions.zeroDataRetention) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -1,8 +1,8 @@
 import { Meta } from "../..";
 import { config } from "../../../../config";
 import { EngineScrapeResult } from "..";
-import * as marked from "marked";
 import { downloadFile, fetchFileToBuffer } from "../utils/downloadFile";
+import { safeMarkdownToHtml } from "./markdownToHtml";
 import {
   PDFAntibotError,
   PDFInsufficientTimeError,
@@ -300,7 +300,11 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         }
 
         if (eligible && pdfResult.markdown) {
-          const html = await marked.parse(pdfResult.markdown, { async: true });
+          const html = await safeMarkdownToHtml(
+            pdfResult.markdown,
+            logger,
+            meta.id,
+          );
           result = { markdown: pdfResult.markdown, html };
         }
       } catch (error) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/markdownToHtml.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/markdownToHtml.ts
@@ -1,0 +1,24 @@
+import * as marked from "marked";
+import type { Logger } from "winston";
+
+export async function safeMarkdownToHtml(
+  markdown: string,
+  logger: Logger,
+  scrapeId: string,
+): Promise<string> {
+  try {
+    return await marked.parse(markdown, { async: true });
+  } catch (e) {
+    logger.warn("marked.parse failed, falling back to <pre> wrapper", {
+      error: e,
+      scrapeId,
+      markdownLength: markdown.length,
+    });
+    return `<pre>${markdown
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;")}</pre>`;
+  }
+}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/runpodMU.ts
@@ -1,7 +1,7 @@
 import { Meta } from "../..";
 import { config } from "../../../../config";
-import * as marked from "marked";
 import { robustFetch } from "../../lib/fetch";
+import { safeMarkdownToHtml } from "./markdownToHtml";
 import { z } from "zod";
 import path from "node:path";
 import {
@@ -188,7 +188,7 @@ export async function scrapePDFWithRunPodMU(
 
   const processorResult = {
     markdown: result.markdown,
-    html: await marked.parse(result.markdown, { async: true }),
+    html: await safeMarkdownToHtml(result.markdown, meta.logger, meta.id),
   };
 
   if (!meta.internalOptions.zeroDataRetention) {


### PR DESCRIPTION
## Summary

- Add `safeMarkdownToHtml` helper that wraps `marked.parse()` in a try/catch, falling back to an HTML-escaped `<pre>` block on stack overflow (or any error). This prevents ~32 scrapes/day from crashing with `RangeError: Maximum call stack size exceeded` on deeply nested markdown from large PDFs.
- Replace all three `marked.parse()` call sites in the PDF pipeline: `firePDF.ts`, `runpodMU.ts`, and `index.ts` (Rust text-based path — latent bug that would silently fall through to MU/PdfParse fallback, wasting compute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Catches `marked.parse` stack overflows in the PDF pipeline and falls back to a safe, escaped `<pre>` block. This prevents ~32 scrapes/day from crashing and avoids unnecessary MinerU fallbacks.

- **Bug Fixes**
  - Added `safeMarkdownToHtml` to wrap `marked.parse`; on error returns escaped `<pre>` and logs a warning with the scrape ID.
  - Replaced direct `marked.parse` calls in `firePDF.ts`, `runpodMU.ts`, and `index.ts` (Rust text path).
  - Added and cleaned tests: cover normal parsing, deep/large inputs, and XSS-safe `<pre>` fallback; assert `logger.warn` includes `scrapeId` and `markdownLength`.

<sup>Written for commit d375b9994ff67ac36f2e41900d45f8587c82f882. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

