### PR TITLE
perf: 5 Playwright replicas + aggressive concurrency

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,7 @@
 name: firecrawl
 
 x-common-service: &common-service
-  # NOTE: If you don't want to build the service locally,
-  # comment out the build: statement and uncomment the image: statement
-  # image: ghcr.io/firecrawl/firecrawl
   build: apps/api
-
   ulimits:
     nofile:
       soft: 65535
@@ -20,26 +16,27 @@ x-common-service: &common-service
       max-size: "10m"
       max-file: "3"
       compress: "true"
+  restart: unless-stopped
 
 x-common-env: &common-env
   REDIS_URL: ${REDIS_URL:-redis://redis:6379}
   REDIS_RATE_LIMIT_URL: ${REDIS_URL:-redis://redis:6379}
-  PLAYWRIGHT_MICROSERVICE_URL: ${PLAYWRIGHT_MICROSERVICE_URL:-http://playwright-service:3000/scrape}
+  PLAYWRIGHT_MICROSERVICE_URL: ${PLAYWRIGHT_MICROSERVICE_URL:-http://playwright-lb:3000/scrape}
   POSTGRES_USER: ${POSTGRES_USER:-postgres}
-  POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-postgres}"
+  POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
   POSTGRES_DB: ${POSTGRES_DB:-postgres}
   POSTGRES_HOST: ${POSTGRES_HOST:-nuq-postgres}
   POSTGRES_PORT: ${POSTGRES_PORT:-5432}
   USE_DB_AUTHENTICATION: ${USE_DB_AUTHENTICATION:-false}
-  NUM_WORKERS_PER_QUEUE: ${NUM_WORKERS_PER_QUEUE:-8}
-  CRAWL_CONCURRENT_REQUESTS: ${CRAWL_CONCURRENT_REQUESTS:-10}
-  MAX_CONCURRENT_JOBS: ${MAX_CONCURRENT_JOBS:-5}
-  BROWSER_POOL_SIZE: ${BROWSER_POOL_SIZE:-5}
+  NUM_WORKERS_PER_QUEUE: ${NUM_WORKERS_PER_QUEUE:-32}
+  CRAWL_CONCURRENT_REQUESTS: ${CRAWL_CONCURRENT_REQUESTS:-120}
+  MAX_CONCURRENT_JOBS: ${MAX_CONCURRENT_JOBS:-36}
+  BROWSER_POOL_SIZE: ${BROWSER_POOL_SIZE:-36}
   OPENAI_API_KEY: ${OPENAI_API_KEY}
   OPENAI_BASE_URL: ${OPENAI_BASE_URL}
   MODEL_NAME: ${MODEL_NAME}
-  MODEL_EMBEDDING_NAME: ${MODEL_EMBEDDING_NAME} 
-  OLLAMA_BASE_URL: ${OLLAMA_BASE_URL} 
+  MODEL_EMBEDDING_NAME: ${MODEL_EMBEDDING_NAME}
+  OLLAMA_BASE_URL: ${OLLAMA_BASE_URL}
   SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
   BULL_AUTH_KEY: ${BULL_AUTH_KEY}
   TEST_API_KEY: ${TEST_API_KEY}
@@ -47,7 +44,7 @@ x-common-env: &common-env
   SUPABASE_URL: ${SUPABASE_URL}
   SUPABASE_SERVICE_TOKEN: ${SUPABASE_SERVICE_TOKEN}
   SELF_HOSTED_WEBHOOK_URL: ${SELF_HOSTED_WEBHOOK_URL}
-  LOGGING_LEVEL: ${LOGGING_LEVEL}
+  LOGGING_LEVEL: ${LOGGING_LEVEL:-INFO}
   PROXY_SERVER: ${PROXY_SERVER}
   PROXY_USERNAME: ${PROXY_USERNAME}
   PROXY_PASSWORD: ${PROXY_PASSWORD}
@@ -57,9 +54,6 @@ x-common-env: &common-env
 
 services:
   playwright-service:
-    # NOTE: If you don't want to build the service locally,
-    # comment out the build: statement and uncomment the image: statement
-    # image: ghcr.io/firecrawl/playwright-service:latest
     build: apps/playwright-service-ts
     environment:
       PORT: 3000
@@ -67,14 +61,22 @@ services:
       PROXY_USERNAME: ${PROXY_USERNAME}
       PROXY_PASSWORD: ${PROXY_PASSWORD}
       BLOCK_MEDIA: ${BLOCK_MEDIA}
-      # Configure maximum concurrent pages for Playwright browser instances
-      MAX_CONCURRENT_PAGES: ${CRAWL_CONCURRENT_REQUESTS:-10}
+      MAX_CONCURRENT_PAGES: ${MAX_CONCURRENT_PAGES:-60}
     networks:
       - backend
-    # Resource limits for Docker Compose (not Swarm)
-    cpus: 2.0
-    mem_limit: 4G
-    memswap_limit: 4G
+    deploy:
+      replicas: 3
+      resources:
+        limits:
+          cpus: "5.0"
+          memory: 16G
+    shm_size: 2G
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     logging:
       driver: "json-file"
       options:
@@ -82,83 +84,145 @@ services:
         max-file: "3"
         compress: "true"
     tmpfs:
-      - /tmp/.cache:noexec,nosuid,size=1g
+      - /tmp/.cache:noexec,nosuid,size=4g
+    restart: unless-stopped
+
+  playwright-lb:
+    image: nginx:alpine
+    networks:
+      - backend
+    volumes:
+      - ./nginx-playwright.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - playwright-service
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    cpus: 0.5
+    mem_limit: 256M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "5m"
+        max-file: "2"
+    restart: unless-stopped
 
   api:
     <<: *common-service
     environment:
       <<: *common-env
       HOST: "0.0.0.0"
-      PORT: ${INTERNAL_PORT:-3002}
+      PORT: ${INTERNAL_PORT:-3300}
       EXTRACT_WORKER_PORT: ${EXTRACT_WORKER_PORT:-3004}
       WORKER_PORT: ${WORKER_PORT:-3005}
       NUQ_RABBITMQ_URL: amqp://rabbitmq:5672
+      NUQ_WORKER_COUNT: ${NUQ_WORKER_COUNT:-8}
       ENV: local
     depends_on:
       redis:
         condition: service_started
-      playwright-service:
-        condition: service_started
+      playwright-lb:
+        condition: service_healthy
       rabbitmq:
         condition: service_healthy
+      nuq-postgres:
+        condition: service_healthy
     ports:
-      - "${PORT:-3002}:${INTERNAL_PORT:-3002}"
+      - "${PORT:-3300}:${INTERNAL_PORT:-3300}"
     command: node dist/src/harness.js --start-docker
-    # Resource limits for Docker Compose (not Swarm)
-    # Increase if you have more CPU cores/RAM available
-    cpus: 4.0
-    mem_limit: 8G
-    memswap_limit: 8G
-
-  redis:
-    # NOTE: If you want to use Valkey (open source) instead of Redis (source available),
-    # uncomment the Valkey statement and comment out the Redis statement.
-    # Using Valkey with Firecrawl is untested and not guaranteed to work. Use with caution.
-    image: redis:alpine
-    # image: valkey/valkey:alpine
-
+    cpus: 12.0
+    mem_limit: 16G
+    memswap_limit: 16G
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3300/').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     networks:
       - backend
-    command: redis-server --bind 0.0.0.0
+
+  redis:
+    image: redis:alpine
+    networks:
+      - backend
+    command: redis-server --bind 0.0.0.0 --maxmemory 4096mb --maxmemory-policy allkeys-lru
+    cpus: 2.0
+    mem_limit: 5G
+    memswap_limit: 5G
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - redis-data:/data
     logging:
       driver: "json-file"
       options:
         max-size: "5m"
         max-file: "2"
         compress: "true"
-    
+    restart: unless-stopped
+
   rabbitmq:
     image: rabbitmq:3-management
     networks:
       - backend
     command: rabbitmq-server
+    cpus: 2.0
+    mem_limit: 3G
+    memswap_limit: 3G
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
       interval: 5s
       timeout: 5s
       retries: 3
-      start_period: 5s
+      start_period: 40s
     logging:
       driver: "json-file"
       options:
         max-size: "5m"
         max-file: "2"
         compress: "true"
-  
+    restart: unless-stopped
+
   nuq-postgres:
     build: apps/nuq-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
     networks:
       - backend
+    cpus: 1.0
+    mem_limit: 3G
+    memswap_limit: 3G
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-postgres} && psql -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-postgres} -c 'SELECT 1 FROM nuq.queue_scrape LIMIT 1'"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     logging:
       driver: "json-file"
       options:
         max-size: "10m"
         max-file: "3"
         compress: "true"
+    restart: unless-stopped
+
+volumes:
+  redis-data:
+  rabbitmq-data:
+  postgres-data:
 
 networks:
   backend:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,10 +28,10 @@ x-common-env: &common-env
   POSTGRES_HOST: ${POSTGRES_HOST:-nuq-postgres}
   POSTGRES_PORT: ${POSTGRES_PORT:-5432}
   USE_DB_AUTHENTICATION: ${USE_DB_AUTHENTICATION:-false}
-  NUM_WORKERS_PER_QUEUE: ${NUM_WORKERS_PER_QUEUE:-32}
-  CRAWL_CONCURRENT_REQUESTS: ${CRAWL_CONCURRENT_REQUESTS:-120}
-  MAX_CONCURRENT_JOBS: ${MAX_CONCURRENT_JOBS:-36}
-  BROWSER_POOL_SIZE: ${BROWSER_POOL_SIZE:-36}
+  NUM_WORKERS_PER_QUEUE: ${NUM_WORKERS_PER_QUEUE:-60}
+  CRAWL_CONCURRENT_REQUESTS: ${CRAWL_CONCURRENT_REQUESTS:-200}
+  MAX_CONCURRENT_JOBS: ${MAX_CONCURRENT_JOBS:-60}
+  BROWSER_POOL_SIZE: ${BROWSER_POOL_SIZE:-60}
   OPENAI_API_KEY: ${OPENAI_API_KEY}
   OPENAI_BASE_URL: ${OPENAI_BASE_URL}
   MODEL_NAME: ${MODEL_NAME}
@@ -61,16 +61,16 @@ services:
       PROXY_USERNAME: ${PROXY_USERNAME}
       PROXY_PASSWORD: ${PROXY_PASSWORD}
       BLOCK_MEDIA: ${BLOCK_MEDIA}
-      MAX_CONCURRENT_PAGES: ${MAX_CONCURRENT_PAGES:-60}
+      MAX_CONCURRENT_PAGES: ${MAX_CONCURRENT_PAGES:-30}
     networks:
       - backend
     deploy:
-      replicas: 3
+      replicas: 5
       resources:
         limits:
-          cpus: "5.0"
-          memory: 16G
-    shm_size: 2G
+          cpus: "3.0"
+          memory: 10G
+    shm_size: 1536M
     healthcheck:
       test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))\""]
       interval: 30s
