### PR TITLE
fix(api): prevent base64 PDF content in log output

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/fetch.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/fetch.ts
@@ -157,7 +157,7 @@ export async function robustFetch<
           });
           throw new Error("Request failed", {
             cause: {
-              params,
+              params: logParams,
               requestId,
               error,
             },


### PR DESCRIPTION
When robustFetch throws a request failure error, the error cause included the full params object containing the raw PDF base64 body. Upstream callers (e.g. the FirePDF fallback handler) log this error, resulting in massive base64 strings polluting logs. The fix uses logParams (which already strips body.pdf and body.input.file_content) in the error cause, consistent with what the other error path on line 253 already does.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `logParams` in `robustFetch` error causes so raw base64 PDF bodies are not logged. This stops huge strings from polluting upstream logs (e.g., FirePDF fallback) and keeps logs readable.

<sup>Written for commit 8eb682f4ab1bbdb1d89b31d10a651d94d150c4f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

