### PR TITLE
fix(playwright): honor user-agent from request headers

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -197,8 +197,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false): Promise<{ context: BrowserContext; securityState: ContextSecurityState }> => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, userAgentOverride?: string): Promise<{ context: BrowserContext; securityState: ContextSecurityState }> => {
+  const userAgent = userAgentOverride || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
   const securityState: ContextSecurityState = {
     blockedNavigationRequestUrl: null,
@@ -401,13 +401,27 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    const contextBundle = await createContext(skip_tls_verification);
+    // Extract user-agent from request headers (case-insensitive) so it can
+    // be applied at the context level.  Playwright ignores user-agent in
+    // setExtraHTTPHeaders when the context already defines one (#2802).
+    const userAgentOverride = headers
+      ? Object.entries(headers).find(([k]) => k.toLowerCase() === 'user-agent')?.[1]
+      : undefined;
+
+    const contextBundle = await createContext(skip_tls_verification, userAgentOverride);
     requestContext = contextBundle.context;
     securityState = contextBundle.securityState;
     page = await requestContext.newPage();
 
     if (headers) {
-      await page.setExtraHTTPHeaders(headers);
+      // Remove the user-agent key before calling setExtraHTTPHeaders since
+      // we already forwarded it to the context-level userAgent option.
+      const filteredHeaders = Object.fromEntries(
+        Object.entries(headers).filter(([k]) => k.toLowerCase() !== 'user-agent')
+      );
+      if (Object.keys(filteredHeaders).length > 0) {
+        await page.setExtraHTTPHeaders(filteredHeaders);
+      }
     }
 
     const result = await scrapePage(


### PR DESCRIPTION
## Problem

When calling the `/scrape` endpoint with a `user-agent` in the `headers` object, the specified value is silently ignored. The actual request uses a randomly-generated user-agent from the `UserAgent` package instead.

## Root Cause

`createContext()` sets `userAgent` in the Playwright context options (line 201/208). Later, `page.setExtraHTTPHeaders(headers)` is called, but **Playwright ignores the `user-agent` key in extra HTTP headers when the context already defines a `userAgent`**. This is by design in Playwright — the context-level user-agent always takes precedence.

## Fix

1. **`createContext()` now accepts an optional `userAgentOverride` parameter.** When provided, it replaces the randomly-generated `UserAgent`. When omitted, behavior is unchanged.

2. **Before creating the context**, the scrape handler extracts `user-agent` from request headers (case-insensitive lookup) and passes it to `createContext()`.

3. **The `user-agent` key is filtered out of `setExtraHTTPHeaders()`** since it is already applied at the context level.

## Changes

- `apps/playwright-service-ts/api.ts`: 18 insertions, 4 deletions across `createContext` signature and the `/scrape` handler.

## Testing

- Without `user-agent` header: random user-agent generated as before (no regression).
- With `user-agent` header: specified value is used as the context-level user-agent.
- Other custom headers (e.g. `Authorization`, `Cookie`) continue to work via `setExtraHTTPHeaders`.

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the user-agent provided in `/scrape` request headers by applying it at the Playwright context level, fixing the header being ignored; behavior is unchanged when no header is provided. Fixes #2802.

- **Bug Fixes**
  - Extract `user-agent` (case-insensitive) and pass to `createContext` as `userAgentOverride`.
  - Remove `user-agent` from `page.setExtraHTTPHeaders()` since context `userAgent` takes precedence in Playwright.

<sup>Written for commit f73e5a885291f0ea6186128a3af6b108506789ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

