### PR TITLE
feat(pdf): enrich fire-pdf payload for jobs dashboard

### DIFF
--- a/apps/api/src/lib/gcs-pdf-cache.ts
+++ b/apps/api/src/lib/gcs-pdf-cache.ts
@@ -11,7 +11,7 @@ const PROVIDER_PREFIXES: Record<PdfCacheProvider, string> = {
   firepdf: "pdf-cache-firepdf/",
 };
 
-function createPdfCacheKey(pdfContent: string | Buffer): string {
+export function createPdfCacheKey(pdfContent: string | Buffer): string {
   return crypto.createHash("sha256").update(pdfContent).digest("hex");
 }
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { PDFProcessorResult } from "./types";
 import { safeMarkdownToHtml } from "./markdownToHtml";
 import {
+  createPdfCacheKey,
   getPdfResultFromCache,
   savePdfResultToCache,
 } from "../../../../lib/gcs-pdf-cache";
@@ -42,6 +43,9 @@ export async function scrapePDFWithFirePDF(
     pagesProcessed,
   });
 
+  const zdr = meta.internalOptions.zeroDataRetention === true;
+  const pdfSha256 = createPdfCacheKey(base64Content);
+
   const resp = await robustFetch({
     url: `${config.FIRE_PDF_BASE_URL}/ocr`,
     method: "POST",
@@ -52,6 +56,16 @@ export async function scrapePDFWithFirePDF(
       pdf: base64Content,
       scrape_id: meta.id,
       ...(maxPages !== undefined && { max_pages: maxPages }),
+      // Enrichment for the fire-pdf jobs DB / dashboard. fire-pdf treats
+      // these as optional — older fire-pdf builds will ignore unknown fields.
+      team_id: meta.internalOptions.teamId,
+      ...(meta.internalOptions.crawlId && {
+        crawl_id: meta.internalOptions.crawlId,
+      }),
+      ...(zdr ? {} : { url: meta.rewrittenUrl ?? meta.url }),
+      pdf_sha256: pdfSha256,
+      source: "firecrawl",
+      zdr,
     },
     logger,
     schema: z.object({

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -404,6 +404,13 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           meta.logger.warn("FirePDF failed -- falling back to MinerU", {
             method: "scrapePDF/firePDF",
             error,
+            event: "pdf_engine_fallback",
+            scrape_id: meta.id,
+            team_id: meta.internalOptions.teamId,
+            from_engine: "firepdf",
+            to_engine: "mineru",
+            error_class: (error as Error)?.name,
+            error_message: ((error as Error)?.message ?? "").slice(0, 500),
           });
         }
       }


### PR DESCRIPTION
## Summary
- Sends `team_id`, `crawl_id`, `url` (omitted when zdr), `pdf_sha256`, `source`, and `zdr` alongside the PDF in the `/ocr` call so fire-pdf can index jobs by team/URL/sha for the new dashboard.
- Exports `createPdfCacheKey` from `gcs-pdf-cache.ts` so we compute the sha once per request (the cache layer already needs it).
- Adds a structured `event=pdf_engine_fallback` log on the fire-pdf → MinerU fallback path — fallback events become queryable in Cloud Logging immediately, ahead of any DB-backed dashboard.

## Pairs with
firecrawl/fire-pdf#32 — fire-pdf jobs recorder + initial schema.

## Why now
fire-pdf currently sees only `scrape_id` + bytes. The dashboard we're building can't slice by team or join PDFs across scrapes without this enrichment. fire-pdf treats every new field as optional, so this rolls out independently of the fire-pdf side and is safe to ship now.

## Lockdown / ZDR
Honored: when `internalOptions.zeroDataRetention === true`, `url` is omitted from the payload. fire-pdf still records lane/timing/error operationally.

## Test plan
- [x] Touched files compile cleanly (`pnpm tsc --noEmit` shows only pre-existing errors in unrelated files: clickhouse-client, transformers/query, services/autumn).
- [ ] Send a sample scrape against a fire-pdf canary with the recorder enabled; verify `team_id` lands in the `jobs` row.
- [ ] Confirm a forced fire-pdf failure produces an `event=pdf_engine_fallback` log line with the expected fields.
- [ ] Confirm a ZDR scrape lands a row with `url=null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enrich the `fire-pdf` `/ocr` payload for the jobs dashboard (team, crawl, URL, sha) and add a structured fallback log. Also expose `createPdfCacheKey` to compute `pdf_sha256` once per request.

- **New Features**
  - Send with `/ocr`: `team_id`, `crawl_id`, `url` (omitted when `zdr`), `pdf_sha256`, `source="firecrawl"`, and `zdr` — all optional on `fire-pdf`.
  - Export `createPdfCacheKey` from `gcs-pdf-cache.ts` to compute and reuse `pdf_sha256`.
  - Emit structured `event="pdf_engine_fallback"` log on FirePDF → MinerU failures with `scrape_id`, `team_id`, `from_engine`, `to_engine`, `error_class`, `error_message`.

<sup>Written for commit 997b27204d536c775588259fb602751179d807f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

