### PR TITLE
(feat/arxiv) Arxiv category

### DIFF
--- a/apps/api/requests/v2/search.requests.http
+++ b/apps/api/requests/v2/search.requests.http
@@ -33,3 +33,27 @@ content-type: application/json
   ],
   "limit": 5
 }
+
+### Search - Arxiv category (hits the dedicated arxiv search API)
+# @name searchArxiv
+POST {{baseUrl}}/v2/search HTTP/1.1
+Authorization: Bearer {{$dotenv TEST_API_KEY}}
+content-type: application/json
+
+{
+  "query": "retrieval augmented generation",
+  "categories": ["arxiv"],
+  "limit": 5
+}
+
+### Search - Arxiv + Github categories combined
+# @name searchArxivGithub
+POST {{baseUrl}}/v2/search HTTP/1.1
+Authorization: Bearer {{$dotenv TEST_API_KEY}}
+content-type: application/json
+
+{
+  "query": "retrieval augmented generation",
+  "categories": ["arxiv", "github"],
+  "limit": 10
+}

--- a/apps/api/src/__tests__/lib/search-query-builder.test.ts
+++ b/apps/api/src/__tests__/lib/search-query-builder.test.ts
@@ -165,6 +165,48 @@ describe("Search Query Builder", () => {
       // And the map still prefers the more specific arxiv category.
       expect(result.categoryMap.get("arxiv.org")).toBe("arxiv");
     });
+
+    it("should map arxiv.org to 'arxiv' regardless of category order (arxiv first)", () => {
+      // Regression: without order-independence, the research branch would
+      // clobber arxiv's claim since arxiv.org is in the default research
+      // sites, and URL classification would depend on array order.
+      const result = buildSearchQuery("rag", ["arxiv", "research"]);
+      expect(result.categoryMap.get("arxiv.org")).toBe("arxiv");
+    });
+
+    it("should map arxiv.org to 'arxiv' regardless of category order (research first)", () => {
+      const result = buildSearchQuery("rag", ["research", "arxiv"]);
+      expect(result.categoryMap.get("arxiv.org")).toBe("arxiv");
+    });
+
+    it("should map arxiv.org to 'arxiv' regardless of order in object form", () => {
+      const a = buildSearchQuery("rag", [
+        { type: "arxiv" },
+        { type: "research" },
+      ]);
+      const b = buildSearchQuery("rag", [
+        { type: "research" },
+        { type: "arxiv" },
+      ]);
+      expect(a.categoryMap.get("arxiv.org")).toBe("arxiv");
+      expect(b.categoryMap.get("arxiv.org")).toBe("arxiv");
+    });
+
+    it("should still map arxiv.org to 'research' when arxiv is NOT selected", () => {
+      // Sanity: research alone should continue to claim arxiv.org.
+      const result = buildSearchQuery("rag", ["research"]);
+      expect(result.categoryMap.get("arxiv.org")).toBe("research");
+    });
+
+    it("should keep custom research sites mapped to 'research' when arxiv + research are both selected", () => {
+      // Arxiv only supersedes arxiv.org — other research sites stay intact.
+      const result = buildSearchQuery("rag", [
+        { type: "research", sites: ["arxiv.org", "nature.com"] },
+        { type: "arxiv" },
+      ]);
+      expect(result.categoryMap.get("arxiv.org")).toBe("arxiv");
+      expect(result.categoryMap.get("nature.com")).toBe("research");
+    });
   });
 
   describe("getCategoryFromUrl", () => {
@@ -266,6 +308,20 @@ describe("Search Query Builder", () => {
       expect(
         getCategoryFromUrl("https://export.arxiv.org/abs/2503.10677", arxivMap),
       ).toBe("arxiv");
+    });
+
+    it("should classify arxiv URLs as 'arxiv' when both arxiv and research are selected, regardless of order", () => {
+      // End-to-end regression: build the map via buildSearchQuery and then
+      // classify, covering both orderings.
+      for (const order of [
+        ["arxiv", "research"] as const,
+        ["research", "arxiv"] as const,
+      ]) {
+        const { categoryMap } = buildSearchQuery("rag", [...order]);
+        expect(
+          getCategoryFromUrl("https://arxiv.org/abs/2503.10677", categoryMap),
+        ).toBe("arxiv");
+      }
     });
   });
 

