### PR TITLE
feat(pdf): add MINERU_PERCENT traffic routing

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -162,6 +162,9 @@ const configSchema = z.object({
   PDF_MU_V2_EXPERIMENT: z.string().optional(),
   PDF_MU_V2_EXPERIMENT_PERCENT: z.coerce.number().default(100),
 
+  // MinerU direct routing (bypass Rust extraction for a % of traffic)
+  MINERU_PERCENT: z.coerce.number().min(0).max(100).default(0),
+
   // Fire PDF (replaces MinerU for a % of traffic)
   FIRE_PDF_ENABLE: z.stringbool().optional(),
   FIRE_PDF_PERCENT: z.coerce.number().min(0).max(100).default(10),

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -357,8 +357,9 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     }
 
     // OCR / MU fallback.
-    // Skipped only when Rust extraction is enabled AND mode is "fast".
-    const skipOCR = rustEnabled && mode === "fast";
+    // Skipped only when Rust extraction is enabled AND mode is "fast",
+    // unless we explicitly routed to MinerU via MINERU_PERCENT.
+    const skipOCR = rustEnabled && mode === "fast" && !routeToMinerU;
     if (!result && !skipOCR) {
       const base64Content = (await readFile(tempFilePath)).toString("base64");
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -161,7 +161,18 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     const rustEnabled = !!config.PDF_RUST_EXTRACT_ENABLE;
     const logger = meta.logger.child({ method: "scrapePDF/processPdf" });
 
-    if (!rustEnabled || mode === "ocr" || forceFirePDF) {
+    // Route a percentage of traffic directly to MinerU, bypassing Rust extraction.
+    const routeToMinerU =
+      config.MINERU_PERCENT > 0 && Math.random() * 100 < config.MINERU_PERCENT;
+
+    if (routeToMinerU) {
+      logger.info("Routing to MinerU via MINERU_PERCENT", {
+        mineruPercent: config.MINERU_PERCENT,
+        url: meta.rewrittenUrl ?? meta.url,
+      });
+    }
+
+    if (!rustEnabled || mode === "ocr" || forceFirePDF || routeToMinerU) {
       // Legacy / OCR path: detect metadata only, skip Rust extraction.
       // When PDF_RUST_EXTRACT_ENABLE is off this is the only path taken,
       // matching current prod behaviour (detectPdf → MinerU → pdfParse).
@@ -349,12 +360,14 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       const base64Content = (await readFile(tempFilePath)).toString("base64");
 
       // Route a percentage of traffic to Fire PDF instead of MinerU
+      // Skip Fire PDF when we explicitly routed to MinerU via MINERU_PERCENT
       const useFirePDF =
-        forceFirePDF ||
-        (config.FIRE_PDF_ENABLE &&
-          config.FIRE_PDF_BASE_URL &&
-          base64Content.length < MAX_FILE_SIZE &&
-          Math.random() * 100 < config.FIRE_PDF_PERCENT);
+        !routeToMinerU &&
+        (forceFirePDF ||
+          (config.FIRE_PDF_ENABLE &&
+            config.FIRE_PDF_BASE_URL &&
+            base64Content.length < MAX_FILE_SIZE &&
+            Math.random() * 100 < config.FIRE_PDF_PERCENT));
 
       if (useFirePDF) {
         try {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -162,8 +162,11 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     const logger = meta.logger.child({ method: "scrapePDF/processPdf" });
 
     // Route a percentage of traffic directly to MinerU, bypassing Rust extraction.
+    // Forced Fire PDF takes precedence — don't divert those requests.
     const routeToMinerU =
-      config.MINERU_PERCENT > 0 && Math.random() * 100 < config.MINERU_PERCENT;
+      !forceFirePDF &&
+      config.MINERU_PERCENT > 0 &&
+      Math.random() * 100 < config.MINERU_PERCENT;
 
     if (routeToMinerU) {
       logger.info("Routing to MinerU via MINERU_PERCENT", {
@@ -359,15 +362,16 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     if (!result && !skipOCR) {
       const base64Content = (await readFile(tempFilePath)).toString("base64");
 
-      // Route a percentage of traffic to Fire PDF instead of MinerU
-      // Skip Fire PDF when we explicitly routed to MinerU via MINERU_PERCENT
+      // Route a percentage of traffic to Fire PDF instead of MinerU.
+      // forceFirePDF always wins; skip percentage-based Fire PDF when
+      // we explicitly routed to MinerU via MINERU_PERCENT.
       const useFirePDF =
-        !routeToMinerU &&
-        (forceFirePDF ||
-          (config.FIRE_PDF_ENABLE &&
-            config.FIRE_PDF_BASE_URL &&
-            base64Content.length < MAX_FILE_SIZE &&
-            Math.random() * 100 < config.FIRE_PDF_PERCENT));
+        forceFirePDF ||
+        (!routeToMinerU &&
+          config.FIRE_PDF_ENABLE &&
+          config.FIRE_PDF_BASE_URL &&
+          base64Content.length < MAX_FILE_SIZE &&
+          Math.random() * 100 < config.FIRE_PDF_PERCENT);
 
       if (useFirePDF) {
         try {


### PR DESCRIPTION
## Summary

Adds a `MINERU_PERCENT` env var (0–100, default 0) that routes a configurable percentage of PDF traffic directly to MinerU, bypassing Rust extraction and Fire PDF. When the roll hits, the request takes the detect-only path straight to RunPod MinerU. This gives us a knob to offload PDF processing pressure to MinerU during traffic spikes without disabling Rust extraction entirely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `MINERU_PERCENT` env var to route a percentage of PDF requests straight to MinerU, bypassing Rust extraction. Routed requests take the detect-only path and skip Fire PDF unless `forceFirePDF` is set, and still hit MinerU in fast mode.

- **New Features**
  - `MINERU_PERCENT` (0–100, default 0) randomizes per-request routing directly to MinerU.

- **Bug Fixes**
  - `forceFirePDF` overrides `MINERU_PERCENT` routing.
  - In fast mode, routed requests no longer skip the MinerU fallback.

<sup>Written for commit 0ef4b7b03339dc09909f82e9a2cf169f1eb14f53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