@@ -133,9 +133,9 @@ services:
     ports:
       - "${PORT:-3300}:${INTERNAL_PORT:-3300}"
     command: node dist/src/harness.js --start-docker
-    cpus: 12.0
-    mem_limit: 16G
-    memswap_limit: 16G
+    cpus: 3.0
+    mem_limit: 6G
+    memswap_limit: 6G
     healthcheck:
       test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3300/').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))\""]
       interval: 30s
@@ -149,10 +149,10 @@ services:
     image: redis:alpine
     networks:
       - backend
-    command: redis-server --bind 0.0.0.0 --maxmemory 4096mb --maxmemory-policy allkeys-lru
-    cpus: 2.0
-    mem_limit: 5G
-    memswap_limit: 5G
+    command: redis-server --bind 0.0.0.0 --maxmemory 3072mb --maxmemory-policy allkeys-lru
+    cpus: 1.0
+    mem_limit: 4G
+    memswap_limit: 4G
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s

--- a/nginx-playwright.conf
+++ b/nginx-playwright.conf
@@ -1,0 +1,37 @@
+worker_processes auto;
+error_log /dev/stderr warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 2048;
+}
+
+http {
+    # Docker internal DNS — re-resolve on every request
+    resolver 127.0.0.11 valid=2s ipv6=off;
+
+    server {
+        listen 3000;
+
+        location /health {
+            # Use variable to force DNS re-resolution per request
+            set $playwright_backend http://playwright-service:3000;
+            proxy_pass $playwright_backend/health;
+            proxy_connect_timeout 5s;
+            proxy_read_timeout 10s;
+        }
+
+        location /scrape {
+            # Variable forces Nginx to re-resolve DNS every request
+            # Docker DNS round-robins across all replicas
+            set $playwright_backend http://playwright-service:3000;
+            proxy_pass $playwright_backend/scrape;
+            proxy_http_version 1.1;
+            proxy_set_header Connection '';
+            proxy_connect_timeout 10s;
+            proxy_read_timeout 120s;
+            proxy_send_timeout 30s;
+            proxy_buffering off;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Scale Playwright from **3 → 5 replicas** with tighter per-replica limits (3 CPU / 10G each)
- Slim down API container (12 CPU → 3 CPU, 16G → 6G) — it's an orchestrator, not compute-heavy
- Bump concurrency: 60 max concurrent jobs (was 36), 200 crawl requests (was 120)
- Reduce Redis CPU (2 → 1, it's single-threaded) and memory (5G → 4G)

### Resource allocation (before → after)

| Service | CPU before | CPU after | RAM before | RAM after |
|---|---|---|---|---|
| Playwright (total) | 15 (3×5) | 15 (5×3) | 48G (3×16) | 50G (5×10) |
| API | 12 | 3 | 16G | 6G |
| Redis | 2 | 1 | 5G | 4G |
| RabbitMQ | 2 | 2 | 3G | 3G |
| PostgreSQL | 1 | 1 | 3G | 3G |
| nginx LB | 0.5 | 0.5 | 256M | 256M |

### Post-deploy checklist
- [ ] SSH into tl-scraping and set up 16G swap as OOM safety net:
  ```bash
  sudo fallocate -l 16G /swapfile
  sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile
  echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
  sudo sysctl vm.swappiness=10
  ```
- [ ] Monitor with `docker stats` for 24h after deploy
- [ ] Watch for OOM kills: `dmesg | grep -i oom`
- [ ] If instability: scale back to 4 replicas via `deploy.replicas: 4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale Playwright to 5 replicas behind an internal `nginx` load balancer and raise concurrency to boost scraping throughput. Right-size container resources, add health checks and persistent volumes, and move the API to port 3300.

- **Refactors**
  - Playwright: 5 replicas (3 CPU/10G each), `MAX_CONCURRENT_PAGES` 30, larger `shm/tmpfs`, health checks.
  - Added `playwright-lb` (`nginx`) with per-request DNS round‑robin; `PLAYWRIGHT_MICROSERVICE_URL` now targets the LB.
  - Concurrency: 60 workers and max jobs; 200 crawl requests; browser pool 60.
  - API: reduced to 3 CPU/6G, port 3300, health check; depends on healthy LB/Postgres/RabbitMQ.
  - Infra: Redis capped at 1 CPU/4G with LRU; persistent volumes for Redis/RabbitMQ/Postgres; restart policies and health checks across services.

- **Migration**
  - Add a 16G swap file on the `tl-scraping` host as an OOM safety net.
  - After deploy, monitor `docker stats` for 24h and check for OOM kills.
  - If unstable, scale Playwright down to 4 replicas.

<sup>Written for commit c8d84a4d7fe0f8941fca036394e92e142d43d983. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