--- a/apps/api/src/__tests__/lib/search-query-builder.test.ts
+++ b/apps/api/src/__tests__/lib/search-query-builder.test.ts
@@ -110,6 +110,61 @@ describe("Search Query Builder", () => {
       expect(result.query).toBe("test");
       expect(result.categoryMap.size).toBe(0);
     });
+
+    it("should map arxiv alone without adding a site filter", () => {
+      // When arxiv is the ONLY category, results come from the dedicated
+      // arxiv retrieval API — the builder must NOT add `site:arxiv.org` to
+      // the search query, but still tags arxiv.org in the category map.
+      const result = buildSearchQuery("rag", ["arxiv"]);
+      expect(result.query).toBe("rag");
+      expect(result.categoryMap.get("arxiv.org")).toBe("arxiv");
+      expect(result.categoryMap.size).toBe(1);
+    });
+
+    it("should map arxiv alone in object form without adding a site filter", () => {
+      const result = buildSearchQuery("rag", [{ type: "arxiv" }]);
+      expect(result.query).toBe("rag");
+      expect(result.categoryMap.get("arxiv.org")).toBe("arxiv");
+      expect(result.categoryMap.size).toBe(1);
+    });
+
+    it("should fold site:arxiv.org into the query when arxiv is mixed with another category", () => {
+      // When arxiv is combined with other categories we skip the dedicated
+      // API and let the main search rank arxiv results alongside the others
+      // via `site:arxiv.org`.
+      const result = buildSearchQuery("retrieval augmented generation", [
+        "arxiv",
+        "github",
+      ]);
+      expect(result.query).toContain("site:github.com");
+      expect(result.query).toContain("site:arxiv.org");
+      expect(result.query).toContain(" OR ");
+      expect(result.categoryMap.get("arxiv.org")).toBe("arxiv");
+      expect(result.categoryMap.get("github.com")).toBe("github");
+    });
+
+    it("should fold site:arxiv.org into the query when arxiv is mixed in object form", () => {
+      const result = buildSearchQuery("rag", [
+        { type: "arxiv" },
+        { type: "github" },
+      ]);
+      expect(result.query).toContain("site:github.com");
+      expect(result.query).toContain("site:arxiv.org");
+    });
+
+    it("should fold site:arxiv.org into the query when arxiv is mixed with pdf", () => {
+      const result = buildSearchQuery("rag", ["arxiv", "pdf"]);
+      expect(result.query).toContain("site:arxiv.org");
+      expect(result.query).toContain("filetype:pdf");
+    });
+
+    it("should not duplicate site:arxiv.org when research + arxiv are both selected", () => {
+      const result = buildSearchQuery("rag", ["research", "arxiv"]);
+      const matches = result.query.match(/site:arxiv\.org/g) ?? [];
+      expect(matches.length).toBe(1);
+      // And the map still prefers the more specific arxiv category.
+      expect(result.categoryMap.get("arxiv.org")).toBe("arxiv");
+    });
   });
 
   describe("getCategoryFromUrl", () => {
@@ -198,6 +253,19 @@ describe("Search Query Builder", () => {
       expect(
         getCategoryFromUrl("https://arxiv.org/abs/2024.12345", emptyMap),
       ).toBeUndefined();
+    });
+
+    it("should prefer arxiv over research mapping when arxiv is selected", () => {
+      const arxivMap = new Map<string, string>([
+        ["arxiv.org", "arxiv"],
+        ["nature.com", "research"],
+      ]);
+      expect(
+        getCategoryFromUrl("https://arxiv.org/abs/2503.10677", arxivMap),
+      ).toBe("arxiv");
+      expect(
+        getCategoryFromUrl("https://export.arxiv.org/abs/2503.10677", arxivMap),
+      ).toBe("arxiv");
     });
   });
 

