### PR TITLE
fix(js-sdk): normalize pollInterval to prevent silent 83-min hang (ms/s double-conversion)

### DIFF
--- a/apps/js-sdk/firecrawl/src/v1/index.ts
+++ b/apps/js-sdk/firecrawl/src/v1/index.ts
@@ -1510,6 +1510,9 @@ export default class FirecrawlApp {
           } else if (
             ["active", "paused", "pending", "queued", "waiting", "scraping"].includes(statusData.status)
           ) {
+            // Normalize: if checkInterval looks like milliseconds (>= 1000), convert to seconds.
+            // This prevents a silent 1000x hang when callers accidentally pass ms instead of s.
+            if (checkInterval >= 1000) checkInterval = checkInterval / 1000;
             checkInterval = Math.max(checkInterval, 2);
             await new Promise((resolve) =>
               setTimeout(resolve, checkInterval * 1000)

--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -118,6 +118,10 @@ export async function getBatchScrapeErrors(http: HttpClient, jobId: string): Pro
 }
 
 export async function waitForBatchCompletion(http: HttpClient, jobId: string, pollInterval = 2, timeout?: number): Promise<BatchScrapeJob> {
+  // Normalize: if pollInterval looks like milliseconds (>= 1000), convert to seconds.
+  // This prevents a silent 1000x hang when callers accidentally pass ms instead of s.
+  if (pollInterval >= 1000) pollInterval = pollInterval / 1000;
+
   const start = Date.now();
 
   while (true) {

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -118,8 +118,12 @@ export async function cancelCrawl(http: HttpClient, jobId: string): Promise<bool
 }
 
 export async function waitForCrawlCompletion(http: HttpClient, jobId: string, pollInterval = 2, timeout?: number): Promise<CrawlJob> {
+  // Normalize: if pollInterval looks like milliseconds (>= 1000), convert to seconds.
+  // This prevents a silent 1000x hang when callers accidentally pass ms instead of s.
+  if (pollInterval >= 1000) pollInterval = pollInterval / 1000;
+
   const start = Date.now();
-  
+
   while (true) {
     try {
       const status = await getCrawlStatus(http, jobId);


### PR DESCRIPTION
## Summary

Fixes #3373 — `firecrawl crawl --wait` (without `--progress`) silently hangs ~83 minutes per poll cycle because of a double ms/s conversion between the CLI and the SDK.

The CLI converts `--poll-interval 5` → `5000` (ms) before passing to `app.crawl()`. The SDK's polling functions then multiply by 1000 again (they expect seconds), producing `5000 × 1000 = 5,000,000 ms ≈ 83 min` per poll. The crawl completes server-side and credits are consumed, but the CLI never returns.

## Fix

Add a normalization guard at the entry of every SDK polling function: if `pollInterval >= 1000`, treat it as milliseconds and divide by 1000 before use. No legitimate polling use case requires intervals of 1000+ seconds (16+ minutes), so the threshold has zero false positives for normal callers while silently correcting accidentally-large ms values.

Three functions patched:
- `waitForCrawlCompletion` — `apps/js-sdk/firecrawl/src/v2/methods/crawl.ts`
- `waitForBatchCompletion` — `apps/js-sdk/firecrawl/src/v2/methods/batch.ts`
- `monitorJobStatus` — `apps/js-sdk/firecrawl/src/v1/index.ts`

## Relevant prior art & context

- **#2608** (js-sdk: retry polling after errors, add jobId to error exception) — established the current shape of `waitForBatchCompletion` and `waitForCrawlCompletion`; the review there called out the need to distinguish retryable vs non-retryable errors in the same polling loop we're touching here.
- **#1892 / #1893** (fix(js-sdk): retry logic for socket hang up errors in `monitorJobStatus`) — last significant change to `monitorJobStatus`; added the `isRetryableError` pattern and the `Math.max(checkInterval, 2)` floor that our normalization guard sits above.
- **#3348** (feat(php-sdk): PHP SDK with Laravel support) — a code reviewer explicitly required "Validate poll interval ≥1s before `sleep()` in all poll loops" as a mandatory fix before merge. That review established the cross-SDK precedent that poll interval inputs must be validated/normalized, which is exactly what this PR does for the JS SDK.

## Test plan

- [ ] `firecrawl crawl <url> --limit 1 --wait --poll-interval 5` completes in seconds (not 83 min)
- [ ] `firecrawl crawl <url> --limit 1 --wait --poll-interval 5000` (ms accidentally passed) also completes correctly (normalized to 5s)
- [ ] Existing SDK callers passing correct seconds values (e.g. `pollInterval: 2`) are unaffected
- [ ] `batchScrape` with an ms-sized `pollInterval` also normalizes correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent 83‑minute hangs by normalizing polling intervals in the JS SDK to handle ms vs s correctly. Fixes #3373 so `firecrawl crawl --wait` polls at the intended frequency and returns promptly.

- **Bug Fixes**
  - Normalize `pollInterval`/`checkInterval`: if ≥ 1000, treat as milliseconds and divide by 1000 before sleeping.
  - Applied to `waitForCrawlCompletion` (v2), `waitForBatchCompletion` (v2), and `monitorJobStatus` (v1).
  - Seconds-based callers are unchanged; ms inputs like `5000` now behave as `5s`.

<sup>Written for commit ffd1ccedc89db9e23bb1873b9c5ff273be42eae6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