--- a/apps/api/src/__tests__/search/arxiv.test.ts
+++ b/apps/api/src/__tests__/search/arxiv.test.ts
@@ -1,0 +1,81 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import { searchArxiv } from "../../search/arxiv";
+import { config } from "../../config";
+
+// Minimal logger stub — the arxiv client only uses `.info` and `.warn`.
+const makeLogger = () =>
+  ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }) as any;
+
+describe("searchArxiv", () => {
+  let originalUrl: string | undefined;
+
+  beforeEach(() => {
+    originalUrl = config.ARXIV_SEARCH_URL;
+  });
+
+  afterEach(() => {
+    (config as any).ARXIV_SEARCH_URL = originalUrl;
+  });
+
+  it("returns [] when ARXIV_SEARCH_URL is not configured", async () => {
+    (config as any).ARXIV_SEARCH_URL = undefined;
+    const logger = makeLogger();
+
+    const result = await searchArxiv({
+      query: "retrieval augmented generation",
+      limit: 5,
+      logger,
+    });
+
+    expect(result).toEqual([]);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("ARXIV_SEARCH_URL is not configured"),
+    );
+  });
+
+  it("returns [] when the query is empty", async () => {
+    (config as any).ARXIV_SEARCH_URL = "http://example.internal/search";
+    const logger = makeLogger();
+
+    const result = await searchArxiv({
+      query: "   ",
+      limit: 5,
+      logger,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] instead of throwing when ARXIV_SEARCH_URL is malformed", async () => {
+    // `new URL("not-a-url")` throws; the client must catch that and degrade
+    // to best-effort so a misconfigured env var never rejects the parent
+    // search request.
+    (config as any).ARXIV_SEARCH_URL = "not-a-url";
+    const logger = makeLogger();
+
+    await expect(
+      searchArxiv({
+        query: "retrieval augmented generation",
+        limit: 5,
+        logger,
+      }),
+    ).resolves.toEqual([]);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Arxiv search API call failed"),
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/api/src/__tests__/snips/v2/search.test.ts
+++ b/apps/api/src/__tests__/snips/v2/search.test.ts
@@ -8,6 +8,8 @@ import {
 import { search, idmux, Identity } from "./lib";
 import { config } from "../../../config";
 
+const HAS_ARXIV = !!config.ARXIV_SEARCH_URL;
+
 let identity: Identity;
 
 beforeAll(async () => {
@@ -265,6 +267,117 @@ describeIf(TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY)("Search tests", () => {
       expect(res.web).toBeDefined();
       expect(res.web?.length).toBeGreaterThan(0);
       expect(res.web?.length).toBeLessThanOrEqual(21);
+    },
+    60000,
+  );
+
+  // Arxiv category tests — these require the internal ARXIV_SEARCH_URL env var
+  // to be set, which points at the private arxiv retrieval service. When the
+  // URL is not configured the category becomes a no-op and these tests are skipped.
+  concurrentIf(HAS_ARXIV && (TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY))(
+    "works with arxiv category",
+    async () => {
+      const res = await search(
+        {
+          query: "retrieval augmented generation",
+          categories: ["arxiv"],
+          limit: 5,
+        },
+        identity,
+      );
+      expect(res.web).toBeDefined();
+      expect(res.web?.length).toBeGreaterThan(0);
+
+      const arxivHits = (res.web ?? []).filter(r => r.category === "arxiv");
+      expect(arxivHits.length).toBeGreaterThan(0);
+      for (const hit of arxivHits) {
+        expect(hit.url).toMatch(/^https?:\/\/([^/]+\.)?arxiv\.org\//);
+        expect(typeof hit.title).toBe("string");
+        expect(hit.title.length).toBeGreaterThan(0);
+      }
+    },
+    60000,
+  );
+
+  concurrentIf(HAS_ARXIV && (TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY))(
+    "works with arxiv category combined with github",
+    async () => {
+      const res = await search(
+        {
+          query: "retrieval augmented generation",
+          categories: ["arxiv", "github"],
+          limit: 10,
+        },
+        identity,
+      );
+      expect(res.web).toBeDefined();
+      expect(res.web?.length).toBeGreaterThan(0);
+
+      const categories = new Set(
+        (res.web ?? [])
+          .map(r => r.category)
+          .filter((c): c is string => Boolean(c)),
+      );
+      // We don't require github results in every environment (DDG fallbacks
+      // can be flaky), but arxiv must come back from the dedicated API.
+      expect(categories.has("arxiv")).toBe(true);
+    },
+    60000,
+  );
+
+  concurrentIf(HAS_ARXIV && (TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY))(
+    "respects limit when arxiv category is selected",
+    async () => {
+      const res = await search(
+        {
+          query: "retrieval augmented generation",
+          categories: ["arxiv"],
+          limit: 3,
+        },
+        identity,
+      );
+      expect(res.web).toBeDefined();
+      expect(res.web?.length).toBeGreaterThan(0);
+      expect(res.web?.length).toBeLessThanOrEqual(3);
+    },
+    60000,
+  );
+
+  concurrentIf(HAS_ARXIV && (TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY))(
+    "arxiv category works with advanced object format",
+    async () => {
+      const res = await search(
+        {
+          query: "retrieval augmented generation",
+          categories: [{ type: "arxiv" }],
+          limit: 5,
+        },
+        identity,
+      );
+      expect(res.web).toBeDefined();
+      const arxivHits = (res.web ?? []).filter(r => r.category === "arxiv");
+      expect(arxivHits.length).toBeGreaterThan(0);
+    },
+    60000,
+  );
+
+  // A happy-path failure test that runs everywhere: when arxiv is selected but
+  // the internal service is not configured, the endpoint must still respond
+  // successfully (just without arxiv-tagged results).
+  concurrentIf(!HAS_ARXIV && (TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY))(
+    "arxiv category is a no-op when ARXIV_SEARCH_URL is not configured",
+    async () => {
+      const res = await search(
+        {
+          query: "firecrawl",
+          categories: ["arxiv"],
+          limit: 5,
+        },
+        identity,
+      );
+      expect(res.web).toBeDefined();
+      const arxivHits = (res.web ?? []).filter(r => r.category === "arxiv");
+      expect(arxivHits.length).toBe(0);
     },
     60000,
   );

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -846,6 +846,51 @@ describe("V2 Types Validation", () => {
       expect(Array.isArray(result.categories)).toBe(true);
     });
 
+    it("should accept arxiv in simple categories array", () => {
+      const input: SearchRequestInput = {
+        query: "retrieval augmented generation",
+        categories: ["arxiv"],
+      };
+
+      const result = searchRequestSchema.parse(input);
+      expect(result.categories).toEqual([{ type: "arxiv" }]);
+    });
+
+    it("should accept arxiv with other categories", () => {
+      const input: SearchRequestInput = {
+        query: "retrieval augmented generation",
+        categories: ["arxiv", "github", "research"],
+      };
+
+      const result = searchRequestSchema.parse(input);
+      expect(result.categories).toEqual([
+        { type: "arxiv" },
+        { type: "github" },
+        { type: "research" },
+      ]);
+    });
+
+    it("should accept arxiv in advanced categories format", () => {
+      const input: SearchRequestInput = {
+        query: "retrieval augmented generation",
+        categories: [{ type: "arxiv" }],
+      };
+
+      const result = searchRequestSchema.parse(input);
+      expect(result.categories).toBeDefined();
+      expect(Array.isArray(result.categories)).toBe(true);
+      expect((result.categories as any[])[0].type).toBe("arxiv");
+    });
+
+    it("should reject unknown categories", () => {
+      const input = {
+        query: "test",
+        categories: ["not-a-real-category"],
+      };
+
+      expect(() => searchRequestSchema.parse(input)).toThrow();
+    });
+
     it("should reject limit exceeding 100", () => {
       const input: SearchRequestInput = {
         query: "test",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -124,6 +124,9 @@ const configSchema = z.object({
   SEARCH_SERVICE_URL: z.string().optional(),
   SEARCH_INDEX_SAMPLE_RATE: z.coerce.number().default(0.1),
   ENABLE_SEARCH_INDEX: z.stringbool().optional(),
+  // Internal arxiv search service. No default — the endpoint is private and
+  // must be configured via env. When unset the `arxiv` category is a no-op.
+  ARXIV_SEARCH_URL: z.string().optional(),
 
   // Worker Configuration
   WORKER_PORT: z.coerce.number().default(3005),

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1636,6 +1636,10 @@ const pdfCategoryOptions = z.strictObject({
   type: z.literal("pdf"),
 });
 
+const arxivCategoryOptions = z.strictObject({
+  type: z.literal("arxiv"),
+});
+
 export const searchRequestSchema = z
   .strictObject({
     query: z.string(),
@@ -1660,13 +1664,14 @@ export const searchRequestSchema = z
     categories: z
       .union([
         // Array of strings (simple format)
-        z.array(z.enum(["github", "research", "pdf"])),
+        z.array(z.enum(["github", "research", "pdf", "arxiv"])),
         // Array of objects (advanced format)
         z.array(
           z.union([
             githubCategoryOptions,
             researchCategoryOptions,
             pdfCategoryOptions,
+            arxivCategoryOptions,
           ]),
         ),
       ])
@@ -1785,6 +1790,10 @@ export const searchRequestSchema = z
             case "pdf":
               return {
                 type: "pdf" as const,
+              };
+            case "arxiv":
+              return {
+                type: "arxiv" as const,
               };
             default:
               return { type: c as any };

--- a/apps/api/src/lib/search-query-builder.ts
+++ b/apps/api/src/lib/search-query-builder.ts
@@ -57,7 +57,7 @@ export function buildSearchQuery(
 
   // Arxiv has two modes:
   //   1. When it's the ONLY category → the dedicated arxiv retrieval API is
-  //      used (handled in execute.ts) and we skip the site filter here.
+  //      used (handled in execute.ts) and we skip the site filter.
   //   2. When it's mixed with other categories → we fold `site:arxiv.org`
   //      into the search query so arxiv results are ranked alongside the rest.
   const categoryTypes = categories.map(c =>

--- a/apps/api/src/lib/search-query-builder.ts
+++ b/apps/api/src/lib/search-query-builder.ts
@@ -66,6 +66,11 @@ export function buildSearchQuery(
   const arxivMixed =
     categoryTypes.includes("arxiv") && categoryTypes.some(t => t !== "arxiv");
 
+  const claimForResearch = (site: string): string =>
+    site === "arxiv.org" && categoryTypes.includes("arxiv")
+      ? "arxiv"
+      : "research";
+
   for (const category of categories) {
     if (typeof category === "string") {
       // Simple string format
@@ -76,7 +81,7 @@ export function buildSearchQuery(
         // Use default research sites
         for (const site of DEFAULT_RESEARCH_SITES) {
           siteFilters.push(`site:${site}`);
-          categoryMap.set(site, "research");
+          categoryMap.set(site, claimForResearch(site));
         }
       } else if (category === "pdf") {
         hasPdfFilter = true;
@@ -97,7 +102,7 @@ export function buildSearchQuery(
         const sites = category.sites || DEFAULT_RESEARCH_SITES;
         for (const site of sites) {
           siteFilters.push(`site:${site}`);
-          categoryMap.set(site, "research");
+          categoryMap.set(site, claimForResearch(site));
         }
       } else if (category.type === "pdf") {
         hasPdfFilter = true;

--- a/apps/api/src/lib/search-query-builder.ts
+++ b/apps/api/src/lib/search-query-builder.ts
@@ -4,7 +4,7 @@
  */
 
 interface CategoryInput {
-  type: "github" | "research" | "pdf";
+  type: "github" | "research" | "pdf" | "arxiv";
   sites?: string[];
 }
 
@@ -55,6 +55,17 @@ export function buildSearchQuery(
   const siteFilters: string[] = [];
   let hasPdfFilter = false;
 
+  // Arxiv has two modes:
+  //   1. When it's the ONLY category → the dedicated arxiv retrieval API is
+  //      used (handled in execute.ts) and we skip the site filter here.
+  //   2. When it's mixed with other categories → we fold `site:arxiv.org`
+  //      into the search query so arxiv results are ranked alongside the rest.
+  const categoryTypes = categories.map(c =>
+    typeof c === "string" ? c : c.type,
+  );
+  const arxivMixed =
+    categoryTypes.includes("arxiv") && categoryTypes.some(t => t !== "arxiv");
+
   for (const category of categories) {
     if (typeof category === "string") {
       // Simple string format
@@ -70,6 +81,11 @@ export function buildSearchQuery(
       } else if (category === "pdf") {
         hasPdfFilter = true;
         categoryMap.set("__pdf__", "pdf");
+      } else if (category === "arxiv") {
+        categoryMap.set("arxiv.org", "arxiv");
+        if (arxivMixed) {
+          siteFilters.push("site:arxiv.org");
+        }
       }
     } else {
       // Object format with options
@@ -86,14 +102,21 @@ export function buildSearchQuery(
       } else if (category.type === "pdf") {
         hasPdfFilter = true;
         categoryMap.set("__pdf__", "pdf");
+      } else if (category.type === "arxiv") {
+        categoryMap.set("arxiv.org", "arxiv");
+        if (arxivMixed) {
+          siteFilters.push("site:arxiv.org");
+        }
       }
     }
   }
 
-  // Build the OR filter for sites
+  // Build the OR filter for sites (dedupe so e.g. research + arxiv doesn't
+  // emit `site:arxiv.org` twice).
+  const uniqueSiteFilters = [...new Set(siteFilters)];
   let categoryFilter = "";
-  if (siteFilters.length > 0) {
-    categoryFilter = " (" + siteFilters.join(" OR ") + ")";
+  if (uniqueSiteFilters.length > 0) {
+    categoryFilter = " (" + uniqueSiteFilters.join(" OR ") + ")";
   }
 
   // Add filetype:pdf filter if PDF category is requested
@@ -127,6 +150,15 @@ export function getCategoryFromUrl(
       return "pdf";
     }
 
+    // Arxiv takes priority over the hardcoded GitHub and any research mapping
+    // when the caller explicitly asked for the arxiv category.
+    if (
+      categoryMap.get("arxiv.org") === "arxiv" &&
+      (hostname === "arxiv.org" || hostname.endsWith(".arxiv.org"))
+    ) {
+      return "arxiv";
+    }
+
     // Direct match for GitHub
     if (hostname === "github.com" || hostname.endsWith(".github.com")) {
       return "github";
@@ -135,7 +167,7 @@ export function getCategoryFromUrl(
     // Check against category map for other sites
     for (const [site, category] of categoryMap.entries()) {
       if (site === "__pdf__") continue; // Skip the special PDF marker
-      
+
       if (
         hostname === site.toLowerCase() ||
         hostname.endsWith("." + site.toLowerCase())

--- a/apps/api/src/lib/search-query-builder.ts
+++ b/apps/api/src/lib/search-query-builder.ts
@@ -57,7 +57,7 @@ export function buildSearchQuery(
 
   // Arxiv has two modes:
   //   1. When it's the ONLY category → the dedicated arxiv retrieval API is
-  //      used (handled in execute.ts) and we skip the site filter.
+  //      used (handled in execute.ts) and we skip the site filter here.
   //   2. When it's mixed with other categories → we fold `site:arxiv.org`
   //      into the search query so arxiv results are ranked alongside the rest.
   const categoryTypes = categories.map(c =>

--- a/apps/api/src/search/arxiv.ts
+++ b/apps/api/src/search/arxiv.ts
@@ -96,12 +96,16 @@ export async function searchArxiv({
 
   const topK = Math.max(1, Math.min(limit, 100));
   const candidates = Math.max(50, topK * 10);
-  const url = buildArxivUrl({ base, query, topK, candidates });
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
+    // Kept inside the try block so a malformed `ARXIV_SEARCH_URL` (which
+    // makes `new URL()` throw) is handled like any other arxiv failure
+    // instead of rejecting the whole search request.
+    const url = buildArxivUrl({ base, query, topK, candidates });
+
     logger.info("Calling arxiv search API", { topK, candidates });
 
     const response = await fetch(url, {

--- a/apps/api/src/search/arxiv.ts
+++ b/apps/api/src/search/arxiv.ts
@@ -1,0 +1,148 @@
+import type { Logger } from "winston";
+import { config } from "../config";
+import { WebSearchResult } from "../lib/entities";
+
+const ARXIV_COLLECTION = "arxiv_abstracts_v1";
+const ARXIV_RERANKER = "8b";
+
+interface ArxivApiResult {
+  arxiv_id?: string;
+  title?: string;
+  abstract?: string;
+  text?: string;
+  authors?: string;
+  categories?: string;
+  update_date?: string;
+  created_date?: string;
+}
+
+interface SearchArxivOptions {
+  query: string;
+  limit: number;
+  logger: Logger;
+  timeoutMs?: number;
+}
+
+function buildArxivUrl(opts: {
+  base: string;
+  query: string;
+  topK: number;
+  candidates: number;
+}): string {
+  const url = new URL(opts.base);
+  url.searchParams.set("q", opts.query);
+  url.searchParams.set("collection", ARXIV_COLLECTION);
+  url.searchParams.set("top_k", String(opts.topK));
+  url.searchParams.set("candidates", String(opts.candidates));
+  url.searchParams.set("reranker", ARXIV_RERANKER);
+  return url.toString();
+}
+
+function mapArxivResult(
+  result: ArxivApiResult,
+  position: number,
+): WebSearchResult | null {
+  if (!result.arxiv_id) {
+    return null;
+  }
+
+  const url = `https://arxiv.org/abs/${result.arxiv_id}`;
+  const title = result.title?.trim() || result.arxiv_id;
+  // Prefer the abstract for the short description; fall back to the text field if needed.
+  const description = (result.abstract || result.text || "").trim();
+
+  return {
+    url,
+    title,
+    description,
+    position,
+    category: "arxiv",
+    metadata: {
+      arxivId: result.arxiv_id,
+      authors: result.authors,
+      arxivCategories: result.categories,
+      updateDate: result.update_date,
+      createdDate: result.created_date,
+    },
+  };
+}
+
+/**
+ * Queries the internal arxiv search API and returns `WebSearchResult`s
+ * tagged with `category: "arxiv"`. Any failure (network, HTTP, parse) is
+ * swallowed and logged — callers should treat this as best-effort.
+ *
+ * When `ARXIV_SEARCH_URL` is not configured the function logs an info
+ * message and returns an empty array so the rest of the search pipeline
+ * continues to work.
+ */
+export async function searchArxiv({
+  query,
+  limit,
+  logger,
+  timeoutMs = 10000,
+}: SearchArxivOptions): Promise<WebSearchResult[]> {
+  if (!query.trim()) {
+    return [];
+  }
+
+  const base = config.ARXIV_SEARCH_URL;
+  if (!base) {
+    logger.info(
+      "Arxiv category requested but ARXIV_SEARCH_URL is not configured; skipping",
+    );
+    return [];
+  }
+
+  const topK = Math.max(1, Math.min(limit, 100));
+  const candidates = Math.max(50, topK * 10);
+  const url = buildArxivUrl({ base, query, topK, candidates });
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    logger.info("Calling arxiv search API", { topK, candidates });
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger.warn("Arxiv search API returned non-200 status", {
+        status: response.status,
+      });
+      return [];
+    }
+
+    const data = (await response.json()) as { results?: ArxivApiResult[] };
+    const hits = Array.isArray(data.results) ? data.results : [];
+
+    const mapped: WebSearchResult[] = [];
+    for (const hit of hits) {
+      const r = mapArxivResult(hit, mapped.length + 1);
+      if (r) mapped.push(r);
+      if (mapped.length >= limit) break;
+    }
+
+    logger.info("Arxiv search API returned results", {
+      returned: mapped.length,
+      requested: topK,
+    });
+
+    return mapped;
+  } catch (error) {
+    const isAbort =
+      error instanceof Error &&
+      (error.name === "AbortError" || error.message.includes("aborted"));
+    logger.warn("Arxiv search API call failed", {
+      error: error instanceof Error ? error.message : String(error),
+      aborted: isAbort,
+    });
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "winston";
 import { search } from "./v2";
-import { SearchV2Response } from "../lib/entities";
+import { SearchV2Response, WebSearchResult } from "../lib/entities";
 import {
   buildSearchQuery,
   getCategoryFromUrl,
@@ -15,6 +15,7 @@ import {
 } from "./scrape";
 import { trackSearchResults, trackSearchRequest } from "../lib/tracking";
 import type { BillingMetadata } from "../services/billing/types";
+import { searchArxiv } from "./arxiv";
 
 interface SearchOptions {
   query: string;
@@ -81,24 +82,76 @@ export async function executeSearch(
     categories,
   );
 
-  const searchResponse = (await search({
-    query: searchQuery,
-    logger,
-    advanced: false,
-    num_results: num_results_buffer,
-    tbs: options.tbs,
-    filter: options.filter,
-    lang: options.lang,
-    country: options.country,
-    location: options.location,
-    type: searchTypes,
-    enterprise: options.enterprise,
-  })) as SearchV2Response;
+  // The dedicated arxiv retrieval API is only used when `arxiv` is the ONLY
+  // category. When it's mixed with other categories the query builder has
+  // already folded `site:arxiv.org` into the main search query so results
+  // come back ranked alongside the other categories instead of always
+  // prepended to the top.
+  const categoryTypes = (categories ?? []).map(c =>
+    typeof c === "string" ? c : c.type,
+  );
+  const wantsArxiv = categoryTypes.includes("arxiv");
+  const arxivOnly = wantsArxiv && categoryTypes.every(t => t === "arxiv");
+  const shouldFetchArxiv = arxivOnly && searchTypes.includes("web");
+
+  // When arxiv is the sole source of `web` results, strip `web` from the
+  // main search request so we don't burn a call on results that would just
+  // be appended behind the arxiv hits. Non-web sources (news, images) still
+  // go through the main search as normal.
+  const mainSearchTypes = shouldFetchArxiv
+    ? searchTypes.filter(t => t !== "web")
+    : searchTypes;
+  const shouldRunMainSearch = mainSearchTypes.length > 0;
+
+  const [searchResponse, arxivResults] = (await Promise.all([
+    shouldRunMainSearch
+      ? search({
+          query: searchQuery,
+          logger,
+          advanced: false,
+          num_results: num_results_buffer,
+          tbs: options.tbs,
+          filter: options.filter,
+          lang: options.lang,
+          country: options.country,
+          location: options.location,
+          type: mainSearchTypes,
+          enterprise: options.enterprise,
+        })
+      : Promise.resolve({} as SearchV2Response),
+    shouldFetchArxiv
+      ? searchArxiv({ query, limit, logger })
+      : Promise.resolve([] as WebSearchResult[]),
+  ])) as [SearchV2Response, WebSearchResult[]];
+
+  if (wantsArxiv && !shouldFetchArxiv) {
+    if (!arxivOnly) {
+      logger.info("Using main search for arxiv (mixed with other categories)", {
+        categories: categoryTypes,
+      });
+    } else {
+      logger.info(
+        "Skipping arxiv fetch because 'web' is not in the requested sources",
+        { sources: searchTypes },
+      );
+    }
+  }
+
+  if (arxivResults.length > 0) {
+    const existingWeb = searchResponse.web ?? [];
+    const existingUrls = new Set(
+      existingWeb.map(r => r.url?.toLowerCase()).filter(Boolean) as string[],
+    );
+    const dedupedArxiv = arxivResults.filter(
+      r => r.url && !existingUrls.has(r.url.toLowerCase()),
+    );
+    searchResponse.web = [...dedupedArxiv, ...existingWeb];
+  }
 
   if (searchResponse.web && searchResponse.web.length > 0) {
     searchResponse.web = searchResponse.web.map(result => ({
       ...result,
-      category: getCategoryFromUrl(result.url, categoryMap),
+      category: result.category ?? getCategoryFromUrl(result.url, categoryMap),
     }));
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `arxiv` as a first-class search category. Uses a dedicated internal service when `arxiv` is the only category; when combined with others, the query adds `site:arxiv.org` so arXiv results rank alongside them.

- **New Features**
  - Accepts `arxiv` in both simple and advanced category formats.
  - Query builder tags `arxiv.org`, only adds `site:arxiv.org` when mixed, de-dupes site filters, avoids duplication with `research`, and prefers `arxiv` for arXiv domains and subdomains (order-independent).
  - New `search/arxiv.ts` calls the internal arXiv service via `ARXIV_SEARCH_URL`, maps results (with metadata), enforces limits, times out safely, logs failures, and returns `[]` on errors or unset config.
  - Search execution uses the dedicated arXiv API only when `arxiv` is the sole `web` category, strips `web` from the main call in that case, and merges/dedupes results while preserving categories; uses main search when mixed.
  - Tests cover schema validation, query building and classification, execution paths (incl. no-op behavior), and HTTP request examples.

- **Migration**
  - Optional env: `ARXIV_SEARCH_URL`. When unset, `arxiv` is a no-op and falls back to normal search. No breaking changes.

<sup>Written for commit c6593767456121e92990c74fd87a2de34620e843. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

